### PR TITLE
Clear object store handle's index set when deleted. Resolves #109

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2224,7 +2224,11 @@ method, when invoked, must run these steps:
 5. Remove |store| from this [=/connection=]'s [=object
     store set=].
 
-6. Destroy |store|.
+6. If there is an [=/object store handle=] associated with
+    |store| and |transaction|, remove all entries from its
+    [=object-store-handle/index set=].
+
+7. Destroy |store|.
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -1440,7 +1440,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-31">31 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-04">4 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1448,7 +1448,7 @@ pre.idl.highlight { color: #708090; }
      <dt>Previous Versions:
      <dd><a href="https://www.w3.org/TR/IndexedDB/" rel="previous">https://www.w3.org/TR/IndexedDB/</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webapps@w3.org?subject=%5BIndexedDB%5D%20YOUR%20TOPIC%20HERE">public-webapps@w3.org</a> with subject line “<kbd>[IndexedDB] <i data-lt="">… message topic …</i></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webapps/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-webapps@w3.org?subject=%5Bindexeddb%5D%20YOUR%20TOPIC%20HERE">public-webapps@w3.org</a> with subject line “<kbd>[indexeddb] <i data-lt="">… message topic …</i></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webapps/" rel="discussion">archives</a>)</span>
      <dt>Test Suite:
      <dd><a href="https://github.com/w3c/web-platform-tests/tree/master/IndexedDB">https://github.com/w3c/web-platform-tests/tree/master/IndexedDB</a>
      <dt>Issue Tracking:
@@ -1481,7 +1481,7 @@ persistent B-tree data structure.</p>
   Its publication here does not imply endorsement of its contents by W3C.
   Don’t cite this document other than as work in progress. </p>
    <p> <strong>Changes to this document may be tracked at <a href="https://github.com/w3c/IndexedDB">https://github.com/w3c/IndexedDB</a>.</strong> </p>
-   <p> If you wish to make comments regarding this document, please send them to this specification’s <a href="https://github.com/w3c/IndexedDB">GitHub repository</a> or (<a href="http://lists.w3.org/Archives/Public/public-webapps/">archived</a>) public mailing list <a href="mailto:public-webapps@w3.org?Subject=%5BIndexedDB%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> (see <a href="http://www.w3.org/Mail/Request">instructions</a>). When sending e-mail, please put the text “IndexedDB” in the subject, preferably like this: “[IndexedDB] <em>…summary of comment…</em>. All comments are welcome. </p>
+   <p> If you wish to make comments regarding this document, please send them to this specification’s <a href="https://github.com/w3c/IndexedDB">GitHub repository</a> or (<a href="http://lists.w3.org/Archives/Public/public-webapps/">archived</a>) public mailing list <a href="mailto:public-webapps@w3.org?Subject=%5Bindexeddb%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> (see <a href="http://www.w3.org/Mail/Request">instructions</a>). When sending e-mail, please put the text “indexeddb” in the subject, preferably like this: “[indexeddb] <em>…summary of comment…</em>. All comments are welcome. </p>
    <p> This document was produced by the <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>. </p>
    <p> This document was produced by a group operating under
   the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
@@ -3136,6 +3136,8 @@ or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">thr
       <p>Remove <var>store</var> from this <a data-link-type="dfn" href="#connection" id="ref-for-connection-36">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-2">object
 store set</a>.</p>
      <li data-md="">
+      <p>If there is an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-9">object store handle</a> associated with <var>store</var> and <var>transaction</var>, remove all entries from its <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-1">index set</a>.</p>
+     <li data-md="">
       <p>Destroy <var>store</var>.</p>
     </ol>
    </div>
@@ -3190,7 +3192,7 @@ event handler for the <code>error</code> event.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-onversionchange">onversionchange</dfn> attribute is
 the event handler for the <code>versionchange</code> event.</p>
    <h3 class="heading settled" data-level="4.5" id="object-store-interface"><span class="secno">4.5. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-4">IDBObjectStore</a></code> interface</span><a class="self-link" href="#object-store-interface"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-5">IDBObjectStore</a></code> interface represents an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-9">object store handle</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-5">IDBObjectStore</a></code> interface represents an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-10">object store handle</a>.</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbobjectstore">IDBObjectStore</dfn> {
            <span class="kt">attribute</span> <span class="kt">DOMString</span>      <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-1">name</a>;
@@ -3230,7 +3232,7 @@ the event handler for the <code>versionchange</code> event.</p>
 };
 </pre>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-name">name</dfn> attribute’s getter
