### PR TITLE
Replace abrupt completion asserts/returns with !? shortcuts from ES spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5681,7 +5681,7 @@ steps may throw an exception.
         4. Let |index| be 0.
         5. While |index| is less than |len|, run these substeps:
 
-            1. Let |hop| be [=!=] HasOwnProperty(|input|, |index|).
+            1. Let |hop| be [=?=] HasOwnProperty(|input|, |index|).
 
             2. If |hop| is false, return invalid.
 

--- a/index.bs
+++ b/index.bs
@@ -54,6 +54,9 @@ spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/
         text: ArrayBuffer; url: #sec-arraybuffer-objects
         text: Uint8Array; url: #sec-typedarray-objects
         text: Promise; url: #sec-promise-objects
+        url: sec-algorithm-conventions
+            text: !
+            text: ?
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/
     type: dfn
         text: sequence<DOMString>; url: #idl-sequence
@@ -5444,11 +5447,11 @@ ECMAScript value or failure, or the steps may throw an exception.
       <dd>
         1. If Type(|value|) is not Object, return failure.
 
-        2. Let |hop| be ! HasOwnProperty(|value|, |identifier|)
+        2. Let |hop| be [=!=] HasOwnProperty(|value|, |identifier|)
 
         3. If |hop| is false, return failure.
 
