### PR TITLE
Remove DOMStringList definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5040,73 +5040,6 @@ event handler for the <code>error</code> event.
   the <code>success</code> event fires.
 </aside>
 
-<!-- ============================================================ -->
-<h3 id=domstringlist-api>The {{DOMStringList}} interface</h3>
-<!-- ============================================================ -->
-
-The {{DOMStringList}} interface represents an immutable ordered
-collection of zero or more {{DOMString}} values. The items in a
-{{DOMStringList}} are accessible via an integral index, starting from
-zero.
-
-<aside class=note>
-  The {{DOMStringList}} interface was previously defined in
-  [[DOM-Level-3-core]] but has been removed from the current versions
-  of [[DOM]] and is now only referenced in this specification. It is
-  hoped that in the future all uses of this type can be replaced by
-  the conceptually similar <code>FrozenArray&lt;DOMString&gt;</code>
-  to enable the use of other [=Array=] methods, but retaining support
-  for the {{DOMStringList/contains()}} method for compatibility with
-  deployed content.
-</aside>
-
-<pre class=idl>
-interface DOMStringList {
-    readonly attribute unsigned long length;
-    getter DOMString (unsigned long index);
-    DOMString? item(unsigned long index);
-
-    boolean contains(DOMString str);
-};
-</pre>
-
-<div class=note>
-  <dl class=domintro>
-    <dt><var>list</var> . {{DOMStringList/length}}</dt>
-    <dd>
-      Returns the length of the list.
-    </dd>
-    <dt><var>list</var> [ <var>index</var> ]</dt>
-    <dt><var>list</var> . {{DOMStringList/item()|item}}(<var>index</var>)</dt>
-    <dd>
-      Returns the |index|th item in the list.
-    </dd>
-    <dt><var>list</var> . {{DOMStringList/contains()|contains}}(<var>string</var>)</dt>
-    <dd>
-      Returns true if the list contains |string|, or false otherwise.
-    </dd>
-  </dl>
-</div>
-
-The [=supported property indices=] for a {{DOMStringList}} |list|
-are the numbers zero to the number of items in |list| minus one.
-If |list| has no items, it has no [=supported property indices=].
-
-To [=determine the value of an indexed property=] for a given index
-|index| in a {{DOMStringList}} |list|, return the |index|<sup>th</sup>
-item in |list|.
-
-The <dfn attribute for=DOMStringList>length</dfn> attribute's
-getter must return the number of items in the collection.
-
-The <dfn method for=DOMStringList>item(|index|)</dfn> method must
-return the |index|<sup>th</sup> item in the collection, or null
-if there are less than |index| + 1 items in the collection.
-
-The <dfn method for=DOMStringList>contains(|str|)</dfn> method must
-return true if |str| is equal to any item in the collection, and false
-otherwise.
-
 
 <!-- ============================================================ -->
 <h2 id=algorithms>Algorithms</h2>
@@ -6914,9 +6847,6 @@ document's Revision History</a>.
     <a href="https://github.com/w3c/IndexedDB/issues/77">bug #78</a>,
     <a href="https://github.com/w3c/IndexedDB/issues/77">bug #79</a>,
     <a href="https://github.com/w3c/IndexedDB/issues/77">bug #81</a>)