-must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-10">object store handle</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-7">name</a>.</p>
+must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-11">object store handle</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-7">name</a>.</p>
    <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-31">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-5">finished</a>,
   this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-67">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-8">name</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-32">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-6">finished</a>, this attribute will not reflect changes made with a
   later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-23">upgrade transaction</a>. </aside>
@@ -3240,9 +3242,9 @@ must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for
      <li data-md="">
       <p>Let <var>name</var> be the given value.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-11">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-2">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-12">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-2">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-12">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-3">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-13">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-3">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-7">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3257,7 +3259,7 @@ terminate these steps.</p>
      <li data-md="">
       <p>Set <var>store</var>’s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-11">name</a> to <var>name</var>.</p>
      <li data-md="">
-      <p>Set this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-13">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-name" id="ref-for-object-store-handle-name-1">name</a> to <var>name</var>.</p>
+      <p>Set this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-14">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-name" id="ref-for-object-store-handle-name-1">name</a> to <var>name</var>.</p>
     </ol>
    </div>
    <aside class="advisement"> 🚧
@@ -3265,7 +3267,7 @@ terminate these steps.</p>
   It will be supported in Firefox 51.
   🚧 </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-keypath">keyPath</dfn> attribute’s getter
-must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-14">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-4">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-12">key
+must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-15">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-4">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-12">key
 path</a>, or null if none.</p>
    <p>The conversion is done following the normal <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> binding logic
 for <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> values, as