-        4. Let |value| be ! |value|.[<span>[</span>Get]](|identifier|,
+        4. Let |value| be [=!=] |value|.[<span>[</span>Get]](|identifier|,
             |value|)
 
         5. If |value| is Undefined, return failure.
@@ -5493,7 +5496,7 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
         object (see [=structured clone algorithm=] [[!HTML]]), then
         [=throw=] a {{DataError}}.
 
-    2. Let |hop| be ! HasOwnProperty(|value|, |identifier|)
+    2. Let |hop| be [=!=] HasOwnProperty(|value|, |identifier|)
 
     3. If |hop| is false, run these substeps:
 
@@ -5504,7 +5507,7 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
 
          3. Assert: |status| is true
 
-    4. Let |value| be ! |value|.[<span>[</span>Get]](|identifier|,
+    4. Let |value| be [=!=] |value|.[<span>[</span>Get]](|identifier|,
         |value|)
 
 5. Assert: |value| is an [=Object=] or an [=Array=].
@@ -5671,18 +5674,18 @@ steps may throw an exception.
       <dt>If IsArray(|input|)</dt>
       <dd>
 
-        1. Let |len| be ! ToLength(Get(|input|,
+        1. Let |len| be [=!=] ToLength(Get(|input|,
             "<code>length</code>"))
         2. Add |input| to |seen|
         3. Let |keys| be a new empty list
         4. Let |index| be 0
         5. While |index| is less than |len|, run these substeps:
 
-            1. Let |hop| be ! HasOwnProperty(|input|, |index|)
+            1. Let |hop| be [=!=] HasOwnProperty(|input|, |index|)
 
             2. If |hop| is false, return invalid.
 
-            3. Let |entry| be ? |input|.[<span>[</span>Get]](|index|,
+            3. Let |entry| be [=?=] |input|.[<span>[</span>Get]](|index|,
                 |input|)
 
             4. Let |key| be the result of running the steps to
@@ -5719,7 +5722,7 @@ steps may throw an exception.
 
 1. If IsArray(|input|), then:
 
-    1. Let |len| be ! ToLength(Get(|input|, "<code>length</code>")).
+    1. Let |len| be [=!=] ToLength(Get(|input|, "<code>length</code>")).
 
     2. Let |seen| be a new set containing only |input|.
 

--- a/index.bs
+++ b/index.bs
@@ -5339,10 +5339,10 @@ follows.
 
 This section defines how [=/key=] values defined in this specification
 are converted to and from ECMAScript values, and how they may be
-extracted from and injected into ECMAScript values using [=/key paths=].
-This section references
-types and algorithms from the ECMAScript Language Specification. [[!ECMA-262]]
-
+extracted from and injected into ECMAScript values using [=/key
+paths=]. This section references types and algorithms and uses some
+algorithm conventions from the ECMAScript Language Specification.
+[[!ECMA-262]]
 
 <aside class=issue>
   Simplify this section as much as possible by relying more on [[!WEBIDL]]
@@ -5444,18 +5444,14 @@ ECMAScript value or failure, or the steps may throw an exception.
       <dd>
         1. If Type(|value|) is not Object, return failure.
 
-        2. Let |hop| be HasOwnProperty(|value|, |identifier|)
+        2. Let |hop| be ! HasOwnProperty(|value|, |identifier|)
 
-        3. Assert: |hop| is not an abrupt completion.
+        3. If |hop| is false, return failure.
 
-        4. If |hop| is false, return failure.
-
-        5. Let |value| be |value|.[<span>[</span>Get]](|identifier|,
+        4. Let |value| be ! |value|.[<span>[</span>Get]](|identifier|,
             |value|)
 
-        6. Assert: |value| is not an abrupt completion.
-
-        7. If |value| is Undefined, return failure.
+        5. If |value| is Undefined, return failure.
       </dd>
 
     </dl>
@@ -5497,11 +5493,9 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
         object (see [=structured clone algorithm=] [[!HTML]]), then
         [=throw=] a {{DataError}}.
 
-    2. Let |hop| be HasOwnProperty(|value|, |identifier|)
+    2. Let |hop| be ! HasOwnProperty(|value|, |identifier|)
 
-    3. Assert: |hop| is not an abrupt completion.
-
-    4. If |hop| is false, run these substeps:
+    3. If |hop| is false, run these substeps:
 
          1. Let |o| be a new [=Object=].
 
@@ -5510,10 +5504,8 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
 
          3. Assert: |status| is true
 
-    5. Let |value| be |value|.[<span>[</span>Get]](|identifier|,
+    4. Let |value| be ! |value|.[<span>[</span>Get]](|identifier|,
         |value|)
-
-    6. Assert: |value| is not an abrupt completion.
 
 5. Assert: |value| is an [=Object=] or an [=Array=].
 
@@ -5679,39 +5671,34 @@ steps may throw an exception.
       <dt>If IsArray(|input|)</dt>
       <dd>
 
-        1. Let |len| be the ToLength(Get(|input|,
+        1. Let |len| be ! ToLength(Get(|input|,
             "<code>length</code>"))
-        2. Assert: |len| will never an abrupt completion.
-        3. Add |input| to |seen|
-        4. Let |keys| be a new empty list
-        5. Let |index| be 0
-        6. While |index| is less than |len|, run these substeps:
+        2. Add |input| to |seen|
+        3. Let |keys| be a new empty list
+        4. Let |index| be 0
+        5. While |index| is less than |len|, run these substeps:
 
-            1. Let |hop| be HasOwnProperty(|input|, |index|)
+            1. Let |hop| be ! HasOwnProperty(|input|, |index|)
 
-            2. Assert: |hop| is not an abrupt completion.
+            2. If |hop| is false, return invalid.
 
-            3. If |hop| is false, return invalid.
-
-            4. Let |entry| be |input|.[<span>[</span>Get]](|index|,
+            3. Let |entry| be ? |input|.[<span>[</span>Get]](|index|,
                 |input|)
 
-            5. ReturnIfAbrupt(|entry|)
-
-            6. Let |key| be the result of running the steps to
+            4. Let |key| be the result of running the steps to
                 [=convert a value to a key=] with arguments |entry|
                 and |seen|
 
-            7. ReturnIfAbrupt(|key|)
+            5. ReturnIfAbrupt(|key|)
 
-            8. If |key| is invalid or an exception, then abort these
-                steps and return |key|.
+            6. If |key| is invalid abort these steps and return
+                invalid.
 
-            9. Append |key| to |keys|
+            7. Append |key| to |keys|
 
-            10. Increase |index| by 1
+            8. Increase |index| by 1
 
-        7. Return a new [=array key=] with [=key/value=]
+        6. Return a new [=array key=] with [=key/value=]
             |keys|.
 
       </dd>
@@ -5732,17 +5719,15 @@ steps may throw an exception.
 
 1. If IsArray(|input|), then:
 
-    1. Let |len| be the ToLength(Get(|input|, "<code>length</code>")).
+    1. Let |len| be ! ToLength(Get(|input|, "<code>length</code>")).
 
-    2. Assert: |len| will never an abrupt completion.
+    2. Let |seen| be a new set containing only |input|.
 
-    3. Let |seen| be a new set containing only |input|.
+    3. Let |keys| be a new empty set.
 
-    4. Let |keys| be a new empty set.
+    4. Let |index| be 0.
 
-    5. Let |index| be 0.
-
-    6. While |index| is less than |len|, run these substeps:
+    5. While |index| is less than |len|, run these substeps:
 
         1. Let |entry| be |input|.[<span>[</span>Get]](|index|, |input|)
 
@@ -5758,7 +5743,7 @@ steps may throw an exception.
 
         3. Increase |index| by 1
 
-   7. Return a new [=array key=] with [=key/value=] set to
+   6. Return a new [=array key=] with [=key/value=] set to
        a list of the members of |keys|.
 
 2. Otherwise, return the result of running the steps to [=convert a

--- a/index.bs
+++ b/index.bs
@@ -5425,7 +5425,7 @@ ECMAScript value or failure, or the steps may throw an exception.
       <dd>Let |value| be a Number equal to the number of elements in |value|.</dd>
 
       <dt>If |value| is an [=Array=] and |identifier| is "<code>length</code>"</dt>
-      <dd>Let |value| be ToLength(Get(|value|, "length")).</dd>
+      <dd>Let |value| be [=!=] ToLength([=!=] Get(|value|, "<code>length</code>")).</dd>
 
       <dt>If |value| is a {{Blob}} and |identifier| is "<code>size</code>"</dt>
       <dd>Let |value| be a Number equal to |value|'s {{Blob/size}}.</dd>
@@ -5674,7 +5674,7 @@ steps may throw an exception.
       <dt>If IsArray(|input|)</dt>
       <dd>
 
-        1. Let |len| be [=!=] ToLength( [=!=] Get(|input|,
+        1. Let |len| be [=?=] ToLength( [=?=] Get(|input|,
             "<code>length</code>")).
         2. Add |input| to |seen|.
         3. Let |keys| be a new empty list.
@@ -5722,7 +5722,7 @@ steps may throw an exception.
 
 1. If IsArray(|input|), then:
 
-    1. Let |len| be [=!=] ToLength( [=!=] Get(|input|, "<code>length</code>")).
+    1. Let |len| be [=?=] ToLength( [=?=] Get(|input|, "<code>length</code>")).
 
     2. Let |seen| be a new set containing only |input|.
 

--- a/index.bs
+++ b/index.bs
@@ -5454,7 +5454,7 @@ ECMAScript value or failure, or the steps may throw an exception.
         4. Let |value| be [=!=] |value|.[<span>[</span>Get]](|identifier|,
             |value|)
 
-        5. If |value| is Undefined, return failure.
+        5. If |value| is undefined, return failure.
       </dd>
 
     </dl>
@@ -5496,28 +5496,28 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
         object (see [=structured clone algorithm=] [[!HTML]]), then
         [=throw=] a {{DataError}}.
 
-    2. Let |hop| be [=!=] HasOwnProperty(|value|, |identifier|)
+    2. Let |hop| be [=!=] HasOwnProperty(|value|, |identifier|).
 
     3. If |hop| is false, run these substeps:
 
          1. Let |o| be a new [=Object=].
 
          2. Let |status| be CreateDataProperty(|value|, |identifier|,
-            |o|)
+            |o|).
 
-         3. Assert: |status| is true
+         3. Assert: |status| is true.
 
     4. Let |value| be [=!=] |value|.[<span>[</span>Get]](|identifier|,
-        |value|)
+        |value|).
 
 5. Assert: |value| is an [=Object=] or an [=Array=].
 
 6. Let |keyValue| be the result of running the steps to [=convert a
     key to a value=].
 
-7. Let |status| be CreateDataProperty(|value|, |last|, |keyValue|)
+7. Let |status| be CreateDataProperty(|value|, |last|, |keyValue|).
 
-8. Assert: |status| is true
+8. Assert: |status| is true.
 
 </div>
 
@@ -5560,9 +5560,9 @@ steps take one argument, |key|, and return an ECMAScript value.
       <dt><i>date</i></dt>
       <dd>
         1. Let |date| be the result of executing the ECMAScript Date
-            constructor with the single argument |value|
+            constructor with the single argument |value|.
         2. Assert: |date| is not an abrupt completion.
-        3. Return |date|
+        3. Return |date|.
 
       </dd>
 
@@ -5575,7 +5575,7 @@ steps take one argument, |key|, and return an ECMAScript value.
         4. Set the entries in |buffer|'s
             [<span>[</span>ArrayBufferData]] internal slot to the entries
             in |value|.
-        5. Return |buffer|
+        5. Return |buffer|.
 
       </dd>
 
@@ -5596,7 +5596,7 @@ steps take one argument, |key|, and return an ECMAScript value.
             3. Assert: |status| is true.
             4. Increase |index| by 1.
 
-        6. Return |array|
+        6. Return |array|.
 
       </dd>
     </dl>
@@ -5674,32 +5674,32 @@ steps may throw an exception.
       <dt>If IsArray(|input|)</dt>
       <dd>
 
-        1. Let |len| be [=!=] ToLength(Get(|input|,
-            "<code>length</code>"))
-        2. Add |input| to |seen|
-        3. Let |keys| be a new empty list
-        4. Let |index| be 0
+        1. Let |len| be [=!=] ToLength( [=!=] Get(|input|,
+            "<code>length</code>")).
+        2. Add |input| to |seen|.
+        3. Let |keys| be a new empty list.
+        4. Let |index| be 0.
         5. While |index| is less than |len|, run these substeps:
 
-            1. Let |hop| be [=!=] HasOwnProperty(|input|, |index|)
+            1. Let |hop| be [=!=] HasOwnProperty(|input|, |index|).
 
             2. If |hop| is false, return invalid.
 
             3. Let |entry| be [=?=] |input|.[<span>[</span>Get]](|index|,
-                |input|)
+                |input|).
 
             4. Let |key| be the result of running the steps to
                 [=convert a value to a key=] with arguments |entry|
-                and |seen|
+                and |seen|.
 
-            5. ReturnIfAbrupt(|key|)
+            5. ReturnIfAbrupt(|key|).
 
             6. If |key| is invalid abort these steps and return
                 invalid.
 
-            7. Append |key| to |keys|
+            7. Append |key| to |keys|.
 
-            8. Increase |index| by 1
+            8. Increase |index| by 1.
 
         6. Return a new [=array key=] with [=key/value=]
             |keys|.
@@ -5722,7 +5722,7 @@ steps may throw an exception.
 
 1. If IsArray(|input|), then:
 
-    1. Let |len| be [=!=] ToLength(Get(|input|, "<code>length</code>")).
+    1. Let |len| be [=!=] ToLength( [=!=] Get(|input|, "<code>length</code>")).
 
     2. Let |seen| be a new set containing only |input|.
 
@@ -5738,13 +5738,13 @@ steps may throw an exception.
 
              1. Let |key| be the result of running the steps to
                  [=convert a value to a key=] with arguments
-                 |entry| and |seen|
+                 |entry| and |seen|.
 
              2. If |key| is not invalid or an exception, add |key| to
                  |keys| if there are no other members of |keys|
-                 [=equal to=] |key|
+                 [=equal to=] |key|.
 
-        3. Increase |index| by 1
+        3. Increase |index| by 1.
 
    6. Return a new [=array key=] with [=key/value=] set to
        a list of the members of |keys|.

--- a/index.html
+++ b/index.html
@@ -5447,11 +5447,11 @@ string</a> <var>keyPath</var> on U+002E FULL STOP characters (.).</p>
           <li data-md="">
            <p>If Type(<var>value</var>) is not Object, return failure.</p>
           <li data-md="">
-           <p>Let <var>hop</var> be ! HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
+           <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
           <li data-md="">
            <p>If <var>hop</var> is false, return failure.</p>
           <li data-md="">
-           <p>Let <var>value</var> be ! <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
+           <p>Let <var>value</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
           <li data-md="">
            <p>If <var>value</var> is Undefined, return failure.</p>
          </ol>
@@ -5485,7 +5485,7 @@ substeps:</p>
         <li data-md="">
          <p>If <var>value</var> is not an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> object or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> object (see <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#safe-passing-of-structured-data">structured clone algorithm</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>), then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-request-dataerror" id="ref-for-exceptiondef-request-dataerror-32">DataError</a></code>.</p>
         <li data-md="">
-         <p>Let <var>hop</var> be ! HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
+         <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
         <li data-md="">
          <p>If <var>hop</var> is false, run these substeps:</p>
          <ol>
@@ -5497,7 +5497,7 @@ substeps:</p>
            <p class="assertion">Assert: <var>status</var> is true</p>
          </ol>
         <li data-md="">
-         <p>Let <var>value</var> be ! <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
+         <p>Let <var>value</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
        </ol>
       <li data-md="">
        <p class="assertion">Assert: <var>value</var> is an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>.</p>
@@ -5643,7 +5643,7 @@ steps may throw an exception.</p>
         <dd>
          <ol>
           <li data-md="">
-           <p>Let <var>len</var> be ! ToLength(Get(<var>input</var>,
+           <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength(Get(<var>input</var>,
 "<code>length</code>"))</p>
           <li data-md="">
            <p>Add <var>input</var> to <var>seen</var></p>
@@ -5655,11 +5655,11 @@ steps may throw an exception.</p>
            <p>While <var>index</var> is less than <var>len</var>, run these substeps:</p>
            <ol>
             <li data-md="">
-             <p>Let <var>hop</var> be ! HasOwnProperty(<var>input</var>, <var>index</var>)</p>
+             <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>input</var>, <var>index</var>)</p>
             <li data-md="">
              <p>If <var>hop</var> is false, return invalid.</p>
             <li data-md="">
-             <p>Let <var>entry</var> be ? <var>input</var>.[<span>[</span>Get]](<var>index</var>, <var>input</var>)</p>
+             <p>Let <var>entry</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <var>input</var>.[<span>[</span>Get]](<var>index</var>, <var>input</var>)</p>
             <li data-md="">
              <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#request-convert-a-value-to-a-key" id="ref-for-request-convert-a-value-to-a-key-17">convert a value to a key</a> with arguments <var>entry</var> and <var>seen</var></p>
             <li data-md="">
@@ -5690,7 +5690,7 @@ steps may throw an exception.</p>
        <p>If IsArray(<var>input</var>), then:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>len</var> be ! ToLength(Get(<var>input</var>, "<code>length</code>")).</p>
+         <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength(Get(<var>input</var>, "<code>length</code>")).</p>
         <li data-md="">
          <p>Let <var>seen</var> be a new set containing only <var>input</var>.</p>
         <li data-md="">
@@ -6497,6 +6497,8 @@ specification.</p>
    <li>
     <a data-link-type="biblio">[ecma262]</a> defines the following terms:
     <ul>
+     <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-array-objects">array</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects">arraybuffer</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-date-objects">date</a>

--- a/index.html
+++ b/index.html
@@ -5429,7 +5429,7 @@ string</a> <var>keyPath</var> on U+002E FULL STOP characters (.).</p>
         <dt>If Type(<var>value</var>) is String, and <var>identifier</var> is "<code>length</code>"
         <dd>Let <var>value</var> be a Number equal to the number of elements in <var>value</var>.
         <dt>If <var>value</var> is an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> and <var>identifier</var> is "<code>length</code>"
-        <dd>Let <var>value</var> be ToLength(Get(<var>value</var>, "length")).
+        <dd>Let <var>value</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength(<a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> Get(<var>value</var>, "<code>length</code>")).
         <dt>If <var>value</var> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> and <var>identifier</var> is "<code>size</code>"
         <dd>Let <var>value</var> be a Number equal to <var>value</var>’s <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-size">size</a></code>.
         <dt>If <var>value</var> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> and <var>identifier</var> is "<code>type</code>"
@@ -5643,7 +5643,7 @@ steps may throw an exception.</p>
         <dd>
          <ol>
           <li data-md="">
-           <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength( <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> Get(<var>input</var>,
+           <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> ToLength( <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> Get(<var>input</var>,
 "<code>length</code>")).</p>
           <li data-md="">
            <p>Add <var>input</var> to <var>seen</var>.</p>
@@ -5690,7 +5690,7 @@ steps may throw an exception.</p>
        <p>If IsArray(<var>input</var>), then:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength( <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> Get(<var>input</var>, "<code>length</code>")).</p>
+         <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> ToLength( <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> Get(<var>input</var>, "<code>length</code>")).</p>
         <li data-md="">
          <p>Let <var>seen</var> be a new set containing only <var>input</var>.</p>
         <li data-md="">

--- a/index.html
+++ b/index.html
@@ -5655,7 +5655,7 @@ steps may throw an exception.</p>
            <p>While <var>index</var> is less than <var>len</var>, run these substeps:</p>
            <ol>
             <li data-md="">
-             <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>input</var>, <var>index</var>).</p>
+             <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> HasOwnProperty(<var>input</var>, <var>index</var>).</p>
             <li data-md="">
              <p>If <var>hop</var> is false, return invalid.</p>
             <li data-md="">

--- a/index.html
+++ b/index.html
@@ -5453,7 +5453,7 @@ string</a> <var>keyPath</var> on U+002E FULL STOP characters (.).</p>
           <li data-md="">
            <p>Let <var>value</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
           <li data-md="">
-           <p>If <var>value</var> is Undefined, return failure.</p>
+           <p>If <var>value</var> is undefined, return failure.</p>
          </ol>
        </dl>
       <li data-md="">
@@ -5485,19 +5485,19 @@ substeps:</p>
         <li data-md="">
          <p>If <var>value</var> is not an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> object or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> object (see <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#safe-passing-of-structured-data">structured clone algorithm</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>), then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-request-dataerror" id="ref-for-exceptiondef-request-dataerror-32">DataError</a></code>.</p>
         <li data-md="">
-         <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
+         <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>value</var>, <var>identifier</var>).</p>
         <li data-md="">
          <p>If <var>hop</var> is false, run these substeps:</p>
          <ol>
           <li data-md="">
            <p>Let <var>o</var> be a new <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a>.</p>
           <li data-md="">
-           <p>Let <var>status</var> be CreateDataProperty(<var>value</var>, <var>identifier</var>, <var>o</var>)</p>
+           <p>Let <var>status</var> be CreateDataProperty(<var>value</var>, <var>identifier</var>, <var>o</var>).</p>
           <li data-md="">
-           <p class="assertion">Assert: <var>status</var> is true</p>
+           <p class="assertion">Assert: <var>status</var> is true.</p>
          </ol>
         <li data-md="">
-         <p>Let <var>value</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
+         <p>Let <var>value</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>).</p>
        </ol>
       <li data-md="">
        <p class="assertion">Assert: <var>value</var> is an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>.</p>
@@ -5505,9 +5505,9 @@ substeps:</p>
        <p>Let <var>keyValue</var> be the result of running the steps to <a data-link-type="dfn" href="#request-convert-a-key-to-a-value" id="ref-for-request-convert-a-key-to-a-value-7">convert a
 key to a value</a>.</p>
       <li data-md="">
-       <p>Let <var>status</var> be CreateDataProperty(<var>value</var>, <var>last</var>, <var>keyValue</var>)</p>
+       <p>Let <var>status</var> be CreateDataProperty(<var>value</var>, <var>last</var>, <var>keyValue</var>).</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>status</var> is true</p>
+       <p class="assertion">Assert: <var>status</var> is true.</p>
      </ol>
     </div>
     <aside class="note" role="note"> The <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-4">key path</a> used here is always a string and never a sequence,
@@ -5537,11 +5537,11 @@ steps take one argument, <var>key</var>, and return an ECMAScript value.</p>
          <ol>
           <li data-md="">
            <p>Let <var>date</var> be the result of executing the ECMAScript Date
-constructor with the single argument <var>value</var></p>
+constructor with the single argument <var>value</var>.</p>
           <li data-md="">
            <p class="assertion">Assert: <var>date</var> is not an abrupt completion.</p>
           <li data-md="">
-           <p>Return <var>date</var></p>
+           <p>Return <var>date</var>.</p>
          </ol>
         <dt><i>binary</i>
         <dd>
@@ -5558,7 +5558,7 @@ ArrayBuffer constructor with <var>len</var>.</p>
 [<span>[</span>ArrayBufferData]] internal slot to the entries
 in <var>value</var>.</p>
           <li data-md="">
-           <p>Return <var>buffer</var></p>
+           <p>Return <var>buffer</var>.</p>
          </ol>
         <dt><i>array</i>
         <dd>
@@ -5586,7 +5586,7 @@ entry of <var>value</var> as input.</p>
              <p>Increase <var>index</var> by 1.</p>
            </ol>
           <li data-md="">
-           <p>Return <var>array</var></p>
+           <p>Return <var>array</var>.</p>
          </ol>
        </dl>
      </ol>
@@ -5643,34 +5643,34 @@ steps may throw an exception.</p>
         <dd>
          <ol>
           <li data-md="">
-           <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength(Get(<var>input</var>,
-"<code>length</code>"))</p>
+           <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength( <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> Get(<var>input</var>,
+"<code>length</code>")).</p>
           <li data-md="">
-           <p>Add <var>input</var> to <var>seen</var></p>
+           <p>Add <var>input</var> to <var>seen</var>.</p>
           <li data-md="">
-           <p>Let <var>keys</var> be a new empty list</p>
+           <p>Let <var>keys</var> be a new empty list.</p>
           <li data-md="">
-           <p>Let <var>index</var> be 0</p>
+           <p>Let <var>index</var> be 0.</p>
           <li data-md="">
            <p>While <var>index</var> is less than <var>len</var>, run these substeps:</p>
            <ol>
             <li data-md="">
-             <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>input</var>, <var>index</var>)</p>
+             <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> HasOwnProperty(<var>input</var>, <var>index</var>).</p>
             <li data-md="">
              <p>If <var>hop</var> is false, return invalid.</p>
             <li data-md="">
-             <p>Let <var>entry</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <var>input</var>.[<span>[</span>Get]](<var>index</var>, <var>input</var>)</p>
+             <p>Let <var>entry</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <var>input</var>.[<span>[</span>Get]](<var>index</var>, <var>input</var>).</p>
             <li data-md="">
-             <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#request-convert-a-value-to-a-key" id="ref-for-request-convert-a-value-to-a-key-17">convert a value to a key</a> with arguments <var>entry</var> and <var>seen</var></p>
+             <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#request-convert-a-value-to-a-key" id="ref-for-request-convert-a-value-to-a-key-17">convert a value to a key</a> with arguments <var>entry</var> and <var>seen</var>.</p>
             <li data-md="">
-             <p>ReturnIfAbrupt(<var>key</var>)</p>
+             <p>ReturnIfAbrupt(<var>key</var>).</p>
             <li data-md="">
              <p>If <var>key</var> is invalid abort these steps and return
 invalid.</p>
             <li data-md="">
-             <p>Append <var>key</var> to <var>keys</var></p>
+             <p>Append <var>key</var> to <var>keys</var>.</p>
             <li data-md="">
-             <p>Increase <var>index</var> by 1</p>
+             <p>Increase <var>index</var> by 1.</p>
            </ol>
           <li data-md="">
            <p>Return a new <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-12">array key</a> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-12">value</a> <var>keys</var>.</p>
@@ -5690,7 +5690,7 @@ steps may throw an exception.</p>
        <p>If IsArray(<var>input</var>), then:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength(Get(<var>input</var>, "<code>length</code>")).</p>
+         <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> ToLength( <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> Get(<var>input</var>, "<code>length</code>")).</p>
         <li data-md="">
          <p>Let <var>seen</var> be a new set containing only <var>input</var>.</p>
         <li data-md="">
@@ -5706,12 +5706,12 @@ steps may throw an exception.</p>
            <p>If <var>entry</var> is not an exception, run these substeps:</p>
            <ol>
             <li data-md="">
-             <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#request-convert-a-value-to-a-key" id="ref-for-request-convert-a-value-to-a-key-18">convert a value to a key</a> with arguments <var>entry</var> and <var>seen</var></p>
+             <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#request-convert-a-value-to-a-key" id="ref-for-request-convert-a-value-to-a-key-18">convert a value to a key</a> with arguments <var>entry</var> and <var>seen</var>.</p>
             <li data-md="">
-             <p>If <var>key</var> is not invalid or an exception, add <var>key</var> to <var>keys</var> if there are no other members of <var>keys</var> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-28">equal to</a> <var>key</var></p>
+             <p>If <var>key</var> is not invalid or an exception, add <var>key</var> to <var>keys</var> if there are no other members of <var>keys</var> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-28">equal to</a> <var>key</var>.</p>
            </ol>
           <li data-md="">
-           <p>Increase <var>index</var> by 1</p>
+           <p>Increase <var>index</var> by 1.</p>
          </ol>
        </ol>
       <li data-md="">

--- a/index.html
+++ b/index.html
@@ -1427,7 +1427,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-12">12 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-20">20 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5363,9 +5363,9 @@ record</var>’s <a data-link-type="dfn" href="#index-referenced-value" id="ref-
     <h2 class="heading settled" data-level="7" id="binding"><span class="secno">7. </span><span class="content">ECMAScript binding</span><a class="self-link" href="#binding"></a></h2>
     <p>This section defines how <a data-link-type="dfn" href="#key" id="ref-for-key-65">key</a> values defined in this specification
 are converted to and from ECMAScript values, and how they may be
-extracted from and injected into ECMAScript values using <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-2">key paths</a>.
-This section references
-types and algorithms from the ECMAScript Language Specification. <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a></p>
+extracted from and injected into ECMAScript values using <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-2">key
+paths</a>. This section references types and algorithms and uses some
+algorithm conventions from the ECMAScript Language Specification. <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a></p>
     <aside class="issue" id="issue-8f674373"><a class="self-link" href="#issue-8f674373"></a> Simplify this section as much as possible by relying more on <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> for key conversion logic. </aside>
     <h3 class="heading settled" data-level="7.1" id="extract-key-from-value"><span class="secno">7.1. </span><span class="content">Extract a key from a value</span><a class="self-link" href="#extract-key-from-value"></a></h3>
     <p>The steps to <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-extract-a-key-from-a-value-using-a-key-path">extract a key from a value using a key path</dfn> with <var>value</var>, <var>keyPath</var> and an optional <var>multiEntry flag</var> are as
@@ -5447,15 +5447,11 @@ string</a> <var>keyPath</var> on U+002E FULL STOP characters (.).</p>
           <li data-md="">
            <p>If Type(<var>value</var>) is not Object, return failure.</p>
           <li data-md="">
-           <p>Let <var>hop</var> be HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
-          <li data-md="">
-           <p class="assertion">Assert: <var>hop</var> is not an abrupt completion.</p>
+           <p>Let <var>hop</var> be ! HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
           <li data-md="">
            <p>If <var>hop</var> is false, return failure.</p>
           <li data-md="">
-           <p>Let <var>value</var> be <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
-          <li data-md="">
-           <p class="assertion">Assert: <var>value</var> is not an abrupt completion.</p>
+           <p>Let <var>value</var> be ! <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
           <li data-md="">
            <p>If <var>value</var> is Undefined, return failure.</p>
          </ol>
@@ -5489,9 +5485,7 @@ substeps:</p>
         <li data-md="">
          <p>If <var>value</var> is not an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> object or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> object (see <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#safe-passing-of-structured-data">structured clone algorithm</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>), then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-request-dataerror" id="ref-for-exceptiondef-request-dataerror-32">DataError</a></code>.</p>
         <li data-md="">
-         <p>Let <var>hop</var> be HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
-        <li data-md="">
-         <p class="assertion">Assert: <var>hop</var> is not an abrupt completion.</p>
+         <p>Let <var>hop</var> be ! HasOwnProperty(<var>value</var>, <var>identifier</var>)</p>
         <li data-md="">
          <p>If <var>hop</var> is false, run these substeps:</p>
          <ol>
@@ -5503,9 +5497,7 @@ substeps:</p>
            <p class="assertion">Assert: <var>status</var> is true</p>
          </ol>
         <li data-md="">
-         <p>Let <var>value</var> be <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
-        <li data-md="">
-         <p class="assertion">Assert: <var>value</var> is not an abrupt completion.</p>
+         <p>Let <var>value</var> be ! <var>value</var>.[<span>[</span>Get]](<var>identifier</var>, <var>value</var>)</p>
        </ol>
       <li data-md="">
        <p class="assertion">Assert: <var>value</var> is an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>.</p>
@@ -5651,10 +5643,8 @@ steps may throw an exception.</p>
         <dd>
          <ol>
           <li data-md="">
-           <p>Let <var>len</var> be the ToLength(Get(<var>input</var>,
+           <p>Let <var>len</var> be ! ToLength(Get(<var>input</var>,
 "<code>length</code>"))</p>
-          <li data-md="">
-           <p class="assertion">Assert: <var>len</var> will never an abrupt completion.</p>
           <li data-md="">
            <p>Add <var>input</var> to <var>seen</var></p>
           <li data-md="">
@@ -5665,22 +5655,18 @@ steps may throw an exception.</p>
            <p>While <var>index</var> is less than <var>len</var>, run these substeps:</p>
            <ol>
             <li data-md="">
-             <p>Let <var>hop</var> be HasOwnProperty(<var>input</var>, <var>index</var>)</p>
-            <li data-md="">
-             <p class="assertion">Assert: <var>hop</var> is not an abrupt completion.</p>
+             <p>Let <var>hop</var> be ! HasOwnProperty(<var>input</var>, <var>index</var>)</p>
             <li data-md="">
              <p>If <var>hop</var> is false, return invalid.</p>
             <li data-md="">
-             <p>Let <var>entry</var> be <var>input</var>.[<span>[</span>Get]](<var>index</var>, <var>input</var>)</p>
-            <li data-md="">
-             <p>ReturnIfAbrupt(<var>entry</var>)</p>
+             <p>Let <var>entry</var> be ? <var>input</var>.[<span>[</span>Get]](<var>index</var>, <var>input</var>)</p>
             <li data-md="">
              <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#request-convert-a-value-to-a-key" id="ref-for-request-convert-a-value-to-a-key-17">convert a value to a key</a> with arguments <var>entry</var> and <var>seen</var></p>
             <li data-md="">
              <p>ReturnIfAbrupt(<var>key</var>)</p>
             <li data-md="">
-             <p>If <var>key</var> is invalid or an exception, then abort these
-steps and return <var>key</var>.</p>
+             <p>If <var>key</var> is invalid abort these steps and return
+invalid.</p>
             <li data-md="">
              <p>Append <var>key</var> to <var>keys</var></p>
             <li data-md="">
@@ -5704,9 +5690,7 @@ steps may throw an exception.</p>
        <p>If IsArray(<var>input</var>), then:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>len</var> be the ToLength(Get(<var>input</var>, "<code>length</code>")).</p>
-        <li data-md="">
-         <p class="assertion">Assert: <var>len</var> will never an abrupt completion.</p>
+         <p>Let <var>len</var> be ! ToLength(Get(<var>input</var>, "<code>length</code>")).</p>
         <li data-md="">
          <p>Let <var>seen</var> be a new set containing only <var>input</var>.</p>
         <li data-md="">


### PR DESCRIPTION
Calling an abstract ECMAScript operation with ! prefix is equivalent to asserting it will never return an abrupt completion. Calling an abstract ECMAScript operation with ? prefix is equivalent to following the call with ReturnIfAbrupt(result).