-
-* Added {{DOMStringList}}.
-    (<a href="https://github.com/w3c/IndexedDB/issues/28">bug #28</a>)
 
 
 <!-- ============================================================ -->

--- a/index.html
+++ b/index.html
@@ -1455,7 +1455,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-10">10 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-13">13 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1560,7 +1560,6 @@ persistent B-tree data structure.</p>
       <li><a href="#keyrange"><span class="secno">4.7</span> <span class="content">The <code class="idl"><span>IDBKeyRange</span></code> interface</span></a>
       <li><a href="#cursor-interface"><span class="secno">4.8</span> <span class="content">The <code class="idl"><span>IDBCursor</span></code> interface</span></a>
       <li><a href="#transaction"><span class="secno">4.9</span> <span class="content">The <code class="idl"><span>IDBTransaction</span></code> interface</span></a>
-      <li><a href="#domstringlist-api"><span class="secno">4.10</span> <span class="content">The <code class="idl"><span>DOMStringList</span></code> interface</span></a>
      </ol>
     <li>
      <a href="#algorithms"><span class="secno">5</span> <span class="content">Algorithms</span></a>
@@ -1852,7 +1851,7 @@ request<span class="p">.</span>onupgradeneeded <span class="o">=</span> <span cl
 from the database. Ideally the user will never see this.</p>
    </aside>
    <h2 class="heading settled" data-level="2" id="constructs"><span class="secno">2. </span><span class="content">Constructs</span><a class="self-link" href="#constructs"></a></h2>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sorted-list">sorted list</dfn> is a <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-1">DOMStringList</a></code> containing strings
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sorted-list">sorted list</dfn> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> containing strings
 sorted in ascending order by code unit.</p>
    <h3 class="heading settled" data-level="2.1" id="database-construct"><span class="secno">2.1. </span><span class="content">Database</span><a class="self-link" href="#database-construct"></a></h3>
    <p>A database’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> is the same as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#worker">worker</a>. Each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> has an associated
@@ -3178,7 +3177,7 @@ If an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbdatabase">IDBDatabase</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>          <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-idbdatabase-name" id="ref-for-dom-idbdatabase-name-1">name</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long" href="#dom-idbdatabase-version" id="ref-for-dom-idbdatabase-version-1">version</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#domstringlist" id="ref-for-domstringlist-2">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-1">objectStoreNames</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-1">objectStoreNames</a>;
 
   <a class="n" data-link-type="idl-name" href="#idbtransaction" id="ref-for-idbtransaction-3">IDBTransaction</a> <a class="nv idl-code" data-link-type="method" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-1">transaction</a>((<span class="kt">DOMString</span> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<span class="kt">DOMString</span>>) <dfn class="nv idl-code" data-dfn-for="IDBDatabase/transaction(storeNames, mode), IDBDatabase/transaction(storeNames)" data-dfn-type="argument" data-export="" id="dom-idbdatabase-transaction-storenames-mode-storenames">storeNames<a class="self-link" href="#dom-idbdatabase-transaction-storenames-mode-storenames"></a></dfn>,
                              <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#enumdef-idbtransactionmode" id="ref-for-enumdef-idbtransactionmode-1">IDBTransactionMode</a> <dfn class="nv idl-code" data-dfn-for="IDBDatabase/transaction(storeNames, mode), IDBDatabase/transaction(storeNames)" data-dfn-type="argument" data-export="" id="dom-idbdatabase-transaction-storenames-mode-mode">mode<a class="self-link" href="#dom-idbdatabase-transaction-storenames-mode-mode"></a></dfn> = "readonly");
@@ -3375,7 +3374,7 @@ the event handler for the <code>versionchange</code> event.</p>
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbobjectstore">IDBObjectStore</dfn> {
            <span class="kt">attribute</span> <span class="kt">DOMString</span>      <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-1">name</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span>            <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-idbobjectstore-keypath" id="ref-for-dom-idbobjectstore-keypath-1">keyPath</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#domstringlist" id="ref-for-domstringlist-3">DOMStringList</a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-1">indexNames</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-1">indexNames</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#idbtransaction" id="ref-for-idbtransaction-5">IDBTransaction</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBTransaction" href="#dom-idbobjectstore-transaction" id="ref-for-dom-idbobjectstore-transaction-1">transaction</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span>        <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-idbobjectstore-autoincrement" id="ref-for-dom-idbobjectstore-autoincrement-1">autoIncrement</a>;
 
@@ -4912,7 +4911,7 @@ the contents of the database.</p>
    <p><a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-49">transaction</a> objects implement the following interface:</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbtransaction">IDBTransaction</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#domstringlist" id="ref-for-domstringlist-4">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbtransaction-objectstorenames" id="ref-for-dom-idbtransaction-objectstorenames-1">objectStoreNames</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbtransaction-objectstorenames" id="ref-for-dom-idbtransaction-objectstorenames-1">objectStoreNames</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-idbtransactionmode" id="ref-for-enumdef-idbtransactionmode-2">IDBTransactionMode</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBTransactionMode" href="#dom-idbtransaction-mode" id="ref-for-dom-idbtransaction-mode-1">mode</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#idbdatabase" id="ref-for-idbdatabase-11">IDBDatabase</a>        <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBDatabase" href="#dom-idbtransaction-db" id="ref-for-dom-idbtransaction-db-1">db</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a>       <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMException" href="#dom-idbtransaction-error" id="ref-for-dom-idbtransaction-error-1">error</a>;
@@ -5028,46 +5027,6 @@ event handler for the <code>error</code> event.</p>
   listen to the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-65">transaction</a>'s <code>complete</code> event
   rather than the <code>success</code> event of a particular <a data-link-type="dfn" href="#request" id="ref-for-request-30">request</a>, because the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-66">transaction</a> may still fail after
   the <code>success</code> event fires. </aside>
-   <h3 class="heading settled" data-level="4.10" id="domstringlist-api"><span class="secno">4.10. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-5">DOMStringList</a></code> interface</span><a class="self-link" href="#domstringlist-api"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-6">DOMStringList</a></code> interface represents an immutable ordered
-collection of zero or more <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> values. The items in a <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-7">DOMStringList</a></code> are accessible via an integral index, starting from
-zero.</p>
-   <aside class="note"> The <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-8">DOMStringList</a></code> interface was previously defined in <a data-link-type="biblio" href="#biblio-dom-level-3-core">[DOM-Level-3-core]</a> but has been removed from the current versions
-  of <a data-link-type="biblio" href="#biblio-dom">[DOM]</a> and is now only referenced in this specification. It is
-  hoped that in the future all uses of this type can be replaced by
-  the conceptually similar <code>FrozenArray&lt;DOMString></code> to enable the use of other <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> methods, but retaining support
-  for the <code class="idl"><a data-link-type="idl" href="#dom-domstringlist-contains" id="ref-for-dom-domstringlist-contains-1">contains()</a></code> method for compatibility with
-  deployed content. </aside>
-<pre class="idl highlight def"><span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="domstringlist">DOMStringList</dfn> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-domstringlist-length" id="ref-for-dom-domstringlist-length-1">length</a>;
-    <span class="kt">getter</span> <span class="kt">DOMString</span> (<span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="DOMStringList/__getter__(index)" data-dfn-type="argument" data-export="" id="dom-domstringlist-__getter__-index-index">index<a class="self-link" href="#dom-domstringlist-__getter__-index-index"></a></dfn>);
-    <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="method" href="#dom-domstringlist-item" id="ref-for-dom-domstringlist-item-1">item</a>(<span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="DOMStringList/item(index)" data-dfn-type="argument" data-export="" id="dom-domstringlist-item-index-index">index<a class="self-link" href="#dom-domstringlist-item-index-index"></a></dfn>);
-
-    <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="method" href="#dom-domstringlist-contains" id="ref-for-dom-domstringlist-contains-2">contains</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="DOMStringList/contains(str)" data-dfn-type="argument" data-export="" id="dom-domstringlist-contains-str-str">str<a class="self-link" href="#dom-domstringlist-contains-str-str"></a></dfn>);
-};
-</pre>
-   <div class="note" role="note">
-    <dl class="domintro">
-     <dt><var>list</var> . <code class="idl"><a data-link-type="idl" href="#dom-domstringlist-length" id="ref-for-dom-domstringlist-length-2">length</a></code>
-     <dd> Returns the length of the list. 
-     <dt><var>list</var> [ <var>index</var> ]
-     <dt><var>list</var> . <code class="idl"><a data-link-type="idl" href="#dom-domstringlist-item" id="ref-for-dom-domstringlist-item-2">item</a></code>(<var>index</var>)
-     <dd> Returns the <var>index</var>th item in the list. 
-     <dt><var>list</var> . <code class="idl"><a data-link-type="idl" href="#dom-domstringlist-contains" id="ref-for-dom-domstringlist-contains-3">contains</a></code>(<var>string</var>)
-     <dd> Returns true if the list contains <var>string</var>, or false otherwise. 
-    </dl>
-   </div>
-   <p>The <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a> for a <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-9">DOMStringList</a></code> <var>list</var> are the numbers zero to the number of items in <var>list</var> minus one.
-If <var>list</var> has no items, it has no <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a>.</p>
-   <p>To <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-determine-the-value-of-an-indexed-property">determine the value of an indexed property</a> for a given index <var>index</var> in a <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-10">DOMStringList</a></code> <var>list</var>, return the <var>index</var><sup>th</sup> item in <var>list</var>.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="DOMStringList" data-dfn-type="attribute" data-export="" id="dom-domstringlist-length">length</dfn> attribute’s
-getter must return the number of items in the collection.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="DOMStringList" data-dfn-type="method" data-export="" id="dom-domstringlist-item">item(<var>index</var>)</dfn> method must
-return the <var>index</var><sup>th</sup> item in the collection, or null
-if there are less than <var>index</var> + 1 items in the collection.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="DOMStringList" data-dfn-type="method" data-export="" id="dom-domstringlist-contains">contains(<var>str</var>)</dfn> method must
-return true if <var>str</var> is equal to any item in the collection, and false
-otherwise.</p>
    <h2 class="heading settled" data-level="5" id="algorithms"><span class="secno">5. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="opening"><span class="secno">5.1. </span><span class="content">Opening a database</span><a class="self-link" href="#opening"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="steps-for-opening-a-database">steps for opening a database</dfn> are defined in the
