### PR TITLE
Fix markdown indentation to repair algorithm. Resolves #142

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,8 +43,8 @@ spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/
         text: ToLength; url: sec-tolength
         text: ToString; url: sec-tostring
         text: IsArray; url: sec-isarray
-        text: String; url: sec-ecmascript-language-types-string-type
-        text: Number; url: sec-ecmascript-language-types-number-type
+        text: String; url: sec-terms-and-definitions-string-type
+        text: Number; url: sec-terms-and-definitions-number-type
         text: Date; url: sec-date-objects
         text: Object; url: sec-object-objects
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
@@ -6551,7 +6551,7 @@ steps may throw an exception.
 
 <div class=algorithm>
 
-1. If [=IsArray=](|input|), then:
+1. If [=IsArray=](|input|), then run these substeps:
 
     1. Let |len| be [=?=] ToLength( [=?=] [=Get=](|input|, "<code>length</code>")).
 
@@ -6577,8 +6577,8 @@ steps may throw an exception.
 
         3. Increase |index| by 1.
 
-   6. Return a new [=array key=] with [=key/value=] set to
-       a list of the members of |keys|.
+    6. Return a new [=array key=] with [=key/value=] set to
+        a list of the members of |keys|.
 
 2. Otherwise, return the result of running the steps to [=convert a
     value to a key=] with argument |input|.

--- a/index.html
+++ b/index.html
@@ -1455,7 +1455,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-20">20 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-06">6 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1965,7 +1965,7 @@ transaction</a> is running.</p>
    <h3 class="heading settled" data-level="2.3" id="value-construct"><span class="secno">2.3. </span><span class="content">Values</span><a class="self-link" href="#value-construct"></a></h3>
    <p>Each record is associated with a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="value">value</dfn>. User agents must
 support any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#cloneable-objects">cloneable object</a>. This includes simple types
-such as <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">String</a> primitive values and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-date-objects">Date</a> objects as well as <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> instances, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-file">File</a></code> objects, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> objects, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#imagedata">ImageData</a></code> objects, and so on. Record <a data-link-type="dfn" href="#value" id="ref-for-value-3">values</a> are
+such as <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type">String</a> primitive values and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-date-objects">Date</a> objects as well as <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-object-objects">Object</a> and <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> instances, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-file">File</a></code> objects, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> objects, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#imagedata">ImageData</a></code> objects, and so on. Record <a data-link-type="dfn" href="#value" id="ref-for-value-3">values</a> are
 stored and retrieved by value rather than by reference; later changes
 to a value have no effect on the record stored in the database.</p>
    <h3 class="heading settled" data-level="2.4" id="key-construct"><span class="secno">2.4. </span><span class="content">Keys</span><a class="self-link" href="#key-construct"></a></h3>
@@ -1990,13 +1990,13 @@ following the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" 
      The following ECMAScript types are valid keys: 
     <ul>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">Number</a> primitive values, except NaN. This includes Infinity
+      <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type">Number</a> primitive values, except NaN. This includes Infinity
   and -Infinity.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-date-objects">Date</a> objects, except where the [[DateValue]]
   internal slot is NaN.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">String</a> primitive values.</p>
+      <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type">String</a> primitive values.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects">ArrayBuffer</a> objects (or views on buffers such as <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-typedarray-objects">Uint8Array</a>).</p>
      <li data-md="">
@@ -2187,7 +2187,7 @@ following type-specific properties:</p>
       <td><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>
       <td><code>length</code>
      <tr>
-      <td><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">String</a>
+      <td><a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type">String</a>
       <td><code>length</code>
    </table>
    <h3 class="heading settled" data-level="2.6" id="index-construct"><span class="secno">2.6. </span><span class="content">Index</span><a class="self-link" href="#index-construct"></a></h3>
@@ -6223,7 +6223,7 @@ steps may throw an exception.</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isarray">IsArray</a>(<var>input</var>), then:</p>
+      <p>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isarray">IsArray</a>(<var>input</var>), then run these substeps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>len</var> be <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> ToLength( <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">?</a> <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>input</var>, "<code>length</code>")).</p>
@@ -6250,10 +6250,10 @@ steps may throw an exception.</p>
          <li data-md="">
           <p>Increase <var>index</var> by 1.</p>
         </ol>
+       <li data-md="">
+        <p>Return a new <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-13">array key</a> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-13">value</a> set to
+a list of the members of <var>keys</var>.</p>
       </ol>
-     <li data-md="">
-      <p>Return a new <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-13">array key</a> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-13">value</a> set to
-   a list of the members of <var>keys</var>.</p>
      <li data-md="">
       <p>Otherwise, return the result of running the steps to <a data-link-type="dfn" href="#convert-a-value-to-a-key" id="ref-for-convert-a-value-to-a-key-19">convert a
 value to a key</a> with argument <var>input</var>.</p>
@@ -7030,11 +7030,11 @@ specification.</p>
      <li><a href="https://tc39.github.io/ecma262/#sec-hasownproperty">hasownproperty</a>
      <li><a href="https://tc39.github.io/ecma262/#prod-IdentifierName">identifiername</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-isarray">isarray</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">number</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type">number</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-object-objects">object</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-code-objects">realm</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-returnifabrupt">returnifabrupt</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">string</a>
+     <li><a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type">string</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-tolength">tolength</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-tostring">tostring</a>
      <li><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">type</a>


### PR DESCRIPTION
Literally just whitespace causing an algorithm to have a step in the wrong place.

Also added the "run these substeps" boilerplate, and fixed a couple ECMAScript spec refs.