@@ -3275,24 +3277,24 @@ an object (specifically an <a data-link-type="dfn" href="https://tc39.github.io/
 instance every time it is inspected. Changing the properties of the
 object has no effect on the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-70">object store</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-indexnames">indexNames</dfn> attribute’s
-getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-2">sorted list</a> of the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-2">names</a> of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-19">indexes</a> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-15">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-1">index set</a>.</p>
+getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-2">sorted list</a> of the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-2">names</a> of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-19">indexes</a> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-16">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-2">index set</a>.</p>
    <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-33">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-7">finished</a>,
   this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-71">object store</a>'s list
   of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-20">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-3">names</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-34">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-8">finished</a>, this attribute will not
   reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-25">upgrade transaction</a>. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-transaction">transaction</dfn> attribute’s
-getter must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-16">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-3">transaction</a>.</p>
+getter must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-17">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-3">transaction</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-autoincrement">autoIncrement</dfn> attribute’s
-getter must return true if this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-17">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-5">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-13">key generator</a>,
+getter must return true if this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-18">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-5">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-13">key generator</a>,
 and false otherwise.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="method" data-export="" data-lt="put(value, key)|put(value)" id="dom-idbobjectstore-put">put(<var>value</var>, <var>key</var>)</dfn> method,
 when invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-18">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-4">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-19">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-4">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-19">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-6">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-20">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-6">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-9">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3336,7 +3338,7 @@ generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#df
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-2">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-18">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-20">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-storing-a-record-into-an-object-store" id="ref-for-steps-for-storing-a-record-into-an-object-store-1">steps for storing a record into an object store</a> as <var>operation</var>, using <var>store</var>, the <var>clone</var> as <var>value</var>, <var>key</var>, and
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-21">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-storing-a-record-into-an-object-store" id="ref-for-steps-for-storing-a-record-into-an-object-store-1">steps for storing a record into an object store</a> as <var>operation</var>, using <var>store</var>, the <var>clone</var> as <var>value</var>, <var>key</var>, and
 with the <var>no-overwrite flag</var> unset.</p>
     </ol>
    </div>
@@ -3345,9 +3347,9 @@ when invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-21">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-5">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-22">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-5">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-22">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-7">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-23">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-7">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-10">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3391,7 +3393,7 @@ generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#df
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-3">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-19">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-23">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-storing-a-record-into-an-object-store" id="ref-for-steps-for-storing-a-record-into-an-object-store-2">steps for storing a record into an object store</a> as <var>operation</var>, using <var>store</var>, <var>clone</var> as <var>value</var>, <var>key</var>, and with
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-24">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-storing-a-record-into-an-object-store" id="ref-for-steps-for-storing-a-record-into-an-object-store-2">steps for storing a record into an object store</a> as <var>operation</var>, using <var>store</var>, <var>clone</var> as <var>value</var>, <var>key</var>, and with
 the <var>no-overwrite flag</var> set.</p>
     </ol>
    </div>
@@ -3400,9 +3402,9 @@ invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-24">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-6">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-25">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-6">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-25">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-8">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-26">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-8">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-11">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3414,7 +3416,7 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-4">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-20">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-26">object store handle</a> as <var>source</var> and
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-27">object store handle</a> as <var>source</var> and
 the <a data-link-type="dfn" href="#steps-for-deleting-records-from-an-object-store" id="ref-for-steps-for-deleting-records-from-an-object-store-1">steps for deleting records from an object store</a> as <var>operation</var>, using <var>store</var> and <var>range</var>.</p>
     </ol>
    </div>
@@ -3427,9 +3429,9 @@ must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-27">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-7">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-28">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-7">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-28">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-9">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-29">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-9">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-12">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3439,16 +3441,16 @@ must run these steps:</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-5">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-21">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-29">object store handle</a> as <var>source</var> and
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-30">object store handle</a> as <var>source</var> and
 the <a data-link-type="dfn" href="#steps-for-clearing-an-object-store" id="ref-for-steps-for-clearing-an-object-store-1">steps for clearing an object store</a> as <var>operation</var>, using <var>store</var>.</p>
     </ol>
     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="method" data-export="" id="dom-idbobjectstore-get">get(<var>query</var>)</dfn> method, when
 invoked, must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-30">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-8">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-31">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-8">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-31">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-10">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-32">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-10">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-13">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3458,7 +3460,7 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-6">steps for asynchronously executing a request</a> and
   return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-22">IDBRequest</a></code> created by these steps. The steps
-  are run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-32">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-a-value-from-an-object-store" id="ref-for-steps-for-retrieving-a-value-from-an-object-store-1">steps for retrieving a value from
+  are run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-33">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-a-value-from-an-object-store" id="ref-for-steps-for-retrieving-a-value-from-an-object-store-1">steps for retrieving a value from
   an object store</a> as <var>operation</var>, using <var>store</var> and <var>range</var>.</p>
     </ol>
    </div>
@@ -3475,9 +3477,9 @@ invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-33">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-9">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-34">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-9">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-34">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-11">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-35">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-11">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-14">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3487,7 +3489,7 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-7">steps for asynchronously executing a request</a> and
   return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-23">IDBRequest</a></code> created by these steps. The steps
-  are run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-35">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-a-key-from-an-object-store" id="ref-for-steps-for-retrieving-a-key-from-an-object-store-1">steps for retrieving a key from an
+  are run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-36">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-a-key-from-an-object-store" id="ref-for-steps-for-retrieving-a-key-from-an-object-store-1">steps for retrieving a key from an
   object store</a> as <var>operation</var>, using <var>store</var> and <var>range</var>.</p>
     </ol>
    </div>
@@ -3503,9 +3505,9 @@ the first existing key in that range.</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-36">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-10">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-37">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-10">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-37">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-12">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-38">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-12">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-15">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3516,7 +3518,7 @@ Rethrow any exceptions.</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-8">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-24">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-38">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-multiple-values-from-an-object-store" id="ref-for-steps-for-retrieving-multiple-values-from-an-object-store-1">steps for retrieving multiple values from an object store</a> as <var>operation</var>, using <var>store</var>, <var>range</var>, and <var>count</var> if given.</p>
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-39">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-multiple-values-from-an-object-store" id="ref-for-steps-for-retrieving-multiple-values-from-an-object-store-1">steps for retrieving multiple values from an object store</a> as <var>operation</var>, using <var>store</var>, <var>range</var>, and <var>count</var> if given.</p>
     </ol>
    </div>
    <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-49">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-4">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-28">records</a> to be retrieved. If null or not given,
@@ -3530,9 +3532,9 @@ there are more than <var>count</var> records in range, only the first <var>count
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-39">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-11">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-40">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-11">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-40">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-13">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-41">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-13">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-16">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3543,7 +3545,7 @@ Rethrow any exceptions.</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-9">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-25">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-41">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-multiple-keys-from-an-object-store" id="ref-for-steps-for-retrieving-multiple-keys-from-an-object-store-1">steps for retrieving multiple keys from an object store</a> as <var>operation</var>, using <var>store</var>, <var>range</var>, and <var>count</var> if given.</p>
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-42">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-retrieving-multiple-keys-from-an-object-store" id="ref-for-steps-for-retrieving-multiple-keys-from-an-object-store-1">steps for retrieving multiple keys from an object store</a> as <var>operation</var>, using <var>store</var>, <var>range</var>, and <var>count</var> if given.</p>
     </ol>
    </div>
    <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-50">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-5">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-29">records</a> keys to be retrieved. If null or not
@@ -3558,9 +3560,9 @@ invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-42">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-12">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-43">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-12">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-43">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-14">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-44">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-14">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-17">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3571,7 +3573,7 @@ Rethrow any exceptions.</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-10">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-26">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-44">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-to-count-the-records-in-a-range" id="ref-for-steps-to-count-the-records-in-a-range-1">steps to count the records in a range</a> as <var>operation</var>, with <var>source</var> and <var>range</var>.</p>
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-45">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-to-count-the-records-in-a-range" id="ref-for-steps-to-count-the-records-in-a-range-1">steps to count the records in a range</a> as <var>operation</var>, with <var>source</var> and <var>range</var>.</p>
     </ol>
    </div>
    <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-51">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-6">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-30">records</a> keys to be counted. If null or not
@@ -3580,9 +3582,9 @@ given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unboun
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-45">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-13">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-46">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-13">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-46">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-15">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-47">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-15">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-18">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3596,7 +3598,7 @@ flag</a> unset, and undefined <a data-link-type="dfn" href="#cursor-key" id="ref
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-11">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-27">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-47">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-iterating-a-cursor" id="ref-for-steps-for-iterating-a-cursor-1">steps for iterating a cursor</a> with <var>cursor</var> as <var>operation</var>.</p>
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-48">object store handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-for-iterating-a-cursor" id="ref-for-steps-for-iterating-a-cursor-1">steps for iterating a cursor</a> with <var>cursor</var> as <var>operation</var>.</p>
     </ol>
    </div>
    <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-52">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-7">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-17">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-4">range</a>.
@@ -3605,9 +3607,9 @@ If null or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id=
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-48">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-14">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-49">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-14">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-49">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-16">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-50">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-16">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-19">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3622,7 +3624,7 @@ set.</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-12">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-28">IDBRequest</a></code> created by these steps. The steps are
-run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-50">object store handle</a> as <var>source</var> and
+run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-51">object store handle</a> as <var>source</var> and
 the <a data-link-type="dfn" href="#steps-for-iterating-a-cursor" id="ref-for-steps-for-iterating-a-cursor-2">steps for iterating a cursor</a> with <var>cursor</var> as <var>operation</var>.</p>
     </ol>
    </div>
@@ -3636,9 +3638,9 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-51">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-15">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-52">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-15">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-52">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-17">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-53">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-17">object store</a>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-26">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-20">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3661,10 +3663,10 @@ set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">t
 Set <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-5">name</a> to <var>name</var> and <a data-link-type="dfn" href="#index-key-path" id="ref-for-index-key-path-4">key path</a> to <var>keyPath</var>. If <var>unique</var> is set, set <var>index</var>’s <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-3">unique flag</a>. If <var>multiEntry</var> is
 set, set <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-3">multiEntry flag</a>.</p>
      <li data-md="">
-      <p>Add <var>index</var> to this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-53">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-2">index
+      <p>Add <var>index</var> to this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-54">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-3">index
   set</a>.</p>
      <li data-md="">
-      <p>Return a new <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-6">index handle</a> associated with <var>index</var> and this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-54">object store handle</a>.</p>
+      <p>Return a new <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-6">index handle</a> associated with <var>index</var> and this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-55">object store handle</a>.</p>
     </ol>
    </div>
    <p>This method creates and returns a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-23">index</a> with the
@@ -3713,19 +3715,19 @@ invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-55">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-16">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-56">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-16">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-56">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-18">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-57">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-18">object store</a>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-22">InvalidStateError</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-9">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-23">InvalidStateError</a></code>.</p>
      <li data-md="">
-      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-25">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-6">named</a> <var>name</var> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-57">object
-store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-3">index set</a> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-notfounderror" id="ref-for-exceptiondef-exceptions-notfounderror-3">NotFoundError</a></code> otherwise.</p>
+      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-25">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-6">named</a> <var>name</var> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-58">object
+store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-4">index set</a> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-notfounderror" id="ref-for-exceptiondef-exceptions-notfounderror-3">NotFoundError</a></code> otherwise.</p>
      <li data-md="">
       <p>Return an <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-7">index handle</a> associated with <var>index</var> and
-this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-58">object store handle</a>.</p>
+this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-59">object store handle</a>.</p>
     </ol>
    </div>
    <aside class="note"> Each call to this method on the same <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-8">IDBObjectStore</a></code> instance
@@ -3738,9 +3740,9 @@ when invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-59">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-17">transaction</a>.</p>
+      <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-60">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-17">transaction</a>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-60">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-19">object store</a>.</p>
+      <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-61">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-19">object store</a>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-30">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-invalidstateerror" id="ref-for-exceptiondef-exceptions-invalidstateerror-24">InvalidStateError</a></code>.</p>
      <li data-md="">
@@ -3750,7 +3752,7 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-26">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-7">named</a> <var>name</var> in <var>store</var> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-notfounderror" id="ref-for-exceptiondef-exceptions-notfounderror-4">NotFoundError</a></code> otherwise.</p>
      <li data-md="">
-      <p>Remove <var>index</var> from this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-61">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-4">index set</a>.</p>
+      <p>Remove <var>index</var> from this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-62">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-5">index set</a>.</p>
      <li data-md="">
       <p>Destroy <var>index</var>.</p>
     </ol>
@@ -4472,7 +4474,7 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-86">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-14">named</a> <var>name</var> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-49">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-13">scope</a>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="#exceptiondef-exceptions-notfounderror" id="ref-for-exceptiondef-exceptions-notfounderror-5">NotFoundError</a></code> if none.</p>
      <li data-md="">
-      <p>Return an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-62">object store handle</a> associated with <var>store</var> and this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-50">transaction</a>.</p>
+      <p>Return an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-63">object store handle</a> associated with <var>store</var> and this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-50">transaction</a>.</p>
     </ol>
    </div>
    <aside class="note"> Each call to this method on the same <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-6">IDBTransaction</a></code> instance
@@ -4699,7 +4701,7 @@ considered deleted for the purposes of other algorithms.</p>
      <li data-md="">
       <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-39">upgrade transactions</a>, run the <a data-link-type="dfn" href="#steps-for-aborting-an-upgrade-transaction" id="ref-for-steps-for-aborting-an-upgrade-transaction-2">steps
 for aborting an upgrade transaction</a> with <var>transaction</var>. This
-reverts changes to all <a data-link-type="dfn" href="#connection" id="ref-for-connection-51">connection</a>, <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-63">object store handle</a>,
+reverts changes to all <a data-link-type="dfn" href="#connection" id="ref-for-connection-51">connection</a>, <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-64">object store handle</a>,
 and <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-38">index handle</a> instances associated with <var>transaction</var>.</p>
      <li data-md="">
       <p>If <var>error</var> is not null, set <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-2">error</a> to <var>error</var>.</p>
@@ -4859,14 +4861,14 @@ existed, or the empty set if <var>database</var> was newly created.</p>
       <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-4">objectStoreNames</a></code> returned
   by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-13">IDBDatabase</a></code> object. </aside>
      <li data-md="">
-      <p>For each <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-64">object store handle</a> <var>handle</var> associated with <var>transaction</var>, including those for <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a> that
+      <p>For each <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-65">object store handle</a> <var>handle</var> associated with <var>transaction</var>, including those for <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a> that
 were created or deleted during <var>transaction</var>, run these substeps:</p>
       <ol>
        <li data-md="">
         <p>If <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-20">object store</a> was not
 newly created during <var>transaction</var>, set <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-name" id="ref-for-object-store-handle-name-2">name</a> to its <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-21">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-15">name</a>.</p>
        <li data-md="">
-        <p>Set <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-5">index set</a> to the set of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-37">indexes</a> that
+        <p>Set <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-6">index set</a> to the set of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-37">indexes</a> that
 reference its <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-22">object store</a>.</p>
       </ol>
       <aside class="note">
@@ -7024,11 +7026,11 @@ specification.</p>
    <ul>
     <li><a href="#ref-for-object-store-handle-1">2.2.1. Object Store Handle</a> <a href="#ref-for-object-store-handle-2">(2)</a> <a href="#ref-for-object-store-handle-3">(3)</a> <a href="#ref-for-object-store-handle-4">(4)</a> <a href="#ref-for-object-store-handle-5">(5)</a> <a href="#ref-for-object-store-handle-6">(6)</a>
     <li><a href="#ref-for-object-store-handle-7">2.6.1. Index Handle</a>
-    <li><a href="#ref-for-object-store-handle-8">4.4. The IDBDatabase interface</a>
-    <li><a href="#ref-for-object-store-handle-9">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-handle-10">(2)</a> <a href="#ref-for-object-store-handle-11">(3)</a> <a href="#ref-for-object-store-handle-12">(4)</a> <a href="#ref-for-object-store-handle-13">(5)</a> <a href="#ref-for-object-store-handle-14">(6)</a> <a href="#ref-for-object-store-handle-15">(7)</a> <a href="#ref-for-object-store-handle-16">(8)</a> <a href="#ref-for-object-store-handle-17">(9)</a> <a href="#ref-for-object-store-handle-18">(10)</a> <a href="#ref-for-object-store-handle-19">(11)</a> <a href="#ref-for-object-store-handle-20">(12)</a> <a href="#ref-for-object-store-handle-21">(13)</a> <a href="#ref-for-object-store-handle-22">(14)</a> <a href="#ref-for-object-store-handle-23">(15)</a> <a href="#ref-for-object-store-handle-24">(16)</a> <a href="#ref-for-object-store-handle-25">(17)</a> <a href="#ref-for-object-store-handle-26">(18)</a> <a href="#ref-for-object-store-handle-27">(19)</a> <a href="#ref-for-object-store-handle-28">(20)</a> <a href="#ref-for-object-store-handle-29">(21)</a> <a href="#ref-for-object-store-handle-30">(22)</a> <a href="#ref-for-object-store-handle-31">(23)</a> <a href="#ref-for-object-store-handle-32">(24)</a> <a href="#ref-for-object-store-handle-33">(25)</a> <a href="#ref-for-object-store-handle-34">(26)</a> <a href="#ref-for-object-store-handle-35">(27)</a> <a href="#ref-for-object-store-handle-36">(28)</a> <a href="#ref-for-object-store-handle-37">(29)</a> <a href="#ref-for-object-store-handle-38">(30)</a> <a href="#ref-for-object-store-handle-39">(31)</a> <a href="#ref-for-object-store-handle-40">(32)</a> <a href="#ref-for-object-store-handle-41">(33)</a> <a href="#ref-for-object-store-handle-42">(34)</a> <a href="#ref-for-object-store-handle-43">(35)</a> <a href="#ref-for-object-store-handle-44">(36)</a> <a href="#ref-for-object-store-handle-45">(37)</a> <a href="#ref-for-object-store-handle-46">(38)</a> <a href="#ref-for-object-store-handle-47">(39)</a> <a href="#ref-for-object-store-handle-48">(40)</a> <a href="#ref-for-object-store-handle-49">(41)</a> <a href="#ref-for-object-store-handle-50">(42)</a> <a href="#ref-for-object-store-handle-51">(43)</a> <a href="#ref-for-object-store-handle-52">(44)</a> <a href="#ref-for-object-store-handle-53">(45)</a> <a href="#ref-for-object-store-handle-54">(46)</a> <a href="#ref-for-object-store-handle-55">(47)</a> <a href="#ref-for-object-store-handle-56">(48)</a> <a href="#ref-for-object-store-handle-57">(49)</a> <a href="#ref-for-object-store-handle-58">(50)</a> <a href="#ref-for-object-store-handle-59">(51)</a> <a href="#ref-for-object-store-handle-60">(52)</a> <a href="#ref-for-object-store-handle-61">(53)</a>
-    <li><a href="#ref-for-object-store-handle-62">4.9. The IDBTransaction interface</a>
-    <li><a href="#ref-for-object-store-handle-63">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-object-store-handle-64">5.8. Aborting an upgrade transaction</a>
+    <li><a href="#ref-for-object-store-handle-8">4.4. The IDBDatabase interface</a> <a href="#ref-for-object-store-handle-9">(2)</a>
+    <li><a href="#ref-for-object-store-handle-10">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-handle-11">(2)</a> <a href="#ref-for-object-store-handle-12">(3)</a> <a href="#ref-for-object-store-handle-13">(4)</a> <a href="#ref-for-object-store-handle-14">(5)</a> <a href="#ref-for-object-store-handle-15">(6)</a> <a href="#ref-for-object-store-handle-16">(7)</a> <a href="#ref-for-object-store-handle-17">(8)</a> <a href="#ref-for-object-store-handle-18">(9)</a> <a href="#ref-for-object-store-handle-19">(10)</a> <a href="#ref-for-object-store-handle-20">(11)</a> <a href="#ref-for-object-store-handle-21">(12)</a> <a href="#ref-for-object-store-handle-22">(13)</a> <a href="#ref-for-object-store-handle-23">(14)</a> <a href="#ref-for-object-store-handle-24">(15)</a> <a href="#ref-for-object-store-handle-25">(16)</a> <a href="#ref-for-object-store-handle-26">(17)</a> <a href="#ref-for-object-store-handle-27">(18)</a> <a href="#ref-for-object-store-handle-28">(19)</a> <a href="#ref-for-object-store-handle-29">(20)</a> <a href="#ref-for-object-store-handle-30">(21)</a> <a href="#ref-for-object-store-handle-31">(22)</a> <a href="#ref-for-object-store-handle-32">(23)</a> <a href="#ref-for-object-store-handle-33">(24)</a> <a href="#ref-for-object-store-handle-34">(25)</a> <a href="#ref-for-object-store-handle-35">(26)</a> <a href="#ref-for-object-store-handle-36">(27)</a> <a href="#ref-for-object-store-handle-37">(28)</a> <a href="#ref-for-object-store-handle-38">(29)</a> <a href="#ref-for-object-store-handle-39">(30)</a> <a href="#ref-for-object-store-handle-40">(31)</a> <a href="#ref-for-object-store-handle-41">(32)</a> <a href="#ref-for-object-store-handle-42">(33)</a> <a href="#ref-for-object-store-handle-43">(34)</a> <a href="#ref-for-object-store-handle-44">(35)</a> <a href="#ref-for-object-store-handle-45">(36)</a> <a href="#ref-for-object-store-handle-46">(37)</a> <a href="#ref-for-object-store-handle-47">(38)</a> <a href="#ref-for-object-store-handle-48">(39)</a> <a href="#ref-for-object-store-handle-49">(40)</a> <a href="#ref-for-object-store-handle-50">(41)</a> <a href="#ref-for-object-store-handle-51">(42)</a> <a href="#ref-for-object-store-handle-52">(43)</a> <a href="#ref-for-object-store-handle-53">(44)</a> <a href="#ref-for-object-store-handle-54">(45)</a> <a href="#ref-for-object-store-handle-55">(46)</a> <a href="#ref-for-object-store-handle-56">(47)</a> <a href="#ref-for-object-store-handle-57">(48)</a> <a href="#ref-for-object-store-handle-58">(49)</a> <a href="#ref-for-object-store-handle-59">(50)</a> <a href="#ref-for-object-store-handle-60">(51)</a> <a href="#ref-for-object-store-handle-61">(52)</a> <a href="#ref-for-object-store-handle-62">(53)</a>
+    <li><a href="#ref-for-object-store-handle-63">4.9. The IDBTransaction interface</a>
+    <li><a href="#ref-for-object-store-handle-64">5.5. Aborting a transaction</a>
+    <li><a href="#ref-for-object-store-handle-65">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="object-store-handle-object-store">
@@ -7049,8 +7051,9 @@ specification.</p>
   <aside class="dfn-panel" data-for="object-store-handle-index-set">
    <b><a href="#object-store-handle-index-set">#object-store-handle-index-set</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-object-store-handle-index-set-1">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-handle-index-set-2">(2)</a> <a href="#ref-for-object-store-handle-index-set-3">(3)</a> <a href="#ref-for-object-store-handle-index-set-4">(4)</a>
-    <li><a href="#ref-for-object-store-handle-index-set-5">5.8. Aborting an upgrade transaction</a>
+    <li><a href="#ref-for-object-store-handle-index-set-1">4.4. The IDBDatabase interface</a>
+    <li><a href="#ref-for-object-store-handle-index-set-2">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-handle-index-set-3">(2)</a> <a href="#ref-for-object-store-handle-index-set-4">(3)</a> <a href="#ref-for-object-store-handle-index-set-5">(4)</a>
+    <li><a href="#ref-for-object-store-handle-index-set-6">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="object-store-handle-name">


### PR DESCRIPTION
Match implementation (Chrome, Firefox) and web-platform-test behavior that an object store handle's index set is cleared when the object store is deleted.