### PR TITLE
Reword DOMException throwing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -930,7 +930,7 @@ The <dfn>lifetime</dfn> of a
     against a transaction only while that transaction is [=transaction/active=].
     If an attempt is made to place a request against a transaction
     when that transaction is not [=transaction/active=], the implementation must
-    reject the attempt by throwing a {{TransactionInactiveError}}.
+    reject the attempt by throwing a "{{TransactionInactiveError}}" {{DOMException}}.
 
 3. Once an implementation is able to enforce the constraints defined
     for the transaction [=transaction/scope=] and [=transaction/mode=], defined below, the
@@ -965,8 +965,8 @@ The <dfn>lifetime</dfn> of a
     request. In this case the implementation must run the [=steps for
     aborting a transaction=] using the transaction as |transaction|
     and the appropriate error type as |error|. For example if quota
-    was exceeded then {{QuotaExceededError}} should be used as
-    |error|, and if an IO error happened, {{UnknownError}} should be
+    was exceeded then a "{{QuotaExceededError}}" {{DOMException}} should be used as
+    |error|, and if an IO error happened, an "{{UnknownError}}" {{DOMException}} should be
     used as |error|.
 
 7. When a transaction has been started and it can no longer become
@@ -1253,13 +1253,13 @@ follows:
 1. If |value| is a [=key range=], return |value|.
 
 2. If |value| is undefined or is null, then [=throw=] a
-    {{DataError}} if |null disallowed flag| is set, or return an
+    "{{DataError}}" {{DOMException}} if |null disallowed flag| is set, or return an
     [=unbounded key range=] otherwise.
 
 3. Let |key| be the result of running the steps to [=convert
     a value to a key=] with |value|. Rethrow any exceptions.
 
-4. If |key| is invalid, [=throw=] a {{DataError}}.
+4. If |key| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 5. Return a [=key range=] [=containing only=] |key|.
 
@@ -1446,7 +1446,7 @@ generating numbers when a [=key generator=] is used.
 * When the [=current number=] of a key generator reaches above the
     value 2<sup>53</sup> (9007199254740992) any attempts to use the
     key generator to generate a new [=/key=] will result in a
-    {{ConstraintError}}. It is still possible to insert
+    "{{ConstraintError}}" {{DOMException}}. It is still possible to insert
     [=object-store/records=] into the object store by specifying an explicit
     key, however the only way to use a key generator again for the
     object store is to delete the object store and create a new one.
@@ -1834,15 +1834,15 @@ enum IDBRequestReadyState {
     <dt><var>request</var> . {{IDBRequest/result}}</dt>
     <dd>
         When a request is completed, returns the [=request/result=],
-        or <code>undefined</code> if the request failed. Throws
-        {{InvalidStateError}} if the request is still pending.
+        or <code>undefined</code> if the request failed. Throws a
+        "{{InvalidStateError}}" {{DOMException}} if the request is still pending.
     </dd>
 
     <dt><var>request</var> . {{IDBRequest/error}}</dt>
     <dd>
         When a request is completed, returns the [=request/error=] (a
         {{DOMException}}), or null if the request succeeded. Throws
-        {{InvalidStateError}} if the request is still pending.
+        a "{{InvalidStateError}}" {{DOMException}} if the request is still pending.
     </dd>
 
     <dt><var>request</var> . {{IDBRequest/source}}</dt>
@@ -1868,14 +1868,14 @@ enum IDBRequestReadyState {
 </div>
 
 The <dfn attribute for=IDBRequest>result</dfn> attribute's getter must
-[=throw=] an {{InvalidStateError}} if the [=request/done flag=] is
+[=throw=] an "{{InvalidStateError}}" {{DOMException}} if the [=request/done flag=] is
 unset. Otherwise, the attribute's getter must return the
 [=request/result=] of the request, or undefined if the
 request resulted in an error.
 
 
 The <dfn attribute for=IDBRequest>error</dfn> attribute's getter must
-[=throw=] an {{InvalidStateError}} if the [=request/done flag=] is unset.
+[=throw=] an "{{InvalidStateError}}" {{DOMException}} if the [=request/done flag=] is unset.
 Otherwise, the attribute's getter must return the [=request/error=] of
 the request, or null if no error occurred.
 
@@ -2143,7 +2143,7 @@ when invoked, must run these steps:
         |key2| precedes |key1|, and 0 if
         the keys are equal.
 
-        Throws {{DataError}} if either input is not a valid [=/key=].
+        Throws a "{{DataError}}" {{DOMException}} if either input is not a valid [=/key=].
     </dd>
   </dl>
 </div>
@@ -2156,12 +2156,12 @@ when invoked, must run these steps:
 1. Let |a| be the result of running the steps to [=convert a
     value to a key=] with |first|. Rethrow any exceptions.
 
-2. If |a| is invalid, [=throw=] a {{DataError}}.
+2. If |a| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 3. Let |b| be the result of running the steps to [=convert a
     value to a key=] with |second|. Rethrow any exceptions.
 
-4. If |b| is invalid, [=throw=] a {{DataError}}.
+4. If |b| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 5. Return the results of running the steps to [=compare two keys=]
     with |a| and |b|.
@@ -2257,7 +2257,7 @@ must return this [=/connection=]'s
         Creates a new [=/object store=] in with the given |name| and |options|
         and returns a new {{IDBObjectStore}}.
 
-        Throws {{InvalidStateError}} if not called within an
+        Throws a "{{InvalidStateError}}" {{DOMException}} if not called within an
         [=upgrade transaction=].
     </dd>
 
@@ -2266,7 +2266,7 @@ must return this [=/connection=]'s
     <dd>
         Deletes the [=/object store=] with the given |name|.
 
-        Throws {{InvalidStateError}} if not called within an
+        Throws a "{{InvalidStateError}}" {{DOMException}} if not called within an
         [=upgrade transaction=].
     </dd>
   </dl>
@@ -2294,19 +2294,19 @@ The <dfn method for=IDBDatabase>createObjectStore(|name|,
 
 2. Let |transaction| be the currently running [=upgrade
     transaction=] associated with |database|, or
-    [=throw=] an {{InvalidStateError}} if none.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}} if none.
 
 3. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 4. Let |keyPath| be |options|'s {{IDBObjectStoreParameters/keyPath}}
     member if it is not undefined or null, or null otherwise.
 
 5. If |keyPath| is not null and is not a [=valid key
-    path=], [=throw=] a {{SyntaxError}}.
+    path=], [=throw=] a "{{SyntaxError}}" {{DOMException}}.
 
 6. If an [=/object store=] [=object-store/named=] |name| already
-    exists in |database| [=throw=] a {{ConstraintError}}.
+    exists in |database| [=throw=] a "{{ConstraintError}}" {{DOMException}}.
 
 7. Let |autoIncrement| be set if |options|'s
     {{IDBObjectStoreParameters/autoIncrement}} member is true, or
@@ -2314,7 +2314,7 @@ The <dfn method for=IDBDatabase>createObjectStore(|name|,
 
 8. If |autoIncrement| is set and |keyPath| is an empty string or any
     sequence (empty or otherwise), [=throw=] an
-    {{InvalidAccessError}}.
+    "{{InvalidAccessError}}" {{DOMException}}.
 
 9. Let |store| be a new [=/object store=] in
     |database|. Set the created [=/object store=]'s
@@ -2348,7 +2348,7 @@ reasons. Such implementations must still create and return an
 creating the [=/object store=] has failed, it must abort the
 transaction using the [=steps for aborting a transaction=] using the
 appropriate error. For example if creating the [=/object store=]
-failed due to quota reasons, {{QuotaExceededError}} must be used as
+failed due to quota reasons, a "{{QuotaExceededError}}" {{DOMException}} must be used as
 error.
 
 
@@ -2362,14 +2362,14 @@ method, when invoked, must run these steps:
 
 2. Let |transaction| be the currently running [=upgrade
     transaction=] associated with |database|, or
-    [=throw=] an {{InvalidStateError}} if none.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}} if none.
 
 3. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 4. Let |store| be the [=/object store=]
     [=object-store/named=] |name| in |database|,
-    or [=throw=] a {{NotFoundError}} if none.
+    or [=throw=] a "{{NotFoundError}}" {{DOMException}} if none.
 
 5. Remove |store| from this [=/connection=]'s [=object
     store set=].
@@ -2422,11 +2422,11 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|,
 
 2. If this method is called on {{IDBDatabase}} object for which an
     [=upgrade transaction=] is still running, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 3. If this method is called on an {{IDBDatabase}} instance where the
     [=close pending flag=] is set, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. Let |scope| be the set of unique strings in |storeNames| if it is a
     sequence, or a set containing one string equal to |storeNames|
@@ -2434,9 +2434,9 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|,
 
 5. If any string in |scope| is not the name of an [=/object
     store=] in the [=connected=] [=database=], [=throw=] a
-    {{NotFoundError}}.
+    "{{NotFoundError}}" {{DOMException}}.
 