@@ -6466,9 +6425,6 @@ and define abstract types such as <a data-link-type="dfn" href="#key" id="ref-fo
     <li data-md="">
      <p>Clarified <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-15">open request</a> / <a data-link-type="dfn" href="#request-connection-queue" id="ref-for-request-connection-queue-5">connection queue</a> processing.
 (<a href="https://github.com/w3c/IndexedDB/issues/9">bug #9</a>, <a href="https://github.com/w3c/IndexedDB/issues/77">bug #78</a>, <a href="https://github.com/w3c/IndexedDB/issues/77">bug #79</a>, <a href="https://github.com/w3c/IndexedDB/issues/77">bug #81</a>)</p>
-    <li data-md="">
-     <p>Added <code class="idl"><a data-link-type="idl" href="#domstringlist" id="ref-for-domstringlist-11">DOMStringList</a></code>.
-(<a href="https://github.com/w3c/IndexedDB/issues/28">bug #28</a>)</p>
    </ul>
    <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Special thanks to Nikunj Mehta, the original author of the first
@@ -6596,7 +6552,6 @@ specification.</p>
     </ul>
    <li><a href="#request-connection-queue">connection queue</a><span>, in §2.8.1</span>
    <li><a href="#containing-only">containing only</a><span>, in §2.9</span>
-   <li><a href="#dom-domstringlist-contains">contains(str)</a><span>, in §4.10</span>
    <li><a href="#dom-idbcursor-continue">continue()</a><span>, in §4.8</span>
    <li><a href="#dom-idbcursor-continue">continue(key)</a><span>, in §4.8</span>
    <li><a href="#dom-idbcursor-continueprimarykey">continuePrimaryKey(key, primaryKey)</a><span>, in §4.8</span>
@@ -6637,7 +6592,6 @@ specification.</p>
      <li><a href="#cursor-direction">dfn for cursor</a><span>, in §2.10</span>
      <li><a href="#dom-idbcursor-direction">attribute for IDBCursor</a><span>, in §4.8</span>
     </ul>
-   <li><a href="#domstringlist">DOMStringList</a><span>, in §4.10</span>
    <li><a href="#dom-idbrequestreadystate-done">done</a><span>, in §4.1</span>
    <li><a href="#dom-idbrequestreadystate-done">"done"</a><span>, in §4.1</span>
    <li><a href="#request-done-flag">done flag</a><span>, in §2.8</span>
@@ -6744,7 +6698,6 @@ specification.</p>
    <li><a href="#object-store-handle-index-set">index set</a><span>, in §2.2.1</span>
    <li><a href="#inject-a-key-into-a-value-using-a-key-path">inject a key into a value using a key path</a><span>, in §7.2</span>
    <li><a href="#object-store-in-line-keys">in-line keys</a><span>, in §2.2</span>
-   <li><a href="#dom-domstringlist-item">item(index)</a><span>, in §4.10</span>
    <li>
     key
     <ul>
@@ -6770,7 +6723,6 @@ specification.</p>
     </ul>
    <li><a href="#key-range">key range</a><span>, in §2.9</span>
    <li><a href="#index-keys">keys</a><span>, in §2.6</span>
-   <li><a href="#dom-domstringlist-length">length</a><span>, in §4.10</span>
    <li><a href="#less-than">less than</a><span>, in §2.4</span>
    <li><a href="#transaction-lifetime">lifetime</a><span>, in §2.7.1</span>
    <li>
@@ -7081,6 +7033,7 @@ specification.</p>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>
      <li><a href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a>
      <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#imagedata">ImageData</a>
@@ -7120,12 +7073,10 @@ specification.</p>
      <li><a href="https://heycam.github.io/webidl/#versionerror">VersionError</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-buffer-source-type">buffer source types</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-create-exception">create exception</a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-determine-the-value-of-an-indexed-property">determine the value of an indexed property</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">getting a copy of the bytes held by a buffer source</a>
      <li><a href="https://heycam.github.io/webidl/#idl-octet">octet</a>
      <li><a href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;any></a>
      <li><a href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;domstring></a>
-     <li><a href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
      <li><a href="https://heycam.github.io/webidl/#idl-unrestricted-double">unrestricted double</a>
     </ul>
@@ -7150,8 +7101,6 @@ specification.</p>
   <dl>
    <dt id="biblio-cookies">[COOKIES]
    <dd>A. Barth. <a href="https://tools.ietf.org/html/rfc6265">HTTP State Management Mechanism</a>. April 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6265">https://tools.ietf.org/html/rfc6265</a>
-   <dt id="biblio-dom-level-3-core">[DOM-Level-3-core]
-   <dd>Arnaud Le Hors; et al. <a href="https://www.w3.org/TR/DOM-Level-3-Core/">Document Object Model (DOM) Level 3 Core Specification</a>. 7 April 2004. REC. URL: <a href="https://www.w3.org/TR/DOM-Level-3-Core/">https://www.w3.org/TR/DOM-Level-3-Core/</a>
    <dt id="biblio-webstorage">[WEBSTORAGE]
    <dd>Ian Hickson. <a href="https://w3c.github.io/webstorage/">Web Storage (Second Edition)</a>. URL: <a href="https://w3c.github.io/webstorage/">https://w3c.github.io/webstorage/</a>
   </dl>
@@ -7210,7 +7159,7 @@ specification.</p>
 <span class="kt">interface</span> <a class="nv" href="#idbdatabase">IDBDatabase</a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>          <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-idbdatabase-name">name</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long" href="#dom-idbdatabase-version">version</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbdatabase-objectstorenames">objectStoreNames</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbdatabase-objectstorenames">objectStoreNames</a>;
 
   <a class="n" data-link-type="idl-name" href="#idbtransaction">IDBTransaction</a> <a class="nv idl-code" data-link-type="method" href="#dom-idbdatabase-transaction">transaction</a>((<span class="kt">DOMString</span> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<span class="kt">DOMString</span>>) <a class="nv" href="#dom-idbdatabase-transaction-storenames-mode-storenames">storeNames</a>,
                              <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#enumdef-idbtransactionmode">IDBTransactionMode</a> <a class="nv" href="#dom-idbdatabase-transaction-storenames-mode-mode">mode</a> = "readonly");
@@ -7236,7 +7185,7 @@ specification.</p>
 <span class="kt">interface</span> <a class="nv" href="#idbobjectstore">IDBObjectStore</a> {
            <span class="kt">attribute</span> <span class="kt">DOMString</span>      <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-idbobjectstore-name">name</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span>            <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-idbobjectstore-keypath">keyPath</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#domstringlist">DOMStringList</a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbobjectstore-indexnames">indexNames</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbobjectstore-indexnames">indexNames</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#idbtransaction">IDBTransaction</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBTransaction" href="#dom-idbobjectstore-transaction">transaction</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span>        <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-idbobjectstore-autoincrement">autoIncrement</a>;
 
@@ -7340,7 +7289,7 @@ specification.</p>
 
 [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
 <span class="kt">interface</span> <a class="nv" href="#idbtransaction">IDBTransaction</a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbtransaction-objectstorenames">objectStoreNames</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbtransaction-objectstorenames">objectStoreNames</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-idbtransactionmode">IDBTransactionMode</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBTransactionMode" href="#dom-idbtransaction-mode">mode</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#idbdatabase">IDBDatabase</a>        <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBDatabase" href="#dom-idbtransaction-db">db</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a>       <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMException" href="#dom-idbtransaction-error">error</a>;
@@ -7358,14 +7307,6 @@ specification.</p>
   <a class="s" href="#dom-idbtransactionmode-readonly">"readonly"</a>,
   <a class="s" href="#dom-idbtransactionmode-readwrite">"readwrite"</a>,
   <a class="s" href="#dom-idbtransactionmode-versionchange">"versionchange"</a>
-};
-
-<span class="kt">interface</span> <a class="nv" href="#domstringlist">DOMStringList</a> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-domstringlist-length">length</a>;
-    <span class="kt">getter</span> <span class="kt">DOMString</span> (<span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-domstringlist-__getter__-index-index">index</a>);
-    <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="method" href="#dom-domstringlist-item">item</a>(<span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-domstringlist-item-index-index">index</a>);
-
-    <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="method" href="#dom-domstringlist-contains">contains</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-domstringlist-contains-str-str">str</a>);
 };
 
 </pre>
@@ -9180,35 +9121,6 @@ specification.</p>
    <b><a href="#dom-idbtransaction-onerror">#dom-idbtransaction-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-onerror-1">4.9. The IDBTransaction interface</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="domstringlist">
-   <b><a href="#domstringlist">#domstringlist</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-domstringlist-1">2. Constructs</a>
-    <li><a href="#ref-for-domstringlist-2">4.4. The IDBDatabase interface</a>
-    <li><a href="#ref-for-domstringlist-3">4.5. The IDBObjectStore interface</a>
-    <li><a href="#ref-for-domstringlist-4">4.9. The IDBTransaction interface</a>
-    <li><a href="#ref-for-domstringlist-5">4.10. The DOMStringList interface</a> <a href="#ref-for-domstringlist-6">(2)</a> <a href="#ref-for-domstringlist-7">(3)</a> <a href="#ref-for-domstringlist-8">(4)</a> <a href="#ref-for-domstringlist-9">(5)</a> <a href="#ref-for-domstringlist-10">(6)</a>
-    <li><a href="#ref-for-domstringlist-11">10. Revision History</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-domstringlist-length">
-   <b><a href="#dom-domstringlist-length">#dom-domstringlist-length</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-domstringlist-length-1">4.10. The DOMStringList interface</a> <a href="#ref-for-dom-domstringlist-length-2">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-domstringlist-item">
-   <b><a href="#dom-domstringlist-item">#dom-domstringlist-item</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-domstringlist-item-1">4.10. The DOMStringList interface</a> <a href="#ref-for-dom-domstringlist-item-2">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-domstringlist-contains">
-   <b><a href="#dom-domstringlist-contains">#dom-domstringlist-contains</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-domstringlist-contains-1">4.10. The DOMStringList interface</a> <a href="#ref-for-dom-domstringlist-contains-2">(2)</a> <a href="#ref-for-dom-domstringlist-contains-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="steps-for-opening-a-database">


### PR DESCRIPTION
Following https://github.com/whatwg/html/commit/a830aef7a9087b0d879f548980f0c616df02149e the definition of DOMStringList is now in [[HTML]](https://html.spec.whatwg.org/multipage/infrastructure.html#the-domstringlist-interface) - remove it from here.