### PR TITLE
Do not automatically throw in `continuePrimaryKey` for key == cursor position

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3940,22 +3940,22 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 12. Let |primaryKey| be |r|.
 
 13. If |key| is [=less than=] or [=equal to=] this cursor's
-    [=position=] and this cursor's [=direction=] is {{"next"}}
-    or {{"nextunique"}}, [=throw=] a {{DataError}}.
+    [=position=] and this cursor's [=direction=] is {{"next"}},
+    [=throw=] a {{DataError}}.
 
 14. If |key| is [=greater than=] or [=equal to=] this cursor's
-    [=position=] and this cursor's [=direction=] is {{"prev"}}
-    or {{"prevunique"}}, [=throw=] a {{DataError}}.
+    [=position=] and this cursor's [=direction=] is {{"prev"}},
+    [=throw=] a {{DataError}}.
 
 15. If |key| is [=equal to=] this cursor's [=position=] and
     |primaryKey| is [=less than=] or [=equal to=] this cursor's
     [=object store position=] and this cursor's [=direction=] is
-    {{"next"}} or {{"nextunique"}}, [=throw=] a {{DataError}}.
+    {{"next"}}, [=throw=] a {{DataError}}.
 
 16. If |key| is [=equal to=] this cursor's [=position=] and
     |primaryKey| is [=greater than=] or [=equal to=] this
     cursor's [=object store position=] and this cursor's
-    [=direction=] is {{"prev"}} or {{"prevunique"}}, [=throw=] a
+    [=direction=] is {{"prev"}}, [=throw=] a
     {{DataError}}.
 
 17. Unset the [=got value flag=] on the cursor.

--- a/index.bs
+++ b/index.bs
@@ -3939,13 +3939,11 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 
 12. Let |primaryKey| be |r|.
 
-13. If |key| is [=less than=] or [=equal to=] this cursor's
-    [=position=] and this cursor's [=direction=] is {{"next"}},
-    [=throw=] a {{DataError}}.
+13. If |key| is [=less than=] this cursor's [=position=] and this
+    cursor's [=direction=] is {{"next"}}, [=throw=] a {{DataError}}.
 
-14. If |key| is [=greater than=] or [=equal to=] this cursor's
-    [=position=] and this cursor's [=direction=] is {{"prev"}},
-    [=throw=] a {{DataError}}.
+14. If |key| is [=greater than=] this cursor's [=position=] and this
+    cursor's [=direction=] is {{"prev"}}, [=throw=] a {{DataError}}.
 
 15. If |key| is [=equal to=] this cursor's [=position=] and
     |primaryKey| is [=less than=] or [=equal to=] this cursor's


### PR DESCRIPTION
Builds on prior PR related to `continuePrimaryKey`.

For `continuePrimaryKey`, do not automatically throw as with `continue`  when the key is equal to the cursor's position (the following steps will instead check that possibility, depending on the `primaryKey` and object store position)