-6. If |scope| is empty, [=throw=] an {{InvalidAccessError}}.
+6. If |scope| is empty, [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 
 7. Let |transaction| be a newly [=transaction/created=] [=/transaction=] with
     |connection|, |mode| and the set of [=/object stores=] named in
@@ -2543,7 +2543,7 @@ dictionary IDBIndexParameters {
     <dd>
         Updates the [=object-store/name=] of the store to |newName|.
 
-        Throws {{/InvalidStateError}} if not called within an [=upgrade
+        Throws "{{InvalidStateError}}" {{DOMException}} if not called within an [=upgrade
         transaction=].
     </dd>
     <dt><var>store</var> . {{IDBObjectStore/keyPath}}</dt>
@@ -2592,20 +2592,20 @@ The {{IDBObjectStore/name}} attribute's setter must run these steps:
     [=object-store-handle/object store=].
 
 4. If |store| has been deleted,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 5. If |transaction| is not an [=upgrade transaction=],
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 6. If |transaction| is not [=transaction/active=],
-    [=throw=] a {{TransactionInactiveError}}.
+    [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
 7. If |store|'s [=object-store/name=] is equal to |name|,
     terminate these steps.
 
 8. If an [=/object store=] [=object-store/named=]
     |name| already exists in |store|'s [=database=], [=throw=] a
-    {{ConstraintError}}.
+    "{{ConstraintError}}" {{DOMException}}.
 
 9. Set |store|'s [=object-store/name=] to |name|.
 
@@ -2664,8 +2664,8 @@ and false otherwise.
 
 
 <div class=note>
-  The following methods throw {{ReadOnlyError}} if called within a
-  [=read-only transaction=], and {{TransactionInactiveError}} if
+  The following methods throw a "{{ReadOnlyError}}" {{DOMException}} if called within a
+  [=read-only transaction=], and a "{{TransactionInactiveError}}" {{DOMException}} if
   called when the [=/transaction=] is not [=transaction/active=].
 
   <dl class=domintro>
@@ -2680,13 +2680,13 @@ and false otherwise.
     <dd>
        Adds or updates a [=record=] in |store| with the given |value|
        and |key|. If the store uses [=in-line keys=], then |key| must
-       not be specified, or a {{DataError}} will be thrown.
+       not be specified, or a "{{DataError}}" {{DOMException}} will be thrown.
 
        If {{IDBObjectStore/put()}} is used, any existing [=record=]
        with the [=/key=] will be replaced. If {{IDBObjectStore/add()}}
        is used, and if a [=record=] with the [=/key=] already exists
        the |request| will fail, with |request|'s {{IDBRequest/error}}
-       set to {{ConstraintError}}.
+       set to a "{{ConstraintError}}" {{DOMException}}.
 
        If successful, |request|'s {{IDBRequest/result}} will be the
        [=record=]'s [=/key=].
@@ -2728,27 +2728,27 @@ when invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=],
-    [=throw=] a {{TransactionInactiveError}}.
+    [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. If |transaction| is a [=read-only transaction=],
-    [=throw=] a {{ReadOnlyError}}.
+    [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
 6. If |store| uses [=in-line keys=] and |key| was given,
-    [=throw=] a {{DataError}}.
+    [=throw=] a "{{DataError}}" {{DOMException}}.
 
 7. If |store| uses [=out-of-line keys=] and has no [=key
     generator=] and |key| was not given, [=throw=] a
-    {{DataError}}.
+    "{{DataError}}" {{DOMException}}.
 
 8. If |key| was given, run these substeps:
 
     1. Let |r| be the result of running the steps to [=convert a
         value to a key=] with |key|. Rethrow any exceptions.
 
-    2. If |r| is invalid, [=throw=] a {{DataError}}.
+    2. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
     3. Let |key| be |r|.
 
@@ -2762,12 +2762,12 @@ when invoked, must run these steps:
         |store|'s [=object-store/key path=]. Rethrow any
         exceptions.
 
-    2. If |kpk| is invalid, [=throw=] a {{DataError}}.
+    2. If |kpk| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
     3. If |kpk| is not failure, let |key| be |kpk|.
 
     4. Otherwise, if |store| does not have a [=key
-        generator=], [=throw=] a {{DataError}}.
+        generator=], [=throw=] a "{{DataError}}" {{DOMException}}.
 
 11. Run the [=steps for asynchronously executing a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
@@ -2790,27 +2790,27 @@ when invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. If |transaction| is a [=read-only transaction=],
-    [=throw=] a {{ReadOnlyError}}.
+    [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
 6. If |store| uses [=in-line keys=] and |key| was given,
-    [=throw=] a {{DataError}}.
+    [=throw=] a "{{DataError}}" {{DOMException}}.
 
 7. If |store| uses [=out-of-line keys=] and has no [=key
     generator=] and |key| was not given, [=throw=] a
-    {{DataError}}.
+    "{{DataError}}" {{DOMException}}.
 
 8. If |key| was given, run these substeps:
 
     1. Let |r| be the result of running the steps to [=convert a
         value to a key=] with |key|. Rethrow any exceptions.
 
-    2. If |r| is invalid, [=throw=] a {{DataError}}.
+    2. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
     3. Let |key| be |r|.
 
@@ -2824,13 +2824,13 @@ when invoked, must run these steps:
         |store|'s [=object-store/key path=]. Rethrow any
         exceptions.
 
-    2. If |kpk| is invalid, [=throw=] a {{DataError}}.
+    2. If |kpk| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
     3. If |kpk| is not failure, let |key| be
         |kpk|.
 
     4. Otherwise, if |store| does not have a [=key
-        generator=], [=throw=] a {{DataError}}.
+        generator=], [=throw=] a "{{DataError}}" {{DOMException}}.
 
 11. Run the [=steps for asynchronously executing a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
@@ -2853,13 +2853,13 @@ invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. If |transaction| is a [=read-only transaction=],
-    [=throw=] a {{ReadOnlyError}}.
+    [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
 6. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query| and
@@ -2896,13 +2896,13 @@ must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. If |transaction| is a [=read-only transaction=],
-    [=throw=] a {{ReadOnlyError}}.
+    [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
 6. Run the [=steps for asynchronously executing a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
@@ -2912,7 +2912,7 @@ must run these steps:
 
 
 <div class=note>
-  The following methods throw {{TransactionInactiveError}} if called
+  The following methods throw a "{{TransactionInactiveError}}" {{DOMException}} if called
   when the [=/transaction=] is not [=transaction/active=].
 
   <dl class=domintro>
@@ -2990,10 +2990,10 @@ invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query| and
@@ -3035,10 +3035,10 @@ invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query| and
@@ -3079,10 +3079,10 @@ method, when invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3122,10 +3122,10 @@ method, when invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3165,10 +3165,10 @@ invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3187,7 +3187,7 @@ identifying the [=object-store/records=] keys to be counted. If null or not
 given, an [=unbounded key range=] is used.
 
 <div class=note>
-  The following methods throw {{TransactionInactiveError}} if called
+  The following methods throw a "{{TransactionInactiveError}}" {{DOMException}} if called
   when the [=/transaction=] is not [=transaction/active=].
 
   <dl class=domintro>
@@ -3235,10 +3235,10 @@ The <dfn method for=IDBObjectStore>openCursor(|query|,
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3275,10 +3275,10 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|,
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3334,9 +3334,9 @@ or not given, an [=unbounded key range=] is used.
       |keyPath| and |options| define constraints that cannot be
       satisfied with the data already in |store| the [=upgrade
       transaction=] will [=transaction/abort=] with
-      {{ConstraintError}}.
+      a "{{ConstraintError}}" {{DOMException}}.
 
-      Throws {{InvalidStateError}} if not called within an [=upgrade
+      Throws an "{{InvalidStateError}}" {{DOMException}} if not called within an [=upgrade
       transaction=].
     </dd>
 
@@ -3346,7 +3346,7 @@ or not given, an [=unbounded key range=] is used.
     <dd>
       Deletes the [=/index=] in |store| with the given |name|.
 
-      Throws {{InvalidStateError}} if not called within an [=upgrade
+      Throws an "{{InvalidStateError}}" {{DOMException}} if not called within an [=upgrade
       transaction=].
     </dd>
 
@@ -3365,20 +3365,20 @@ The <dfn method for=IDBObjectStore>createIndex(|name|, |keyPath|,
     [=object-store-handle/object store=].
 
 3. If |transaction| is not an [=upgrade transaction=],
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 5. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 6. If an [=/index=] [=index/named=]
     |name| already exists in |store|, [=throw=] a
-    {{ConstraintError}}.
+    "{{ConstraintError}}" {{DOMException}}.
 
 7. If |keyPath| is not a [=valid key path=], [=throw=]
-    a {{SyntaxError}}.
+    a "{{SyntaxError}}" {{DOMException}}.
 
 8. Let |unique| be set if |options|'s
     {{IDBIndexParameters/unique}} member is true, and unset otherwise.
@@ -3387,7 +3387,7 @@ The <dfn method for=IDBObjectStore>createIndex(|name|, |keyPath|,
     {{IDBIndexParameters/multiEntry}} member is true, and unset otherwise.
 
 10. If |keyPath| is a sequence and |multiEntry| is
-    set, [=throw=] an {{InvalidAccessError}}.
+    set, [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 
 11. Let |index| be a new [=/index=] in |store|.
     Set |index|'s [=index/name=] to
@@ -3436,8 +3436,8 @@ and once the implementation determines that creating the index has
 failed, it must abort the transaction using the [=steps for aborting
 a transaction=] using an appropriate error as |error|. For example
 if creating the [=/index=] failed due to quota reasons,
-{{QuotaExceededError}} must be used as error and if the index can't be
-created due to [=unique flag=] constraints, {{ConstraintError}}
+a "{{QuotaExceededError}}" {{DOMException}} must be used as error and if the index can't be
+created due to [=unique flag=] constraints, a "{{ConstraintError}}" {{DOMException}}
 must be used as error.
 
 <aside class=example>
@@ -3473,15 +3473,15 @@ invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| has [=transaction/finished=], [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 5. Let |index| be the [=/index=]
     [=index/named=] |name| in this [=/object
     store handle=]'s [=index set=] if one exists, or [=throw=]
-    a {{NotFoundError}} otherwise.
+    a "{{NotFoundError}}" {{DOMException}} otherwise.
 
 6. Return an [=index handle=] associated with |index| and
     this [=/object store handle=].
@@ -3513,16 +3513,16 @@ when invoked, must run these steps:
     [=object-store-handle/object store=].
 
 3. If |transaction| is not an [=upgrade transaction=],
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |store| has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 5. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 6. Let |index| be the [=/index=] [=index/named=] |name|
-    in |store| if one exists, or [=throw=] a {{NotFoundError}}
+    in |store| if one exists, or [=throw=] a "{{NotFoundError}}" {{DOMException}}
     otherwise.
 
 7. Remove |index| from this [=/object store handle=]'s
@@ -3584,7 +3584,7 @@ interface IDBIndex {
     <dd>
       Updates the [=index/name=] of the store to |newName|.
 
-      Throws {{/InvalidStateError}} if not called within an [=upgrade
+      Throws an "{{InvalidStateError}}" {{DOMException}} if not called within an [=upgrade
       transaction=].
     </dd>
     <dt><var>index</var> . {{IDBIndex/objectStore}}</dt>
@@ -3631,20 +3631,20 @@ The {{IDBIndex/name}} attribute's setter must run these steps:
     [=index-handle/index=].
 
 4. If |transaction| is not an [=upgrade transaction=],
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 5. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 6. If |index| or |index|'s [=/object store=] has
-    been deleted, [=throw=] an {{InvalidStateError}}.
+    been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 7. If |index|'s [=index/name=] is equal to
     |name|, terminate these steps.
 
 8. If an [=/index=] [=index/named=]
     |name| already exists in |index|'s [=/object
-    store=], [=throw=] a {{ConstraintError}}.
+    store=], [=throw=] a "{{ConstraintError}}" {{DOMException}}.
 
 9. Set |index|'s [=index/name=] to
     |name|.
@@ -3692,7 +3692,7 @@ otherwise.
 
 
 <div class=note>
-  The following methods throw {{TransactionInactiveError}} if called
+  The following methods throw an "{{TransactionInactiveError}}" {{DOMException}} if called
   when the [=/transaction=] is not [=transaction/active=].
 
   <dl class=domintro>
@@ -3773,10 +3773,10 @@ must run these steps:
     [=index-handle/index=].
 
 3. If |index| or |index|'s [=/object store=] has
-    been deleted, [=throw=] an {{InvalidStateError}}.
+    been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query| and
@@ -3819,10 +3819,10 @@ invoked, must run these steps:
     [=index-handle/index=].
 
 3. If |index| or |index|'s [=/object store=] has been deleted,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to [=convert a
     value to a key range=] with |query| and |null disallowed flag|
@@ -3854,10 +3854,10 @@ when invoked, must run these steps:
     [=index-handle/index=].
 
 3. If |index| or |index|'s [=/object store=] has
-    been deleted, [=throw=] an {{InvalidStateError}}.
+    been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3897,10 +3897,10 @@ method, when invoked, must run these steps:
     [=index-handle/index=].
 
 3. If |index| or |index|'s [=/object store=] has
-    been deleted, [=throw=] an {{InvalidStateError}}.
+    been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3940,10 +3940,10 @@ invoked, must run these steps:
     [=index-handle/index=].
 
 3. If |index| or |index|'s [=/object store=] has
-    been deleted, [=throw=] an {{InvalidStateError}}.
+    been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -3962,7 +3962,7 @@ identifying the [=object-store/records=] keys to be counted. If null or not
 given, an [=unbounded key range=] is used.
 
 <div class=note>
-  The following methods throw {{TransactionInactiveError}} if called
+  The following methods throw an "{{TransactionInactiveError}}" {{DOMException}} if called
   when the [=/transaction=] is not [=transaction/active=].
 
   <dl class=domintro>
@@ -4009,10 +4009,10 @@ method, when invoked, must run these steps:
     [=index-handle/index=].
 
 3. If |index| or |index|'s [=/object store=] has been deleted,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -4049,10 +4049,10 @@ method, when invoked, must run these steps:
     [=index-handle/index=].
 
 3. If |index| or |index|'s [=/object store=] has
-    been deleted, [=throw=] an {{InvalidStateError}}.
+    been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 5. Let |range| be the result of running the steps to
     [=convert a value to a key range=] with |query|.
@@ -4186,7 +4186,7 @@ invoked, must run these steps:
 1. Let |key| be the result of running the steps to [=convert
     a value to a key=] with |value|. Rethrow any exceptions.
 
-2. If |key| is invalid, [=throw=] a {{DataError}}.
+2. If |key| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 3. Create and return a new [=key range=] [=containing only=]
     |key|.
@@ -4201,7 +4201,7 @@ method, when invoked, must run these steps:
 1. Let |lowerKey| be the result of running the steps to [=convert a
     value to a key=] with |lower|. Rethrow any exceptions.
 
-2. If |lowerKey| is invalid, [=throw=] a {{DataError}}.
+2. If |lowerKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 3. Create and return a new [=key range=] with [=lower bound=]
     set to |lowerKey|, [=lower open flag=] set if |lowerOpen| is
@@ -4218,7 +4218,7 @@ method, when invoked, must run these steps:
 1. Let |upperKey| be the result of running the steps to [=convert a
     value to a key=] with |upper|. Rethrow any exceptions.
 
-2. If |upperKey| is invalid, [=throw=] a {{DataError}}.
+2. If |upperKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 3. Create and return a new [=key range=] with [=lower bound=]
     set to null, [=lower open flag=] set, [=upper bound=] set if
@@ -4234,15 +4234,15 @@ The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|,
 1. Let |lowerKey| be the result of running the steps to [=convert a
     value to a key=] with |lower|. Rethrow any exceptions.
 
-2. If |lowerKey| is invalid, [=throw=] a {{DataError}}.
+2. If |lowerKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 3. Let |upperKey| be the result of running the steps to [=convert a
     value to a key=] with |upper|. Rethrow any exceptions.
 
-4. If |upperKey| is invalid, [=throw=] a {{DataError}}.
+4. If |upperKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 5. If |lowerKey| is [=greater than=] |upperKey|, [=throw=] a
-    {{DataError}}.
+    "{{DataError}}" {{DOMException}}.
 
 6. Create and return a new [=key range=] with [=lower bound=]
     set to |lowerKey|, [=lower open flag=] set if |lowerOpen| is
@@ -4269,7 +4269,7 @@ invoked, must run these steps:
 1. Let |k| be the result of running the steps to [=convert a
     value to a key=] with |key|. Rethrow any exceptions.
 
-2. If |k| is invalid, [=throw=] a {{DataError}}.
+2. If |k| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 3. Return true if |k| is [=in=]
     this range, and false otherwise.
@@ -4334,12 +4334,12 @@ enum IDBCursorDirection {
     <dt><var>cursor</var> . {{IDBCursor/key}}
     <dd>
       Returns the [=cursor/key=] of the cursor.
-      Throws {{InvalidStateError}} if the cursor is advancing or is finished.
+      Throws a "{{InvalidStateError}}" {{DOMException}} if the cursor is advancing or is finished.
     </dd>
     <dt><var>cursor</var> . {{IDBCursor/primaryKey}}
     <dd>
       Returns the [=cursor/effective key=] of the cursor.
-      Throws {{InvalidStateError}} if the cursor is advancing or is finished.
+      Throws a "{{InvalidStateError}}" {{DOMException}} if the cursor is advancing or is finished.
     </dd>
   </dl>
 </div>
@@ -4381,10 +4381,10 @@ does not modify the contents of the database.
   {{IDBRequest/result}} will be the same cursor if a [=record=] was
   in range, or <code>undefined</code> otherwise.
 
-  If called while the cursor is already advancing, {{InvalidStateError}}
+  If called while the cursor is already advancing, an "{{InvalidStateError}}" {{DOMException}}
   will be thrown.
 
-  The following methods throw {{TransactionInactiveError}} if called
+  The following methods throw a "{{TransactionInactiveError}}" {{DOMException}} if called
   when the [=/transaction=] is not [=transaction/active=].
 
   <dl class=domintro>
@@ -4410,7 +4410,7 @@ does not modify the contents of the database.
         <var>primaryKey</var>)</dt>
     <dd>
       Advances the cursor to the next [=record=] in range matching
-      or after |key| and |primaryKey|. Throws {{InvalidAccessError}}
+      or after |key| and |primaryKey|. Throws an "{{InvalidAccessError}}" {{DOMException}}
       if the [=cursor/source=] is not an [=/index=].
     </dd>
   </dl>
@@ -4429,14 +4429,14 @@ invoked, must run these steps:
     [=cursor/transaction=].
 
 3. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 4. If the cursor's [=cursor/source=] or [=effective object
-    store=] has been deleted, [=throw=] an {{InvalidStateError}}.
+    store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 5. If this cursor's [=got value flag=] is unset, indicating that
     the cursor is being iterated or has iterated past its end,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 7. Unset the [=got value flag=] on the cursor.
 
@@ -4455,8 +4455,8 @@ invoked, must run these steps:
 <aside class=note>
   Calling this method more than once before new cursor data has been
   loaded - for example, calling {{advance()}} twice from the
-  same onsuccess handler - results in an {{InvalidStateError}}
-  exception being thrown on the second call because the cursor's
+  same onsuccess handler - results in an "{{InvalidStateError}}" {{DOMException}}
+  being thrown on the second call because the cursor's
   [=got value flag=] has been unset.
 </aside>
 
@@ -4470,32 +4470,32 @@ invoked, must run these steps:
     [=cursor/transaction=].
 
 2. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 3. If the cursor's [=cursor/source=] or
     [=effective object store=] has been deleted, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 4. If this cursor's [=got value flag=] is unset, indicating that
     the cursor is being iterated or has iterated past its end,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 5. If |key| is given, run these substeps:
 
     1. Let |r| be the result of running the steps to [=convert a
         value to a key=] with |key|. Rethrow any exceptions.
 
-    2. If |r| is invalid, [=throw=] a {{DataError}}.
+    2. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
     3. Let |key| be |r|.
 
     4. If |key| is [=less than=] or [=equal to=] this cursor's
         [=cursor/position=] and this cursor's [=cursor/direction=] is
-        {{"next"}} or {{"nextunique"}}, [=throw=] a {{DataError}}.
+        {{"next"}} or {{"nextunique"}}, [=throw=] a "{{DataError}}" {{DOMException}}.
 
     5. If |key| is [=greater than=] or [=equal to=] this
         cursor's [=cursor/position=] and this cursor's [=cursor/direction=] is
-        {{"prev"}} or {{"prevunique"}}, [=throw=] a {{DataError}}.
+        {{"prev"}} or {{"prevunique"}}, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 6. Unset the [=got value flag=] on the cursor.
 
@@ -4514,8 +4514,8 @@ invoked, must run these steps:
 <aside class=note>
   Calling this method more than once before new cursor data has been
   loaded - for example, calling {{continue()}} twice from the
-  same onsuccess handler - results in an {{InvalidStateError}}
-  exception being thrown on the second call because the cursor's
+  same onsuccess handler - results in an "{{InvalidStateError}}" {{DOMException}}
+  being thrown on the second call because the cursor's
   [=got value flag=] has been unset.
 </aside>
 
@@ -4529,53 +4529,53 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
     [=cursor/transaction=].
 
 2. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 3. If the cursor's [=cursor/source=] or [=effective object
-    store=] has been deleted, [=throw=] an {{InvalidStateError}}.
+    store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 4. If this cursor's [=cursor/source=] is not an
-    [=/index=] [=throw=] an {{InvalidAccessError}}.
+    [=/index=] [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 
 5. If this cursor's [=cursor/direction=] is not {{"next"}} or {{"prev"}},
-    [=throw=] an {{InvalidAccessError}}.
+    [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 
 6. If this cursor's [=got value flag=] is unset, indicating that
     the cursor is being iterated or has iterated past its end,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 7. Let |r| be the result of running the steps to [=convert a value to
     a key=] with |key|. Rethrow any exceptions.
 
-8. If |r| is invalid, [=throw=] a {{DataError}}.
+8. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 9. Let |key| be |r|.
 
 10. Let |r| be the result of running the steps to [=convert a value
      to a key=] with |primaryKey|. Rethrow any exceptions.
 
-11. If |r| is invalid, [=throw=] a {{DataError}}.
+11. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 12. Let |primaryKey| be |r|.
 
 13. If |key| is [=less than=] this cursor's
     [=cursor/position=] and this cursor's [=cursor/direction=] is {{"next"}},
-    [=throw=] a {{DataError}}.
+    [=throw=] a "{{DataError}}" {{DOMException}}.
 
 14. If |key| is [=greater than=] this cursor's
     [=cursor/position=] and this cursor's [=cursor/direction=] is {{"prev"}},
-    [=throw=] a {{DataError}}.
+    [=throw=] a "{{DataError}}" {{DOMException}}.
 
 15. If |key| is [=equal to=] this cursor's [=cursor/position=] and
     |primaryKey| is [=less than=] or [=equal to=] this cursor's
     [=object store position=] and this cursor's [=cursor/direction=] is
-    {{"next"}}, [=throw=] a {{DataError}}.
+    {{"next"}}, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 16. If |key| is [=equal to=] this cursor's [=cursor/position=] and
     |primaryKey| is [=greater than=] or [=equal to=] this
     cursor's [=object store position=] and this cursor's
     [=cursor/direction=] is {{"prev"}}, [=throw=] a
-    {{DataError}}.
+    "{{DataError}}" {{DOMException}}.
 
 17. Unset the [=got value flag=] on the cursor.
 
@@ -4601,7 +4601,7 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 <aside class=note>
   Calling this method more than once before new cursor data has been
   loaded - for example, calling {{continuePrimaryKey()}} twice from
-  the same onsuccess handler - results in an {{InvalidStateError}}
+  the same onsuccess handler - results in an "{{InvalidStateError}}" {{DOMException}}
   being thrown on the second call because the cursor's [=got value
   flag=] has been unset.
 </aside>
@@ -4609,8 +4609,8 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 
 
 <div class=note>
-  The following methods throw {{ReadOnlyError}} if called within a
-  [=read-only transaction=], and {{TransactionInactiveError}} if
+  The following methods throw a "{{ReadOnlyError}}" {{DOMException}} if called within a
+  [=read-only transaction=], and a "{{TransactionInactiveError}}" {{DOMException}} if
   called when the [=/transaction=] is not [=transaction/active=].
 
   <dl class=domintro>
@@ -4619,7 +4619,7 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
     <dd>
       Updated the [=record=] pointed at by the cursor with a new value.
 
-      Throws {{DataError}} if the [=cursor/effective object store=]
+      Throws a "{{DataError}}" {{DOMException}} if the [=cursor/effective object store=]
       uses [=in-line keys=] and the [=/key=] would have changed.
 
       If successful, |request|'s {{IDBRequest/result}} will be the
@@ -4646,20 +4646,20 @@ invoked, must run these steps:
     [=cursor/transaction=].
 
 2. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 3. If |transaction| is a [=read-only transaction=], [=throw=] a
-    {{ReadOnlyError}}.
+    "{{ReadOnlyError}}" {{DOMException}}.
 
 4. If the cursor's [=cursor/source=] or [=effective object
-    store=] has been deleted, [=throw=] an {{InvalidStateError}}.
+    store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 5. If this cursor's [=got value flag=] is unset, indicating that
     the cursor is being iterated or has iterated past its end,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 6. If this cursor's [=key only flag=] is set, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 7. Let |clone| be [=structured clone=] of |value|. Rethrow any
     exceptions.
@@ -4675,7 +4675,7 @@ invoked, must run these steps:
 
     2. If |kpk| is failure, invalid, or not [=equal to=]
         the cursor's [=effective key=], [=throw=] a
-        {{DataError}}.
+        "{{DataError}}" {{DOMException}}.
 
 9. Run [=steps for asynchronously executing a request=] and return
     the {{IDBRequest}} created by these steps. The steps are run with
@@ -4703,20 +4703,20 @@ must run these steps:
     [=cursor/transaction=].
 
 2. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 3. If |transaction| is a [=read-only transaction=], [=throw=] a
-    {{ReadOnlyError}}.
+    "{{ReadOnlyError}}" {{DOMException}}.
 
 4. If the cursor's [=cursor/source=] or [=effective object
-    store=] has been deleted, [=throw=] an {{InvalidStateError}}.
+    store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 5. If this cursor's [=got value flag=] is unset, indicating that
     the cursor is being iterated or has iterated past its end,
-    [=throw=] an {{InvalidStateError}}.
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 6. If this cursor's [=key only flag=] is set, [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 7. Run the [=steps for asynchronously executing a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
@@ -4862,10 +4862,10 @@ none.
   [=request=], this will be the same as the [=request=]'s
   [=request/error=]. If this [=/transaction=] was aborted
   due to an uncaught exception in an event handler, the error will be
-  {{AbortError}}. If the [=/transaction=] was aborted due to
+  a "{{AbortError}}" {{DOMException}}. If the [=/transaction=] was aborted due to
   an error while committing, it will reflect the reason for the
-  failure (e.g. {{QuotaExceededError}}, {{ConstraintError}}, or
-  {{UnknownError}}).
+  failure (e.g. "{{QuotaExceededError}}", "{{ConstraintError}}", or
+  "{{UnknownError}}" {{DOMException}}).
 </aside>
 
 <div class=note>
@@ -4878,7 +4878,7 @@ none.
     <dt><var>transaction</var> . {{IDBTransaction/abort()}}</dt>
     <dd>
       Aborts the transaction. All pending [=requests=] will fail with
-      {{AbortError}} and all changes made to the database will be
+      a "{{AbortError}}" {{DOMException}} and all changes made to the database will be
       reverted.
     </dd>
   </dl>
@@ -4890,12 +4890,12 @@ when invoked, must run these steps:
 <div class=algorithm>
 
 1. If |transaction| has [=transaction/finished=], [=throw=] an
-    {{InvalidStateError}}.
+    "{{InvalidStateError}}" {{DOMException}}.
 
 2. Let |store| be the [=/object store=]
     [=object-store/named=] |name| in this
     [=/transaction=]'s [=transaction/scope=], or [=throw=] a
-    {{NotFoundError}} if none.
+    "{{NotFoundError}}" {{DOMException}} if none.
 
 3. Return an [=/object store handle=] associated with |store|
     and this [=/transaction=].
@@ -4921,7 +4921,7 @@ must run these steps:
 <div class=algorithm>
 
 1. If this [=/transaction=] is [=transaction/finished=], [=throw=]
-    an {{InvalidStateError}}.
+    an "{{InvalidStateError}}" {{DOMException}}.
 
 2. Unset the [=/transaction=]'s [=transaction/active flag=] and run the
     [=steps for aborting a transaction=] with null as |error|.
@@ -5043,11 +5043,11 @@ database |name|, a database |version|, and a |request|.
 6. If |db| is null, let |db| be a new [=database=] with
     [=database/name=] |name|, [=database/version=] 0 (zero), and with
     no [=/object stores=]. If this fails for any reason, return an
-    appropriate error (e.g. {{QuotaExceededError}} or
-    {{UnknownError}}).
+    appropriate error (e.g. a "{{QuotaExceededError}}" or
+    "{{UnknownError}}" {{DOMException}}).
 
 7. If |db|'s [=database/version=] is greater than |version|,
-    abort these steps and return a new {{VersionError}}.
+    abort these steps and return a new "{{VersionError}}" {{DOMException}}.
 
 8. Let |connection| be a new [=/connection=] to |db|.
 
@@ -5087,12 +5087,12 @@ database |name|, a database |version|, and a |request|.
 
     7. If |connection| was [=connection/closed=], create and
         return a newly <a lt="create exception">created</a>
-        {{AbortError}} and abort these steps.
+        "{{AbortError}}" {{DOMException}} and abort these steps.
 
     8. If the [=upgrade transaction=] was aborted, run the [=steps
         for closing a database connection=] with |connection|,
         create and return a newly <a lt="create exception">created</a>
-        {{AbortError}} and abort these steps.
+        "{{AbortError}}" {{DOMException}} and abort these steps.
 
 11. Return |connection|.
 
@@ -5113,7 +5113,7 @@ optional |forced flag|.
 2. If the |forced flag| is set, then for each |transaction|
     [=transaction/created=] using |connection| run the [=steps for aborting a
     transaction=] with |transaction| and newly <a lt="create
-    exception">created</a> {{AbortError}}.
+    exception">created</a> "{{AbortError}}" {{DOMException}}.
 
 3. Wait for all transactions [=transaction/created=] using |connection| to complete.
     Once they are complete, |connection| is [=connection/closed=].
@@ -5197,7 +5197,7 @@ requested the [=database=] to be deleted, a database |name|, and a
 10. Let |version| be |db|'s [=database/version=].
 
 11. Delete |db|. If this fails for any reason, return an appropriate
-    error (e.g. {{QuotaExceededError}} or {{UnknownError}}).
+    error (e.g. "{{QuotaExceededError}}" or "{{UnknownError}}" {{DOMException}}).
 
 12. Return |version|.
 
@@ -5220,8 +5220,8 @@ takes one argument, the |transaction| to commit.
 2. If an error occurs while writing the changes to the
     [=database=], abort the transaction by following the [=steps
     for aborting a transaction=] with |transaction| and an
-    appropriate for the error, for example {{QuotaExceededError}} or
-    {{UnknownError}}.
+    appropriate for the error, for example "{{QuotaExceededError}}" or
+    "{{UnknownError}}" {{DOMException}}.
 
 3. [=Queue a task=] to dispatch an event at |transaction|. The
     event must use the [=Event=] interface and have its
@@ -5272,7 +5272,7 @@ takes two arguments: the |transaction| to abort, and |error|.
     1. Set the [=request/done flag=] on |request|.
     2. Set the [=request/result=] of |request| to undefined.
     3. Set the [=request/error=] of |request| to a newly
-        <a lt="create exception">created</a> {{AbortError}}.
+        <a lt="create exception">created</a> "{{AbortError}}" {{DOMException}}.
     4. Dispatch an event at |request|. The event must use the
         [=Event=] interface and have its {{Event/type}} set to
         "<code>error</code>". The event bubbles and is cancelable.
@@ -5311,7 +5311,7 @@ aborting a transaction=].
     |source|.
 
 2. If |transaction| is not [=transaction/active=], [=throw=] a
-    {{TransactionInactiveError}}.
+    "{{TransactionInactiveError}}" {{DOMException}}.
 
 3. If |request| was not given, let |request| be a new |request| with
     [=request/source=] as |source|.
@@ -5399,7 +5399,7 @@ for the [=database=], and a |request|.
         dispatching the event in the previous step, abort the
         transaction by following the [=steps for aborting a
         transaction=] with the |error| property set to a newly
-        <a lt="create exception">created</a> {{AbortError}}.
+        <a lt="create exception">created</a> "{{AbortError}}" {{DOMException}}.
 
 8. Wait for |transaction| to [=transaction/finish=].
 
@@ -5529,7 +5529,7 @@ the implementation must run the following steps:
     dispatching the event in step 3, abort the transaction by
     following the [=steps for aborting a transaction=] with
     |transaction| and a newly <a lt="create exception">created</a>
-    {{AbortError}}.
+    "{{AbortError}}" {{DOMException}}.
 
 </div>
 
@@ -5558,7 +5558,7 @@ the implementation must run the following steps:
     dispatching the event in step 3, abort the transaction by
     following the [=steps for aborting a transaction=] with
     |transaction| and a newly <a lt="create exception">created</a>
-    {{AbortError}} and terminate these steps. This is done even if the
+    "{{AbortError}}" {{DOMException}} and terminate these steps. This is done even if the
     event's [=canceled flag=] is not set.
 
     <aside class=note>
@@ -5611,7 +5611,7 @@ follows.
 
         1. If the [=key generator=]'s [=current number=] is
             greater than 2<sup>53</sup> (9007199254740992), then this
-            operation failed with a {{ConstraintError}}. Abort this
+            operation failed with a "{{ConstraintError}}" {{DOMException}}. Abort this
             algorithm without taking any further steps.
 
         2. Set |key| to the [=key generator=]'s [=current number=].
@@ -5630,7 +5630,7 @@ follows.
 
 3. If the |no-overwrite flag| was given to these steps and is set, and
     a [=object-store/record=] already exists in |store| with its key [=equal to=]
-    |key|, then this operation failed with a {{ConstraintError}}.
+    |key|, then this operation failed with a "{{ConstraintError}}" {{DOMException}}.
     Abort this algorithm without taking any further steps.
 
 4. If a [=object-store/record=] already exists in |store| with its key [=equal
@@ -5661,7 +5661,7 @@ follows.
         is not an [=array key=], and if |index| already contains a
         [=object-store/record=] with [=/key=] [=equal to=] |index
         key|, and |index| has its [=unique flag=] set, then this
-        operation failed with a {{ConstraintError}}. Abort this
+        operation failed with a "{{ConstraintError}}" {{DOMException}}. Abort this
         algorithm without taking any further steps.
 
     4. If |index|'s [=multiEntry flag=] is set and |index key| is
@@ -5669,7 +5669,7 @@ follows.
         [=object-store/record=] with [=/key=] [=equal to=] any of the
         [=subkeys=] of |index key|, and |index| has its [=unique
         flag=] set, then this operation failed with a
-        {{ConstraintError}}. Abort this algorithm without taking any
+        "{{ConstraintError}}" {{DOMException}}. Abort this algorithm without taking any
         further steps.
 
     5. If |index|'s [=multiEntry flag=] is unset, or if |index key|
@@ -6275,7 +6275,7 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
 
     1. If |value| is not an [=Object=] object or an [=Array=]
         object (see [=structured clone algorithm=] [[!HTML]]), then
-        [=throw=] a {{DataError}}.
+        [=throw=] a "{{DataError}}" {{DOMException}}.
 
     2. Let |hop| be [=!=] [=HasOwnProperty=](|value|, |identifier|).
 

--- a/index.html
+++ b/index.html
@@ -2254,7 +2254,7 @@ track of the <a data-link-type="dfn" href="#request" id="ref-for-request-4">requ
 against a transaction only while that transaction is <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-1">active</a>.
 If an attempt is made to place a request against a transaction
 when that transaction is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-2">active</a>, the implementation must
-reject the attempt by throwing a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+reject the attempt by throwing a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Once an implementation is able to enforce the constraints defined
 for the transaction <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-4">scope</a> and <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-6">mode</a>, defined below, the
@@ -2284,7 +2284,7 @@ transaction, or due to running into a quota limit where the
 implementation can’t tie exceeding the quota to a partcular
 request. In this case the implementation must run the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-1">steps for
 aborting a transaction</a> using the transaction as <var>transaction</var> and the appropriate error type as <var>error</var>. For example if quota
-was exceeded then <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code> should be used as <var>error</var>, and if an IO error happened, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code> should be
+was exceeded then a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> should be used as <var>error</var>, and if an IO error happened, an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> should be
 used as <var>error</var>.</p>
      <li data-md="">
       <p>When a transaction has been started and it can no longer become <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-4">active</a>, the implementation must attempt to <dfn class="dfn-paneled" data-dfn-for="transaction" data-dfn-type="dfn" data-lt="commit|committing|committed" data-noexport="" id="transaction-commit">commit</dfn> it, as long as the
@@ -2469,12 +2469,13 @@ follows:</p>
      <li data-md="">
       <p>If <var>value</var> is a <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-18">key range</a>, return <var>value</var>.</p>
      <li data-md="">
-      <p>If <var>value</var> is undefined or is null, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code> if <var>null disallowed flag</var> is set, or return an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-2">unbounded key range</a> otherwise.</p>
+      <p>If <var>value</var> is undefined or is null, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if <var>null disallowed flag</var> is set, or return an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-2">unbounded key range</a> otherwise.</p>
      <li data-md="">
       <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-2">convert
 a value to a key</a> with <var>value</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>key</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>key</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Return a <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-19">key range</a> <a data-link-type="dfn" href="#containing-only" id="ref-for-containing-only-1">containing only</a> <var>key</var>.</p>
     </ol>
@@ -2593,7 +2594,8 @@ before the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-trans
     <li data-md="">
      <p>When the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-16">current number</a> of a key generator reaches above the
 value 2<sup>53</sup> (9007199254740992) any attempts to use the
-key generator to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-41">key</a> will result in a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>. It is still possible to insert <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-22">records</a> into the object store by specifying an explicit
+key generator to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-41">key</a> will result in a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. It is still possible to insert <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-22">records</a> into the object store by specifying an explicit
 key, however the only way to use a key generator again for the
 object store is to delete the object store and create a new one.</p>
      <aside class="note"> As long as key generators are used in a normal fashion this will
@@ -2877,9 +2879,11 @@ request<span class="p">.</span>onerror <span class="o">=</span> <span class="kd"
     <dl class="domintro">
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-2">result</a></code>
      <dd> When a request is completed, returns the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-3">result</a>,
-        or <code>undefined</code> if the request failed. Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if the request is still pending. 
+        or <code>undefined</code> if the request failed. Throws a
+        "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the request is still pending. 
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-error" id="ref-for-dom-idbrequest-error-2">error</a></code>
-     <dd> When a request is completed, returns the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-2">error</a> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>), or null if the request succeeded. Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if the request is still pending. 
+     <dd> When a request is completed, returns the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-2">error</a> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>), or null if the request succeeded. Throws
+        a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the request is still pending. 
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-source" id="ref-for-dom-idbrequest-source-2">source</a></code>
      <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-2">IDBObjectStore</a></code>, <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-2">IDBIndex</a></code>, or <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-2">IDBCursor</a></code> the request was made against, or null if is was an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-10">open
         request</a>. 
@@ -2891,10 +2895,10 @@ request<span class="p">.</span>onerror <span class="o">=</span> <span class="kd"
         then returns <code class="idl"><a data-link-type="idl" href="#dom-idbrequestreadystate-done" id="ref-for-dom-idbrequestreadystate-done-1">"done"</a></code>. 
     </dl>
    </div>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-result">result</dfn> attribute’s getter must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-6">done flag</a> is
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-result">result</dfn> attribute’s getter must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-6">done flag</a> is
 unset. Otherwise, the attribute’s getter must return the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-4">result</a> of the request, or undefined if the
 request resulted in an error.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-error">error</dfn> attribute’s getter must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-7">done flag</a> is unset.
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-error">error</dfn> attribute’s getter must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-7">done flag</a> is unset.
 Otherwise, the attribute’s getter must return the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-3">error</a> of
 the request, or null if no error occurred.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-source">source</dfn> attribute’s getter must
@@ -3067,7 +3071,7 @@ null.</p>
      <dd>
        Compares two values as <a data-link-type="dfn" href="#key" id="ref-for-key-46">keys</a>. Returns -1 if <var>key1</var> precedes <var>key2</var>, 1 if <var>key2</var> precedes <var>key1</var>, and 0 if
         the keys are equal. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code> if either input is not a valid <a data-link-type="dfn" href="#key" id="ref-for-key-47">key</a>.</p>
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if either input is not a valid <a data-link-type="dfn" href="#key" id="ref-for-key-47">key</a>.</p>
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBFactory" data-dfn-type="method" data-export="" id="dom-idbfactory-cmp">cmp(<var>first</var>, <var>second</var>)</dfn> method,
@@ -3078,12 +3082,12 @@ when invoked, must run these steps:</p>
       <p>Let <var>a</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-3">convert a
 value to a key</a> with <var>first</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>a</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>a</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>b</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-4">convert a
 value to a key</a> with <var>second</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>b</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>b</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Return the results of running the steps to <a data-link-type="dfn" href="#compare-two-keys" id="ref-for-compare-two-keys-5">compare two keys</a> with <var>a</var> and <var>b</var>.</p>
     </ol>
@@ -3144,11 +3148,11 @@ must return this <a data-link-type="dfn" href="#connection" id="ref-for-connecti
      <dt><var>store</var> = <var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-2">createObjectStore</a></code>(<var>name</var> [, <var>options</var>])
      <dd>
        Creates a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-52">object store</a> in with the given <var>name</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-4">IDBObjectStore</a></code>. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-18">upgrade transaction</a>.</p>
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-18">upgrade transaction</a>.</p>
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-deleteobjectstore" id="ref-for-dom-idbdatabase-deleteobjectstore-2">deleteObjectStore</a></code>(<var>name</var>)
      <dd>
        Deletes the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-53">object store</a> with the given <var>name</var>. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-19">upgrade transaction</a>.</p>
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-19">upgrade transaction</a>.</p>
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-objectstorenames">objectStoreNames</dfn> attribute’s
@@ -3165,23 +3169,25 @@ the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-54">ob
       <p>Let <var>database</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-40">database</a> associated with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-39">connection</a>.</p>
      <li data-md="">
       <p>Let <var>transaction</var> be the currently running <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-21">upgrade
-transaction</a> associated with <var>database</var>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if none.</p>
+transaction</a> associated with <var>database</var>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-6">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-6">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>keyPath</var> be <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstoreparameters-keypath" id="ref-for-dom-idbobjectstoreparameters-keypath-1">keyPath</a></code> member if it is not undefined or null, or null otherwise.</p>
      <li data-md="">
       <p>If <var>keyPath</var> is not null and is not a <a data-link-type="dfn" href="#valid-key-path" id="ref-for-valid-key-path-1">valid key
-path</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>.</p>
+path</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-56">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-4">named</a> <var>name</var> already
-exists in <var>database</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>.</p>
+exists in <var>database</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>autoIncrement</var> be set if <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstoreparameters-autoincrement" id="ref-for-dom-idbobjectstoreparameters-autoincrement-1">autoIncrement</a></code> member is true, or
 unset otherwise.</p>
      <li data-md="">
       <p>If <var>autoIncrement</var> is set and <var>keyPath</var> is an empty string or any
-sequence (empty or otherwise), <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>.</p>
+sequence (empty or otherwise), <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>store</var> be a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-57">object store</a> in <var>database</var>. Set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-58">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-5">name</a> to <var>name</var>. If <var>autoIncrement</var> is set, then the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-59">object
 store</a> uses a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-12">key generator</a>. If <var>keyPath</var> is
@@ -3202,7 +3208,7 @@ implementation might need to ask the user for permission for quota
 reasons. Such implementations must still create and return an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-5">IDBObjectStore</a></code> object, and once the implementation determines that
 creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-64">object store</a> has failed, it must abort the
 transaction using the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-3">steps for aborting a transaction</a> using the
-appropriate error. For example if creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-65">object store</a> failed due to quota reasons, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code> must be used as
+appropriate error. For example if creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-65">object store</a> failed due to quota reasons, a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as
 error.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="method" data-export="" id="dom-idbdatabase-deleteobjectstore">deleteObjectStore(<var>name</var>)</dfn> method, when invoked, must run these steps:</p>
    <div class="algorithm">
@@ -3211,12 +3217,13 @@ error.</p>
       <p>Let <var>database</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-42">database</a> associated with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-41">connection</a>.</p>
      <li data-md="">
       <p>Let <var>transaction</var> be the currently running <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-23">upgrade
-transaction</a> associated with <var>database</var>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if none.</p>
+transaction</a> associated with <var>database</var>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-7">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-7">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-66">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-6">named</a> <var>name</var> in <var>database</var>,
-or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> if none.</p>
+or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
       <p>Remove <var>store</var> from this <a data-link-type="dfn" href="#connection" id="ref-for-connection-42">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-2">object
 store set</a>.</p>
@@ -3244,17 +3251,20 @@ from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-u
      <li data-md="">
       <p>If <var>mode</var> parameter is not <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-4">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-5">"readwrite"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>.</p>
      <li data-md="">
-      <p>If this method is called on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-9">IDBDatabase</a></code> object for which an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-25">upgrade transaction</a> is still running, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If this method is called on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-9">IDBDatabase</a></code> object for which an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-25">upgrade transaction</a> is still running, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If this method is called on an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-10">IDBDatabase</a></code> instance where the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-4">close pending flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If this method is called on an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-10">IDBDatabase</a></code> instance where the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-4">close pending flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>scope</var> be the set of unique strings in <var>storeNames</var> if it is a
 sequence, or a set containing one string equal to <var>storeNames</var> otherwise.</p>
      <li data-md="">
       <p>If any string in <var>scope</var> is not the name of an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-69">object
-store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-45">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-44">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>.</p>
+store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-45">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-44">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>scope</var> is empty, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>.</p>
+      <p>If <var>scope</var> is empty, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>transaction</var> be a newly <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-3">created</a> <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-32">transaction</a> with <var>connection</var>, <var>mode</var> and the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-70">object stores</a> named in <var>scope</var>.</p>
      <li data-md="">
@@ -3332,7 +3342,7 @@ the event handler for the <code>versionchange</code> event.</p>
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-3">name</a></code> = <var>newName</var>
      <dd>
        Updates the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-10">name</a> of the store to <var>newName</var>. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-26">upgrade
+      <p>Throws "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-26">upgrade
         transaction</a>.</p>
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-keypath" id="ref-for-dom-idbobjectstore-keypath-2">keyPath</a></code>
      <dd> Returns the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-12">key path</a> of the store, or null if none. 
@@ -3359,16 +3369,17 @@ must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-13">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-3">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-28">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-28">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-8">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-8">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>store</var>’s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-13">name</a> is equal to <var>name</var>,
 terminate these steps.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-72">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-14">named</a> <var>name</var> already exists in <var>store</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-45">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>.</p>
+      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-72">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-14">named</a> <var>name</var> already exists in <var>store</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-45">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Set <var>store</var>’s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-15">name</a> to <var>name</var>.</p>
      <li data-md="">
@@ -3401,16 +3412,16 @@ getter must return this <a data-link-type="dfn" href="#object-store-handle" id="
 getter must return true if this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-18">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-5">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-14">key generator</a>,
 and false otherwise.</p>
    <div class="note" role="note">
-     The following methods throw <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code> if called within a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-9">read-only transaction</a>, and <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code> if
+     The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called within a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-9">read-only transaction</a>, and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if
   called when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-38">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-9">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-put" id="ref-for-dom-idbobjectstore-put-2">put</a></code>(<var>value</var> [, <var>key</var>]) 
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-add" id="ref-for-dom-idbobjectstore-add-2">add</a></code>(<var>value</var> [, <var>key</var>]) 
      <dd>
        Adds or updates a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-24">record</a> in <var>store</var> with the given <var>value</var> and <var>key</var>. If the store uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-2">in-line keys</a>, then <var>key</var> must
-       not be specified, or a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code> will be thrown. 
+       not be specified, or a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> will be thrown. 
       <p>If <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-put" id="ref-for-dom-idbobjectstore-put-3">put()</a></code> is used, any existing <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-25">record</a> with the <a data-link-type="dfn" href="#key" id="ref-for-key-48">key</a> will be replaced. If <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-add" id="ref-for-dom-idbobjectstore-add-3">add()</a></code> is used, and if a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-26">record</a> with the <a data-link-type="dfn" href="#key" id="ref-for-key-49">key</a> already exists
-       the <var>request</var> will fail, with <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-error" id="ref-for-dom-idbrequest-error-3">error</a></code> set to <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>.</p>
+       the <var>request</var> will fail, with <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-error" id="ref-for-dom-idbrequest-error-3">error</a></code> set to a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-6">result</a></code> will be the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-27">record</a>'s <a data-link-type="dfn" href="#key" id="ref-for-key-50">key</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-delete" id="ref-for-dom-idbobjectstore-delete-2">delete</a></code>(<var>query</var>) 
      <dd>
@@ -3433,16 +3444,17 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-20">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-6">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-10">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-10">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-10">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>.</p>
+      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-10">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-3">in-line keys</a> and <var>key</var> was given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-3">in-line keys</a> and <var>key</var> was given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-2">out-of-line keys</a> and has no <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-15">key
-generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>key</var> was given, run these substeps:</p>
       <ol>
@@ -3450,7 +3462,7 @@ generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="ht
         <p>Let <var>r</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-5">convert a
 value to a key</a> with <var>key</var>. Rethrow any exceptions.</p>
        <li data-md="">
-        <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>Let <var>key</var> be <var>r</var>.</p>
       </ol>
@@ -3465,12 +3477,12 @@ Rethrow any exceptions.</p>
 key from a value using a key path</a> with <var>clone</var> and <var>store</var>’s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-14">key path</a>. Rethrow any
 exceptions.</p>
        <li data-md="">
-        <p>If <var>kpk</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>kpk</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>If <var>kpk</var> is not failure, let <var>key</var> be <var>kpk</var>.</p>
        <li data-md="">
         <p>Otherwise, if <var>store</var> does not have a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-16">key
-generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-2">steps for asynchronously executing a request</a> and
@@ -3488,16 +3500,19 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-23">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-7">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-11">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-11">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-11">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>.</p>
+      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-11">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-5">in-line keys</a> and <var>key</var> was given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-5">in-line keys</a> and <var>key</var> was given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-3">out-of-line keys</a> and has no <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-17">key
-generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>key</var> was given, run these substeps:</p>
       <ol>
@@ -3505,7 +3520,7 @@ generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="ht
         <p>Let <var>r</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-6">convert a
 value to a key</a> with <var>key</var>. Rethrow any exceptions.</p>
        <li data-md="">
-        <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>Let <var>key</var> be <var>r</var>.</p>
       </ol>
@@ -3520,12 +3535,12 @@ exceptions.</p>
 key from a value using a key path</a> with <var>clone</var> and <var>store</var>’s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-15">key path</a>. Rethrow any
 exceptions.</p>
        <li data-md="">
-        <p>If <var>kpk</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>kpk</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>If <var>kpk</var> is not failure, let <var>key</var> be <var>kpk</var>.</p>
        <li data-md="">
         <p>Otherwise, if <var>store</var> does not have a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-18">key
-generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-3">steps for asynchronously executing a request</a> and
@@ -3543,11 +3558,13 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-26">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-8">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-12">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-12">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-12">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>.</p>
+      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-12">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-1">convert a value to a key range</a> with <var>query</var> and <var>null disallowed flag</var> set. Rethrow any exceptions.</p>
      <li data-md="">
@@ -3570,11 +3587,13 @@ must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-29">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-9">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-13">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-13">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-13">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>.</p>
+      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-13">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-5">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-21">IDBRequest</a></code> created by these steps. The steps are
@@ -3582,7 +3601,7 @@ run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-ob
 the <a data-link-type="dfn" href="#steps-for-clearing-an-object-store" id="ref-for-steps-for-clearing-an-object-store-1">steps for clearing an object store</a> as <var>operation</var>, using <var>store</var>.</p>
     </ol>
     <div class="note" role="note">
-      The following methods throw <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code> if called
+      The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
   when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-39">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-14">active</a>. 
      <dl class="domintro">
       <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-get" id="ref-for-dom-idbobjectstore-get-2">get</a></code>(<var>query</var>) 
@@ -3622,9 +3641,11 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-32">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-10">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-15">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-15">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-2">convert a value to a key range</a> with <var>query</var> and <var>null disallowed flag</var> set. Rethrow any exceptions.</p>
      <li data-md="">
@@ -3651,9 +3672,11 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-35">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-11">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-16">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-16">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-3">convert a value to a key range</a> with <var>query</var> and <var>null disallowed flag</var> set. Rethrow any exceptions.</p>
      <li data-md="">
@@ -3679,9 +3702,11 @@ the first existing key in that range.</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-38">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-12">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-17">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-17">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-4">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -3706,9 +3731,11 @@ there are more than <var>count</var> records in range, only the first <var>count
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-41">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-13">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-18">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-18">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-5">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -3734,9 +3761,11 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-44">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-14">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-19">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-19">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-6">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -3749,7 +3778,7 @@ run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-ob
    <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-66">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-6">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-37">records</a> keys to be counted. If null or not
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-5">unbounded key range</a> is used.</p>
    <div class="note" role="note">
-     The following methods throw <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code> if called
+     The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
   when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-40">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-20">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-opencursor" id="ref-for-dom-idbobjectstore-opencursor-3">openCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
@@ -3772,9 +3801,11 @@ given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unboun
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-47">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-15">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-21">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-21">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-7">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -3797,9 +3828,11 @@ If null or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id=
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-50">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-16">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-22">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-22">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-8">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -3828,13 +3861,14 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
      <dd>
        Creates a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-22">index</a> in <var>store</var> with the given <var>name</var>, <var>keyPath</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-6">IDBIndex</a></code>. If the <var>keyPath</var> and <var>options</var> define constraints that cannot be
       satisfied with the data already in <var>store</var> the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-30">upgrade
-      transaction</a> will <a data-link-type="dfn" href="#transaction-abort" id="ref-for-transaction-abort-6">abort</a> with <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-31">upgrade
+      transaction</a> will <a data-link-type="dfn" href="#transaction-abort" id="ref-for-transaction-abort-6">abort</a> with
+      a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. 
+      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-31">upgrade
       transaction</a>.</p>
      <dt> <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-deleteindex" id="ref-for-dom-idbobjectstore-deleteindex-2">deleteIndex</a></code>(<var>name</var>) 
      <dd>
        Deletes the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-23">index</a> in <var>store</var> with the given <var>name</var>. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-32">upgrade
+      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-32">upgrade
       transaction</a>.</p>
     </dl>
    </div>
@@ -3846,22 +3880,25 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-53">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-17">object store</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-33">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-33">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-23">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-23">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-24">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-4">named</a> <var>name</var> already exists in <var>store</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>.</p>
+      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-24">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-4">named</a> <var>name</var> already exists in <var>store</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>keyPath</var> is not a <a data-link-type="dfn" href="#valid-key-path" id="ref-for-valid-key-path-2">valid key path</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>.</p>
+      <p>If <var>keyPath</var> is not a <a data-link-type="dfn" href="#valid-key-path" id="ref-for-valid-key-path-2">valid key path</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>unique</var> be set if <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbindexparameters-unique" id="ref-for-dom-idbindexparameters-unique-1">unique</a></code> member is true, and unset otherwise.</p>
      <li data-md="">
       <p>Let <var>multiEntry</var> be set if <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbindexparameters-multientry" id="ref-for-dom-idbindexparameters-multientry-1">multiEntry</a></code> member is true, and unset otherwise.</p>
      <li data-md="">
       <p>If <var>keyPath</var> is a sequence and <var>multiEntry</var> is
-set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>.</p>
+set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>index</var> be a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-25">index</a> in <var>store</var>.
 Set <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-5">name</a> to <var>name</var> and <a data-link-type="dfn" href="#index-key-path" id="ref-for-index-key-path-4">key path</a> to <var>keyPath</var>. If <var>unique</var> is set, set <var>index</var>’s <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-3">unique flag</a>. If <var>multiEntry</var> is
@@ -3899,8 +3936,9 @@ implementations must still create and return an <code class="idl"><a data-link-t
 and once the implementation determines that creating the index has
 failed, it must abort the transaction using the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-4">steps for aborting
 a transaction</a> using an appropriate error as <var>error</var>. For example
-if creating the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-27">index</a> failed due to quota reasons, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code> must be used as error and if the index can’t be
-created due to <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-4">unique flag</a> constraints, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code> must be used as error.</p>
+if creating the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-27">index</a> failed due to quota reasons,
+a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as error and if the index can’t be
+created due to <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-4">unique flag</a> constraints, a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as error.</p>
    <aside class="example" id="example-8e79a9fe">
     <a class="self-link" href="#example-8e79a9fe"></a> 
     <p>The asynchronous creation of indexes is observable in the following example:</p>
@@ -3923,12 +3961,14 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-57">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-18">object store</a>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-9">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-9">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-28">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-6">named</a> <var>name</var> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-58">object
-store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-4">index set</a> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> otherwise.</p>
+store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-4">index set</a> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> otherwise.</p>
      <li data-md="">
       <p>Return an <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-7">index handle</a> associated with <var>index</var> and
 this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-59">object store handle</a>.</p>
@@ -3948,13 +3988,15 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-61">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-19">object store</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-37">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-37">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-24">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-24">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-29">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-7">named</a> <var>name</var> in <var>store</var> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> otherwise.</p>
+      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-29">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-7">named</a> <var>name</var> in <var>store</var> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> otherwise.</p>
      <li data-md="">
       <p>Remove <var>index</var> from this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-62">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-5">index set</a>.</p>
      <li data-md="">
@@ -3998,7 +4040,7 @@ within the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgra
      <dt><var>index</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-name" id="ref-for-dom-idbindex-name-3">name</a></code> = <var>newName</var>
      <dd>
        Updates the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-9">name</a> of the store to <var>newName</var>. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-40">upgrade
+      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-40">upgrade
       transaction</a>.</p>
      <dt><var>index</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-objectstore" id="ref-for-dom-idbindex-objectstore-2">objectStore</a></code>
      <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-15">IDBObjectStore</a></code> the index belongs to. 
@@ -4025,17 +4067,18 @@ return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handl
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-11">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-2">index</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-42">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-42">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-25">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-25">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-78">object store</a> has
-been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-12">name</a> is equal to <var>name</var>, terminate these steps.</p>
      <li data-md="">
       <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-32">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-13">named</a> <var>name</var> already exists in <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-79">object
-store</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>.</p>
+store</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Set <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-14">name</a> to <var>name</var>.</p>
      <li data-md="">
@@ -4065,7 +4108,7 @@ otherwise.</p>
 return true if this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-16">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-5">index</a>'s <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-7">unique flag</a> is set, and false
 otherwise.</p>
    <div class="note" role="note">
-     The following methods throw <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code> if called
+     The following methods throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
   when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-44">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-26">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-get" id="ref-for-dom-idbindex-get-2">get</a></code>(<var>query</var>) 
@@ -4103,9 +4146,10 @@ must run these steps:</p>
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-18">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-6">index</a>.</p>
      <li data-md="">
       <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-80">object store</a> has
-been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-27">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-27">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-9">convert a value to a key range</a> with <var>query</var> and <var>null disallowed flag</var> set. Rethrow any exceptions.</p>
      <li data-md="">
@@ -4132,9 +4176,10 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-21">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-7">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-81">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-81">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-28">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-28">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-10">convert a
 value to a key range</a> with <var>query</var> and <var>null disallowed flag</var> set. Rethrow any exceptions.</p>
@@ -4158,9 +4203,10 @@ when invoked, must run these steps:</p>
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-24">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-8">index</a>.</p>
      <li data-md="">
       <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-82">object store</a> has
-been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-29">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-29">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-11">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -4187,9 +4233,10 @@ there are more than <var>count</var> records in range, only the first <var>count
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-27">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-9">index</a>.</p>
      <li data-md="">
       <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-83">object store</a> has
-been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-30">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-30">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-12">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -4217,9 +4264,10 @@ invoked, must run these steps:</p>
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-30">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-10">index</a>.</p>
      <li data-md="">
       <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-84">object store</a> has
-been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-31">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-31">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-13">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -4233,7 +4281,7 @@ count the records in a range</a> as <var>operation</var>, with <a data-link-type
    <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-82">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-13">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-48">records</a> keys to be counted. If null or not
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-10">unbounded key range</a> is used.</p>
    <div class="note" role="note">
-     The following methods throw <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code> if called
+     The following methods throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
   when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-45">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-32">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-opencursor" id="ref-for-dom-idbindex-opencursor-3">openCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
@@ -4255,9 +4303,10 @@ given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unboun
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-33">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-11">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-85">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-85">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-33">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-33">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-14">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -4282,9 +4331,10 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-36">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-12">index</a>.</p>
      <li data-md="">
       <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-86">object store</a> has
-been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-34">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-34">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>range</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key-range" id="ref-for-convert-a-value-to-a-key-range-15">convert a value to a key range</a> with <var>query</var>.
 Rethrow any exceptions.</p>
@@ -4370,7 +4420,7 @@ invoked, must run these steps:</p>
       <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-7">convert
 a value to a key</a> with <var>value</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>key</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>key</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Create and return a new <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-32">key range</a> <a data-link-type="dfn" href="#containing-only" id="ref-for-containing-only-2">containing only</a> <var>key</var>.</p>
     </ol>
@@ -4382,7 +4432,7 @@ a value to a key</a> with <var>value</var>. Rethrow any exceptions.</p>
       <p>Let <var>lowerKey</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-8">convert a
 value to a key</a> with <var>lower</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>lowerKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>lowerKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Create and return a new <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-33">key range</a> with <a data-link-type="dfn" href="#lower-bound" id="ref-for-lower-bound-10">lower bound</a> set to <var>lowerKey</var>, <a data-link-type="dfn" href="#lower-open-flag" id="ref-for-lower-open-flag-6">lower open flag</a> set if <var>lowerOpen</var> is
 true, <a data-link-type="dfn" href="#upper-bound" id="ref-for-upper-bound-10">upper bound</a> set to null and <a data-link-type="dfn" href="#upper-open-flag" id="ref-for-upper-open-flag-6">upper open flag</a> set.</p>
@@ -4395,7 +4445,7 @@ true, <a data-link-type="dfn" href="#upper-bound" id="ref-for-upper-bound-10">up
       <p>Let <var>upperKey</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-9">convert a
 value to a key</a> with <var>upper</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>upperKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>upperKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Create and return a new <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-34">key range</a> with <a data-link-type="dfn" href="#lower-bound" id="ref-for-lower-bound-11">lower bound</a> set to null, <a data-link-type="dfn" href="#lower-open-flag" id="ref-for-lower-open-flag-7">lower open flag</a> set, <a data-link-type="dfn" href="#upper-bound" id="ref-for-upper-bound-11">upper bound</a> set if <var>upperKey</var>, and <a data-link-type="dfn" href="#upper-open-flag" id="ref-for-upper-open-flag-7">upper open flag</a> set to <var>upperOpen</var>.</p>
     </ol>
@@ -4407,14 +4457,15 @@ value to a key</a> with <var>upper</var>. Rethrow any exceptions.</p>
       <p>Let <var>lowerKey</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-10">convert a
 value to a key</a> with <var>lower</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>lowerKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>lowerKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>upperKey</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-11">convert a
 value to a key</a> with <var>upper</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>upperKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>upperKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>lowerKey</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-5">greater than</a> <var>upperKey</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>lowerKey</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-5">greater than</a> <var>upperKey</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Create and return a new <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-35">key range</a> with <a data-link-type="dfn" href="#lower-bound" id="ref-for-lower-bound-12">lower bound</a> set to <var>lowerKey</var>, <a data-link-type="dfn" href="#lower-open-flag" id="ref-for-lower-open-flag-8">lower open flag</a> set if <var>lowerOpen</var> is
 true, <a data-link-type="dfn" href="#upper-bound" id="ref-for-upper-bound-12">upper bound</a> set to <var>upperKey</var> and <a data-link-type="dfn" href="#upper-open-flag" id="ref-for-upper-open-flag-8">upper open
@@ -4435,7 +4486,7 @@ invoked, must run these steps:</p>
       <p>Let <var>k</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-12">convert a
 value to a key</a> with <var>key</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>k</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>k</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Return true if <var>k</var> is <a data-link-type="dfn" href="#in" id="ref-for-in-2">in</a> this range, and false otherwise.</p>
     </ol>
@@ -4479,10 +4530,10 @@ the same time.</p>
       of the cursor. 
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-key" id="ref-for-dom-idbcursor-key-2">key</a></code> 
      <dd> Returns the <a data-link-type="dfn" href="#cursor-key" id="ref-for-cursor-key-5">key</a> of the cursor.
-      Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if the cursor is advancing or is finished. 
+      Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the cursor is advancing or is finished. 
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-primarykey" id="ref-for-dom-idbcursor-primarykey-2">primaryKey</a></code> 
      <dd> Returns the <a data-link-type="dfn" href="#cursor-effective-key" id="ref-for-cursor-effective-key-2">effective key</a> of the cursor.
-      Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> if the cursor is advancing or is finished. 
+      Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the cursor is advancing or is finished. 
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="attribute" data-export="" id="dom-idbcursor-source">source</dfn> attribute’s getter must
@@ -4513,8 +4564,8 @@ does not modify the contents of the database.</p>
   advanced, a <code>success</code> event will be fired at the
   same <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-47">IDBRequest</a></code> returned when the cursor was opened. The <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-23">result</a></code> will be the same cursor if a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-49">record</a> was
   in range, or <code>undefined</code> otherwise. 
-    <p>If called while the cursor is already advancing, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> will be thrown.</p>
-    <p>The following methods throw <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code> if called
+    <p>If called while the cursor is already advancing, an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> will be thrown.</p>
+    <p>The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
   when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-47">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-36">active</a>.</p>
     <dl class="domintro">
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-advance" id="ref-for-dom-idbcursor-advance-2">advance</a></code>(<var>count</var>)
@@ -4527,7 +4578,7 @@ does not modify the contents of the database.</p>
       after <var>key</var>. 
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-continueprimarykey" id="ref-for-dom-idbcursor-continueprimarykey-2">continuePrimaryKey</a></code>(<var>key</var>, <var>primaryKey</var>)
      <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-52">record</a> in range matching
-      or after <var>key</var> and <var>primaryKey</var>. Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code> if the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-15">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-36">index</a>. 
+      or after <var>key</var> and <var>primaryKey</var>. Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-15">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-36">index</a>. 
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="method" data-export="" id="dom-idbcursor-advance">advance(<var>count</var>)</dfn> method, when
@@ -4539,13 +4590,14 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-33">cursor</a>'s <a data-link-type="dfn" href="#cursor-transaction" id="ref-for-cursor-transaction-5">transaction</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-37">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-37">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-16">source</a> or <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-2">effective object
-store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If this cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-5">got value flag</a> is unset, indicating that
-the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Unset the <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-6">got value flag</a> on the cursor.</p>
      <li data-md="">
@@ -4561,7 +4613,7 @@ and <var>request</var>.</p>
    </div>
    <aside class="note"> Calling this method more than once before new cursor data has been
   loaded - for example, calling <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-advance" id="ref-for-dom-idbcursor-advance-3">advance()</a></code> twice from the
-  same onsuccess handler - results in an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception being thrown on the second call because the cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-7">got value flag</a> has been unset. </aside>
+  same onsuccess handler - results in an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> being thrown on the second call because the cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-7">got value flag</a> has been unset. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="method" data-export="" data-lt="continue(key)|continue()" id="dom-idbcursor-continue">continue(<var>key</var>)</dfn> method, when
 invoked, must run these steps:</p>
    <div class="algorithm">
@@ -4569,12 +4621,14 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-36">cursor</a>'s <a data-link-type="dfn" href="#cursor-transaction" id="ref-for-cursor-transaction-6">transaction</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-38">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-38">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-18">source</a> or <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-3">effective object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-18">source</a> or <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-3">effective object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If this cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-8">got value flag</a> is unset, indicating that
-the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>key</var> is given, run these substeps:</p>
       <ol>
@@ -4582,14 +4636,14 @@ the cursor is being iterated or has iterated past its end, <a data-link-type="df
         <p>Let <var>r</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-13">convert a
 value to a key</a> with <var>key</var>. Rethrow any exceptions.</p>
        <li data-md="">
-        <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>Let <var>key</var> be <var>r</var>.</p>
        <li data-md="">
-        <p>If <var>key</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-3">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-4">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-8">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-8">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-4">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-nextunique" id="ref-for-dom-idbcursordirection-nextunique-3">"nextunique"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>key</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-3">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-4">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-8">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-8">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-4">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-nextunique" id="ref-for-dom-idbcursordirection-nextunique-3">"nextunique"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>If <var>key</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-6">greater than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-5">equal to</a> this
-cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-9">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-9">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-4">"prev"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prevunique" id="ref-for-dom-idbcursordirection-prevunique-3">"prevunique"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-9">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-9">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-4">"prev"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prevunique" id="ref-for-dom-idbcursordirection-prevunique-3">"prevunique"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
       <p>Unset the <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-9">got value flag</a> on the cursor.</p>
@@ -4606,47 +4660,49 @@ given), and <var>request</var>.</p>
    </div>
    <aside class="note"> Calling this method more than once before new cursor data has been
   loaded - for example, calling <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-continue" id="ref-for-dom-idbcursor-continue-4">continue()</a></code> twice from the
-  same onsuccess handler - results in an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception being thrown on the second call because the cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-10">got value flag</a> has been unset. </aside>
+  same onsuccess handler - results in an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> being thrown on the second call because the cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-10">got value flag</a> has been unset. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="method" data-export="" data-lt="continuePrimaryKey(key, primaryKey)" id="dom-idbcursor-continueprimarykey">continuePrimaryKey(<var>key</var>, <var>primaryKey</var>)</dfn> method, when invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
       <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-39">cursor</a>'s <a data-link-type="dfn" href="#cursor-transaction" id="ref-for-cursor-transaction-7">transaction</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-39">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-39">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-20">source</a> or <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-4">effective object
-store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-21">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-37">index</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>.</p>
+      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-21">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-37">index</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-10">direction</a> is not <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-5">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-5">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>.</p>
+      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-10">direction</a> is not <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-5">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-5">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If this cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-11">got value flag</a> is unset, indicating that
-the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>r</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-14">convert a value to
 a key</a> with <var>key</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>key</var> be <var>r</var>.</p>
      <li data-md="">
       <p>Let <var>r</var> be the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-15">convert a value
  to a key</a> with <var>primaryKey</var>. Rethrow any exceptions.</p>
      <li data-md="">
-      <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>r</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>primaryKey</var> be <var>r</var>.</p>
      <li data-md="">
-      <p>If <var>key</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-4">less than</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-10">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-11">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-6">"next"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>key</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-4">less than</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-10">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-11">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-6">"next"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>key</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-7">greater than</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-11">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-12">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-6">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>key</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-7">greater than</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-11">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-12">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-6">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>key</var> is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-6">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-12">position</a> and <var>primaryKey</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-5">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-7">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-3">object store position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-13">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-7">"next"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+      <p>If <var>key</var> is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-6">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-12">position</a> and <var>primaryKey</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-5">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-7">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-3">object store position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-13">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-7">"next"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>key</var> is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-8">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-13">position</a> and <var>primaryKey</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-8">greater than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-9">equal to</a> this
-cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-4">object store position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-14">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-7">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-4">object store position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-14">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-7">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Unset the <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-12">got value flag</a> on the cursor.</p>
      <li data-md="">
@@ -4665,16 +4721,16 @@ for iterating a cursor</a> with this <a data-link-type="dfn" href="#cursor" id="
   🚧 </aside>
    <aside class="note"> Calling this method more than once before new cursor data has been
   loaded - for example, calling <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-continueprimarykey" id="ref-for-dom-idbcursor-continueprimarykey-4">continuePrimaryKey()</a></code> twice from
-  the same onsuccess handler - results in an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> being thrown on the second call because the cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-13">got value
+  the same onsuccess handler - results in an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> being thrown on the second call because the cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-13">got value
   flag</a> has been unset. </aside>
    <div class="note" role="note">
-     The following methods throw <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code> if called within a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-14">read-only transaction</a>, and <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code> if
+     The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called within a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-14">read-only transaction</a>, and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if
   called when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-48">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-40">active</a>. 
     <dl class="domintro">
      <dt><var>request</var> = <var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-update" id="ref-for-dom-idbcursor-update-2">update</a></code>(<var>value</var>)
      <dd>
        Updated the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-53">record</a> pointed at by the cursor with a new value. 
-      <p>Throws <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code> if the <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-5">effective object store</a> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-7">in-line keys</a> and the <a data-link-type="dfn" href="#key" id="ref-for-key-85">key</a> would have changed.</p>
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-5">effective object store</a> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-7">in-line keys</a> and the <a data-link-type="dfn" href="#key" id="ref-for-key-85">key</a> would have changed.</p>
       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-24">result</a></code> will be the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-54">record</a>'s <a data-link-type="dfn" href="#key" id="ref-for-key-86">key</a>.</p>
      <dt><var>request</var> = <var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-delete" id="ref-for-dom-idbcursor-delete-2">delete</a></code>()
      <dd>
@@ -4689,17 +4745,20 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-42">cursor</a>'s <a data-link-type="dfn" href="#cursor-transaction" id="ref-for-cursor-transaction-8">transaction</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-41">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-41">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-15">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>.</p>
+      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-15">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-23">source</a> or <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-6">effective object
-store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If this cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-14">got value flag</a> is unset, indicating that
-the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-5">key only flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-5">key only flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>clone</var> be <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclone">structured clone</a> of <var>value</var>. Rethrow any
 exceptions.</p>
@@ -4712,7 +4771,8 @@ keys</a>, run these substeps:</p>
 path</a> of the <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-8">effective object store</a>.
 Rethrow any exceptions.</p>
        <li data-md="">
-        <p>If <var>kpk</var> is failure, invalid, or not <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-10">equal to</a> the cursor’s <a data-link-type="dfn" href="#cursor-effective-key" id="ref-for-cursor-effective-key-5">effective key</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>kpk</var> is failure, invalid, or not <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-10">equal to</a> the cursor’s <a data-link-type="dfn" href="#cursor-effective-key" id="ref-for-cursor-effective-key-5">effective key</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
       <p>Run <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-23">steps for asynchronously executing a request</a> and return
@@ -4732,17 +4792,20 @@ must run these steps:</p>
      <li data-md="">
       <p>Let <var>transaction</var> be this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-44">cursor</a>'s <a data-link-type="dfn" href="#cursor-transaction" id="ref-for-cursor-transaction-9">transaction</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-42">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-42">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-16">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>.</p>
+      <p>If <var>transaction</var> is a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-16">read-only transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-24">source</a> or <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-10">effective object
-store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If this cursor’s <a data-link-type="dfn" href="#cursor-got-value-flag" id="ref-for-cursor-got-value-flag-15">got value flag</a> is unset, indicating that
-the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+the cursor is being iterated or has iterated past its end, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-6">key only flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-6">key only flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-24">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-49">IDBRequest</a></code> created by these steps. The steps are
@@ -4838,15 +4901,18 @@ return the <a data-link-type="dfn" href="#database" id="ref-for-database-47">dat
 must return this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-55">transaction</a>'s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-1">error</a>, or null if
 none.</p>
    <aside class="note"> If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-56">transaction</a> was aborted due to a failed <a data-link-type="dfn" href="#request" id="ref-for-request-27">request</a>, this will be the same as the <a data-link-type="dfn" href="#request" id="ref-for-request-28">request</a>'s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-6">error</a>. If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-57">transaction</a> was aborted
-  due to an uncaught exception in an event handler, the error will be <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>. If the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a> was aborted due to
+  due to an uncaught exception in an event handler, the error will be
+  a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. If the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a> was aborted due to
   an error while committing, it will reflect the reason for the
-  failure (e.g. <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>, or <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>). </aside>
+  failure (e.g. "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>", "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>", or
+  "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>). </aside>
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstore" id="ref-for-dom-idbtransaction-objectstore-2">objectStore</a></code>(<var>name</var>)
      <dd> Returns an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-19">IDBObjectStore</a></code> in the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-59">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-14">scope</a>. 
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-abort" id="ref-for-dom-idbtransaction-abort-2">abort()</a></code>
-     <dd> Aborts the transaction. All pending <a data-link-type="dfn" href="#request" id="ref-for-request-29">requests</a> will fail with <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code> and all changes made to the database will be
+     <dd> Aborts the transaction. All pending <a data-link-type="dfn" href="#request" id="ref-for-request-29">requests</a> will fail with
+      a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and all changes made to the database will be
       reverted. 
     </dl>
    </div>
@@ -4855,9 +4921,11 @@ when invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-12">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-12">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-91">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">named</a> <var>name</var> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-60">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-15">scope</a>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> if none.</p>
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-91">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">named</a> <var>name</var> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-60">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-15">scope</a>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
       <p>Return an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-63">object store handle</a> associated with <var>store</var> and this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-61">transaction</a>.</p>
     </ol>
@@ -4871,7 +4939,7 @@ must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-62">transaction</a> is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-13">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
+      <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-62">transaction</a> is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-13">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Unset the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-63">transaction</a>'s <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-5">active flag</a> and run the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-5">steps for aborting a transaction</a> with null as <var>error</var>.</p>
     </ol>
@@ -4947,10 +5015,11 @@ database <var>name</var>, a database <var>version</var>, and a <var>request</var
      <li data-md="">
       <p>If <var>db</var> is null, let <var>db</var> be a new <a data-link-type="dfn" href="#database" id="ref-for-database-50">database</a> with <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-5">name</a> <var>name</var>, <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-11">version</a> 0 (zero), and with
 no <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-92">object stores</a>. If this fails for any reason, return an
-appropriate error (e.g. <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code> or <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>).</p>
+appropriate error (e.g. a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" or
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>).</p>
      <li data-md="">
       <p>If <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-12">version</a> is greater than <var>version</var>,
-abort these steps and return a new <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#versionerror">VersionError</a></code>.</p>
+abort these steps and return a new "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#versionerror">VersionError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>connection</var> be a new <a data-link-type="dfn" href="#connection" id="ref-for-connection-49">connection</a> to <var>db</var>.</p>
      <li data-md="">
@@ -4980,11 +5049,11 @@ event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-fo
         <p>Run the <a data-link-type="dfn" href="#steps-for-running-an-upgrade-transaction" id="ref-for-steps-for-running-an-upgrade-transaction-3">steps for running an upgrade transaction</a> using <var>connection</var>, <var>version</var> and <var>request</var>.</p>
        <li data-md="">
         <p>If <var>connection</var> was <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-6">closed</a>, create and
-return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code> and abort these steps.</p>
+return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
        <li data-md="">
         <p>If the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-47">upgrade transaction</a> was aborted, run the <a data-link-type="dfn" href="#steps-for-closing-a-database-connection" id="ref-for-steps-for-closing-a-database-connection-4">steps
 for closing a database connection</a> with <var>connection</var>,
-create and return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code> and abort these steps.</p>
+create and return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
       </ol>
      <li data-md="">
       <p>Return <var>connection</var>.</p>
@@ -5000,7 +5069,7 @@ optional <var>forced flag</var>.</p>
       <p>Set the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-6">close pending flag</a> of <var>connection</var>.</p>
      <li data-md="">
       <p>If the <var>forced flag</var> is set, then for each <var>transaction</var> <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-4">created</a> using <var>connection</var> run the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-6">steps for aborting a
-transaction</a> with <var>transaction</var> and newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>.</p>
+transaction</a> with <var>transaction</var> and newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Wait for all transactions <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-5">created</a> using <var>connection</var> to complete.
 Once they are complete, <var>connection</var> is <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-7">closed</a>.</p>
@@ -5054,7 +5123,7 @@ still not closed, <a data-link-type="dfn" href="#fire-a-version-change-event" id
       <p>Let <var>version</var> be <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-18">version</a>.</p>
      <li data-md="">
       <p>Delete <var>db</var>. If this fails for any reason, return an appropriate
-error (e.g. <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code> or <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>).</p>
+error (e.g. "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" or "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>).</p>
      <li data-md="">
       <p>Return <var>version</var>.</p>
     </ol>
@@ -5071,7 +5140,8 @@ written to the <a data-link-type="dfn" href="#database" id="ref-for-database-55"
      <li data-md="">
       <p>If an error occurs while writing the changes to the <a data-link-type="dfn" href="#database" id="ref-for-database-56">database</a>, abort the transaction by following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-7">steps
 for aborting a transaction</a> with <var>transaction</var> and an
-appropriate for the error, for example <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code> or <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>.</p>
+appropriate for the error, for example "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" or
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to dispatch an event at <var>transaction</var>. The
 event must use the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">Event</a> interface and have its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> set to "<code>complete</code>". The event does not
@@ -5111,7 +5181,7 @@ run these substeps:</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-7">result</a> of <var>request</var> to undefined.</p>
        <li data-md="">
-        <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-7">error</a> of <var>request</var> to a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>.</p>
+        <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-7">error</a> of <var>request</var> to a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>Dispatch an event at <var>request</var>. The event must use the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">Event</a> interface and have its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> set to
 "<code>error</code>". The event bubbles and is cancelable.</p>
@@ -5140,7 +5210,8 @@ aborting a transaction</a>.</p>
      <li data-md="">
       <p>Let <var>transaction</var> be the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-69">transaction</a> associated with <var>source</var>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-43">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>.</p>
+      <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-43">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>request</var> was not given, let <var>request</var> be a new <var>request</var> with <a data-link-type="dfn" href="#request-source" id="ref-for-request-source-4">source</a> as <var>source</var>.</p>
      <li data-md="">
@@ -5223,7 +5294,7 @@ version</var> and <var>version</var>.</p>
         <p>If an exception was propagated out from any event handler while
 dispatching the event in the previous step, abort the
 transaction by following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-9">steps for aborting a
-transaction</a> with the <var>error</var> property set to a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>.</p>
+transaction</a> with the <var>error</var> property set to a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
       <p>Wait for <var>transaction</var> to <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-14">finish</a>.</p>
@@ -5311,7 +5382,7 @@ cancelable.</p>
      <li data-md="">
       <p>If an exception was propagated out from any event handler while
 dispatching the event in step 3, abort the transaction by
-following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-12">steps for aborting a transaction</a> with <var>transaction</var> and a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>.</p>
+following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-12">steps for aborting a transaction</a> with <var>transaction</var> and a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="5.10" id="fire-error-event"><span class="secno">5.10. </span><span class="content">Firing an error event</span><a class="self-link" href="#fire-error-event"></a></h3>
@@ -5332,7 +5403,7 @@ The event bubbles and is cancelable.</p>
      <li data-md="">
       <p>If an exception was propagated out from any event handler while
 dispatching the event in step 3, abort the transaction by
-following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-13">steps for aborting a transaction</a> with <var>transaction</var> and a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code> and terminate these steps. This is done even if the
+following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-13">steps for aborting a transaction</a> with <var>transaction</var> and a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and terminate these steps. This is done even if the
 event’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is not set.</p>
       <aside class="note"> This means that if an error event is fired and any of the event
   handlers throw an exception, <var>transaction</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-error" id="ref-for-dom-idbtransaction-error-3">error</a></code> property is set to an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code> rather than <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-10">error</a>, even if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a></code> is never called. </aside>
@@ -5370,7 +5441,7 @@ key from a value using a key path</a> with <var>value</var> and <var>store</var>
          <li data-md="">
           <p>If the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-20">key generator</a>'s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-19">current number</a> is
 greater than 2<sup>53</sup> (9007199254740992), then this
-operation failed with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>. Abort this
+operation failed with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. Abort this
 algorithm without taking any further steps.</p>
          <li data-md="">
           <p>Set <var>key</var> to the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-21">key generator</a>'s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-20">current number</a>.</p>
@@ -5386,7 +5457,7 @@ path</a>.</p>
       </ol>
      <li data-md="">
       <p>If the <var>no-overwrite flag</var> was given to these steps and is set, and
-a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-56">record</a> already exists in <var>store</var> with its key <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-11">equal to</a> <var>key</var>, then this operation failed with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>.
+a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-56">record</a> already exists in <var>store</var> with its key <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-11">equal to</a> <var>key</var>, then this operation failed with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.
 Abort this algorithm without taking any further steps.</p>
      <li data-md="">
       <p>If a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-57">record</a> already exists in <var>store</var> with its key <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-12">equal
@@ -5407,12 +5478,13 @@ for the next index.</p>
        <li data-md="">
         <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-7">multiEntry flag</a> is unset, or if <var>index key</var> is not an <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-5">array key</a>, and if <var>index</var> already contains a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-59">record</a> with <a data-link-type="dfn" href="#key" id="ref-for-key-87">key</a> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-13">equal to</a> <var>index
 key</var>, and <var>index</var> has its <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-8">unique flag</a> set, then this
-operation failed with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>. Abort this
+operation failed with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. Abort this
 algorithm without taking any further steps.</p>
        <li data-md="">
         <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-8">multiEntry flag</a> is set and <var>index key</var> is
 an <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-6">array key</a>, and if <var>index</var> already contains a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-60">record</a> with <a data-link-type="dfn" href="#key" id="ref-for-key-88">key</a> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-14">equal to</a> any of the <a data-link-type="dfn" href="#subkeys" id="ref-for-subkeys-2">subkeys</a> of <var>index key</var>, and <var>index</var> has its <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-9">unique
-flag</a> set, then this operation failed with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>. Abort this algorithm without taking any
+flag</a> set, then this operation failed with a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. Abort this algorithm without taking any
 further steps.</p>
        <li data-md="">
         <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-9">multiEntry flag</a> is unset, or if <var>index key</var> is not an <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-7">array key</a> then store a record in <var>index</var> containing <var>index key</var> as its key and <var>key</var> as its value. The
@@ -5883,7 +5955,7 @@ the list.</p>
 substeps:</p>
       <ol>
        <li data-md="">
-        <p>If <var>value</var> is not an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> object or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> object (see <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#safe-passing-of-structured-data">structured clone algorithm</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>), then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>.</p>
+        <p>If <var>value</var> is not an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> object or an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> object (see <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#safe-passing-of-structured-data">structured clone algorithm</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>), then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p>Let <var>hop</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">!</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-hasownproperty">HasOwnProperty</a>(<var>value</var>, <var>identifier</var>).</p>
        <li data-md="">


### PR DESCRIPTION
To address https://github.com/w3c/IndexedDB/issues/124 as suggested by @domenic -

Use _...throw an `"InvalidStateError"` `DOMException`_ rather than just _throw an `InvalidStateError`_ to reinforce class vs. name

This is based off of https://github.com/w3c/IndexedDB/pull/121 so that should land first.