### PR TITLE
Rework key generator algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1494,88 +1494,130 @@ stated otherwise it is unset.
 <!-- ============================================================ -->
 
 When a [=/object store=] is created it can be specified to use a
-<dfn>key generator</dfn>. A [=key generator=] keeps an internal
-<dfn>current number</dfn>. The [=current number=] is always a positive
-integer. Whenever the key generator is used to generate a new
-[=/key=], the generator's [=current number=] is returned and
-<strong>then</strong> incremented to prepare for the next time a new
-[=/key=] is needed. Implementations must use the following rules for
-generating numbers when a [=key generator=] is used.
+<dfn>key generator</dfn>. A key generator is used to generate keys
+for records inserted into an object store if not otherwise specified.
 
-* Every object store that uses key generators use a separate
-    generator. I.e. interacting with one object store never affects
-    the key generator of any other object store.
+<div dfn-for="key generator">
 
-* The [=current number=] of a [=key generator=] is always set to
-    1 when the [=/object store=] for that key generator is first
-    created.
+A [=key generator=] has a <dfn>current number</dfn>. The
+[=key generator/current number=] is always a positive integer less
+than or equal to 2<sup>53</sup> (9007199254740992). The initial value
+of a [=key generator=]'s [=key generator/current number=] is 1, set
+when the associated [=/object store=] is created. The
+[=key generator/current number=] is incremented as keys are generated,
+and may be updated to a specific value by using explicit keys.
 
-* When a key generator is used to generate a new [=/key=] for
-    a [=/object store=], the key generator's [=current
-    number=] is used as the new key value and then the key
-    generator's [=current number=] is increased by 1.
+</div>
 
-* When a [=object-store/record=] is stored and a [=/key=] is specified
-    in the call to store the record, if [=key/type=] of the key
-    is <i>number</i> and the [=key/value=] is greater than or
-    equal to the key generator's [=current number=], then the key
-    generator's [=current number=] is set to the smallest integer
-    number [=greater than=] the explicit key. A key can be
-    specified both for object stores which use [=in-line keys=], by
-    setting the property on the stored value which the object store's
-    [=object-store/key path=] points to, and for object stores
-    which use [=out-of-line keys=], by passing a key argument to
-    the call to store the [=object-store/record=].
+<aside class=note>
+  Every object store that uses key generators uses a separate
+  generator. That is, interacting with one object store never affects
+  the key generator of any other object store.
+</aside>
 
-    <aside class=note>
-      Only specified keys of [=key/type=] <i>number</i> may affect the
-      [=current number=] of the key generator. Keys of [=key/type=]
-      <i>date</i>, <i>array</i> (regardless of the other keys they
-      contain), <i>binary</i>, or <i>string</i> (regardless of whether
-      they could be parsed as numbers) have no effect on the [=current
-      number=] of the key generator. Keys of [=key/type=]
-      <i>number</i> with [=key/value=] less than 1 do not affect the
-      [=current number=] since they are always lower than the
-      [=current number=].
-    </aside>
+Modifying a key generator's [=key generator/current number=] is considered part
+of a database operation. This means that if the operation fails
+and the operation is reverted, the [=key generator/current number=] is
+reverted to the value it had before the operation started. This
+applies both to modifications that happen due to the [=key generator/current
+number=] getting increased by 1 when the key generator is used,
+and to modifications that happen due to a [=object-store/record=] being
+stored with a key value specified in the call to store the
+[=object-store/record=].
 
-* Modifying a key generator's [=current number=] is considered part
-    of a database operation. This means that if the operation fails
-    and the operation is reverted, the [=current number=] is
-    reverted to the value it had before the operation started. This
-    applies both to modifications that happen due to the [=current
-    number=] getting increased by 1 when the key generator is used,
-    and to modifications that happen due to a [=object-store/record=] being
-    stored with a key value specified in the call to store the
-    [=object-store/record=].
+Likewise, if a [=/transaction=] is aborted, the [=key generator/current
+number=] of the key generator for each [=/object store=] in
+the transaction's [=transaction/scope=] is reverted to the value it had
+before the [=/transaction=] was started.
 
-* Likewise, if a [=/transaction=] is aborted, the [=current
-    number=] of the key generator for each [=/object store=] in
-    the transaction's [=transaction/scope=] is reverted to the value it had
-    before the [=/transaction=] was started.
+The [=key generator/current number=] for a key generator never decreases, other
+than as a result of database operations being reverted. Deleting a
+[=object-store/record=] from an [=/object store=] never affects the
+object store's key generator. Even clearing all records from an
+object store, for example using the {{IDBObjectStore/clear()}} method, does not
+affect the [=key generator/current number=] of the object store's key
+generator.
 
-* When the [=current number=] of a key generator reaches above the
-    value 2<sup>53</sup> (9007199254740992) any attempts to use the
-    key generator to generate a new [=/key=] will result in a
-    "{{ConstraintError}}" {{DOMException}}. It is still possible to insert
-    [=object-store/records=] into the object store by specifying an explicit
-    key, however the only way to use a key generator again for the
-    object store is to delete the object store and create a new one.
+When a [=object-store/record=] is stored and a [=/key=] is not specified
+in the call to store the record, a key is generated.
 
-    <aside class=note>
-      As long as key generators are used in a normal fashion this will
-      not be a problem. If you generate a new key 1000 times per
-      second day and night, you won't run into this limit for over
-      285000 years.
-    </aside>
+<div class=algorithm>
 
-* The [=current number=] for a key generator never decreases, other
-    than as a result of database operations being reverted. Deleting a
-    [=object-store/record=] from an [=/object store=] never affects the
-    object store's key generator. Even clearing all records from an
-    object store, for example using the {{IDBObjectStore/clear()}} method, does not
-    affect the [=current number=] of the object store's key
-    generator.
+  To <dfn>generate a key</dfn> for an [=/object store=] |store|, run the following steps:
+
+  1. Let |generator| be the [=key generator=] associated with |store|.
+
+  2. Let |key| be |generator|'s [=key generator/current number=].
+
+  3. If |key| is greater than 2<sup>53</sup> (9007199254740992), then return failure.
+
+  4. Increase |generator|'s [=key generator/current number=] by 1.
+
+  5. Return |key|.
+
+</div>
+
+When a [=object-store/record=] is stored and a [=/key=] is specified
+in the call to store the record, the associated [=key generator=] may
+be updated.
+
+<div class=algorithm>
+
+  To <dfn>possibly update the key generator</dfn> for an [=/object store=] |store| with |key|,
+  run the following steps:
+
+  1. If the [=key/type=] of |key| is not <i>number</i>, abort these steps.
+
+  2. Let |value| be the [=key/value=] of |key|.
+
+  3. Let |value| be the minimum of |value| and 2<sup>53</sup> (9007199254740992).
+
+  4. Let |value| be the largest integer not greater than |value|.
+
+  5. Let |generator| be the [=key generator=] associated with |store|.
+
+  6. If |value| is greater than or equal to |generator|'s [=key generator/current number=],
+      then set |generator|'s [=key generator/current number=] to |value| + 1.
+
+</div>
+
+<aside class=note>
+  A key can be specified both for object stores which use
+  [=in-line keys=], by setting the property on the stored value
+  which the object store's [=object-store/key path=] points to,
+  and for object stores which use [=out-of-line keys=], by passing
+  a key argument to the call to store the [=object-store/record=].
+
+  Only specified keys of [=key/type=] <i>number</i> may affect the
+  [=key generator/current number=] of the key generator. Keys of [=key/type=]
+  <i>date</i>, <i>array</i> (regardless of the other keys they
+  contain), <i>binary</i>, or <i>string</i> (regardless of whether
+  they could be parsed as numbers) have no effect on the [=key generator/current
+  number=] of the key generator. Keys of [=key/type=]
+  <i>number</i> with [=key/value=] less than 1 do not affect the
+  [=key generator/current number=] since they are always lower than the
+  [=key generator/current number=].
+</aside>
+
+When the [=key generator/current number=] of a key generator reaches above the
+value 2<sup>53</sup> (9007199254740992) any attempts to use the
+key generator to generate a new [=/key=] will result in a
+"{{ConstraintError}}" {{DOMException}}. It is still possible to insert
+[=object-store/records=] into the object store by specifying an explicit
+key, however the only way to use a key generator again for the
+object store is to delete the object store and create a new one.
+
+<aside class=note>
+  This limit arises because integers greater than 9007199254740992
+  cannot be uniquely represented as ECMAScript [=Numbers=].
+  As an example, <code>9007199254740992 + 1 === 9007199254740992</code>
+  in ECMAScript.
+
+  As long as key generators are used in a normal fashion this limit will
+  not be a problem. If you generate a new key 1000 times per
+  second day and night, you won't run into this limit for over
+  285000 years.
+</aside>
 
 A practical result of this is that the first key generated for an
 object store is always 1 (unless a higher numeric key is inserted
@@ -5716,24 +5758,20 @@ follows.
 
     1. If |key| is undefined, run these substeps:
 
-        1. If the [=key generator=]'s [=current number=] is
-            greater than 2<sup>53</sup> (9007199254740992), then this
-            operation failed with a "{{ConstraintError}}" {{DOMException}}. Abort this
+        1. Let |key| be the result of running the steps to
+            [=generate a key=] for |store|.
+
+        2. If |key| is failure, then this operation failed with a
+            "{{ConstraintError}}" {{DOMException}}. Abort this
             algorithm without taking any further steps.
 
-        2. Set |key| to the [=key generator=]'s [=current number=].
-
-        3. Increase the [=key generator=]'s [=current number=] by 1.
-
-        4. If |store| also uses [=in-line keys=], then run the
+        3. If |store| also uses [=in-line keys=], then run the
             steps to [=inject a key into a value using a key path=]
             with |value|, |key| and |store|'s [=object-store/key
             path=].
 
-    2. Otherwise, if the [=key/type=] of |key| is <i>number</i>
-        and the [=key/value=] is greater than or equal to the
-        [=key generator=]'s [=current number=], set the
-        [=current number=] to lowest integer greater than |key|.
+    2. Otherwise, run the steps to [=possibly update the key generator=]
+        for |store| with |key|.
 
 3. If the |no-overwrite flag| was given to these steps and is set, and
     a [=object-store/record=] already exists in |store| with its key [=equal to=]

--- a/index.bs
+++ b/index.bs
@@ -1501,7 +1501,7 @@ for records inserted into an object store if not otherwise specified.
 
 A [=key generator=] has a <dfn>current number</dfn>. The
 [=key generator/current number=] is always a positive integer less
-than or equal to 2<sup>53</sup> (9007199254740992). The initial value
+than or equal to 2<sup>53</sup> (9007199254740992) + 1. The initial value
 of a [=key generator=]'s [=key generator/current number=] is 1, set
 when the associated [=/object store=] is created. The
 [=key generator/current number=] is incremented as keys are generated,
@@ -1600,12 +1600,12 @@ be updated.
 </aside>
 
 When the [=key generator/current number=] of a key generator reaches above the
-value 2<sup>53</sup> (9007199254740992) any attempts to use the
+value 2<sup>53</sup> (9007199254740992) any subsequent attempts to use the
 key generator to generate a new [=/key=] will result in a
 "{{ConstraintError}}" {{DOMException}}. It is still possible to insert
 [=object-store/records=] into the object store by specifying an explicit
-key, however the only way to use a key generator again for the
-object store is to delete the object store and create a new one.
+key, however the only way to use a key generator again for such records
+is to delete the object store and create a new one.
 
 <aside class=note>
   This limit arises because integers greater than 9007199254740992

--- a/index.html
+++ b/index.html
@@ -2641,7 +2641,7 @@ stated otherwise it is unset.</p>
 for records inserted into an object store if not otherwise specified.</p>
    <div>
     <p>A <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-3">key generator</a> has a <dfn class="dfn-paneled" data-dfn-for="key generator" data-dfn-type="dfn" data-noexport="" id="key-generator-current-number">current number</dfn>. The <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-1">current number</a> is always a positive integer less
-than or equal to 2<sup>53</sup> (9007199254740992). The initial value
+than or equal to 2<sup>53</sup> (9007199254740992) + 1. The initial value
 of a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-4">key generator</a>'s <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-2">current number</a> is 1, set
 when the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-40">object store</a> is created. The <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-3">current number</a> is incremented as keys are generated,
 and may be updated to a specific value by using explicit keys.</p>
@@ -2717,11 +2717,11 @@ be updated.</p>
   number</a> of the key generator. Keys of <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-7">type</a> <i>number</i> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-5">value</a> less than 1 do not affect the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-16">current number</a> since they are always lower than the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-17">current number</a>.</p>
    </aside>
    <p>When the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-18">current number</a> of a key generator reaches above the
-value 2<sup>53</sup> (9007199254740992) any attempts to use the
+value 2<sup>53</sup> (9007199254740992) any subsequent attempts to use the
 key generator to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-39">key</a> will result in a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. It is still possible to insert <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-24">records</a> into the object store by specifying an explicit
-key, however the only way to use a key generator again for the
-object store is to delete the object store and create a new one.</p>
+key, however the only way to use a key generator again for such records
+is to delete the object store and create a new one.</p>
    <aside class="note">
      This limit arises because integers greater than 9007199254740992
   cannot be uniquely represented as ECMAScript <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type">Numbers</a>.

--- a/index.html
+++ b/index.html
@@ -2637,71 +2637,100 @@ whether the cursor’s <a data-link-type="dfn" href="#cursor-value" id="ref-for-
 stated otherwise it is unset.</p>
    </div>
    <h3 class="heading settled" data-level="2.11" id="key-generator-construct"><span class="secno">2.11. </span><span class="content">Key Generators</span><a class="self-link" href="#key-generator-construct"></a></h3>
-   <p>When a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-39">object store</a> is created it can be specified to use a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-generator">key generator</dfn>. A <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-3">key generator</a> keeps an internal <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-number">current number</dfn>. The <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-1">current number</a> is always a positive
-integer. Whenever the key generator is used to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-37">key</a>, the generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-2">current number</a> is returned and <strong>then</strong> incremented to prepare for the next time a new <a data-link-type="dfn" href="#key" id="ref-for-key-38">key</a> is needed. Implementations must use the following rules for
-generating numbers when a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-4">key generator</a> is used.</p>
-   <ul>
-    <li data-md="">
-     <p>Every object store that uses key generators use a separate
-generator. I.e. interacting with one object store never affects
-the key generator of any other object store.</p>
-    <li data-md="">
-     <p>The <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-3">current number</a> of a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-5">key generator</a> is always set to
-1 when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-40">object store</a> for that key generator is first
-created.</p>
-    <li data-md="">
-     <p>When a key generator is used to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-39">key</a> for
-a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-41">object store</a>, the key generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-4">current
-number</a> is used as the new key value and then the key
-generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-5">current number</a> is increased by 1.</p>
-    <li data-md="">
-     <p>When a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-18">record</a> is stored and a <a data-link-type="dfn" href="#key" id="ref-for-key-40">key</a> is specified
-in the call to store the record, if <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-4">type</a> of the key
-is <i>number</i> and the <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-4">value</a> is greater than or
-equal to the key generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-6">current number</a>, then the key
-generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-7">current number</a> is set to the smallest integer
-number <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-4">greater than</a> the explicit key. A key can be
-specified both for object stores which use <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-1">in-line keys</a>, by
-setting the property on the stored value which the object store’s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-2">key path</a> points to, and for object stores
-which use <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-1">out-of-line keys</a>, by passing a key argument to
-the call to store the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-19">record</a>.</p>
-     <aside class="note"> Only specified keys of <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-5">type</a> <i>number</i> may affect the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-8">current number</a> of the key generator. Keys of <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-6">type</a> <i>date</i>, <i>array</i> (regardless of the other keys they
-  contain), <i>binary</i>, or <i>string</i> (regardless of whether
-  they could be parsed as numbers) have no effect on the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-9">current
-  number</a> of the key generator. Keys of <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-7">type</a> <i>number</i> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-5">value</a> less than 1 do not affect the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-10">current number</a> since they are always lower than the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-11">current number</a>. </aside>
-    <li data-md="">
-     <p>Modifying a key generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-12">current number</a> is considered part
+   <p>When a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-39">object store</a> is created it can be specified to use a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-generator">key generator</dfn>. A key generator is used to generate keys
+for records inserted into an object store if not otherwise specified.</p>
+   <div>
+    <p>A <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-3">key generator</a> has a <dfn class="dfn-paneled" data-dfn-for="key generator" data-dfn-type="dfn" data-noexport="" id="key-generator-current-number">current number</dfn>. The <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-1">current number</a> is always a positive integer less
+than or equal to 2<sup>53</sup> (9007199254740992). The initial value
+of a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-4">key generator</a>'s <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-2">current number</a> is 1, set
+when the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-40">object store</a> is created. The <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-3">current number</a> is incremented as keys are generated,
+and may be updated to a specific value by using explicit keys.</p>
+   </div>
+   <aside class="note"> Every object store that uses key generators uses a separate
+  generator. That is, interacting with one object store never affects
+  the key generator of any other object store. </aside>
+   <p>Modifying a key generator’s <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-4">current number</a> is considered part
 of a database operation. This means that if the operation fails
-and the operation is reverted, the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-13">current number</a> is
+and the operation is reverted, the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-5">current number</a> is
 reverted to the value it had before the operation started. This
-applies both to modifications that happen due to the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-14">current
+applies both to modifications that happen due to the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-6">current
 number</a> getting increased by 1 when the key generator is used,
-and to modifications that happen due to a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-20">record</a> being
-stored with a key value specified in the call to store the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-21">record</a>.</p>
-    <li data-md="">
-     <p>Likewise, if a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-35">transaction</a> is aborted, the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-15">current
-number</a> of the key generator for each <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-42">object store</a> in
+and to modifications that happen due to a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-18">record</a> being
+stored with a key value specified in the call to store the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-19">record</a>.</p>
+   <p>Likewise, if a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-35">transaction</a> is aborted, the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-7">current
+number</a> of the key generator for each <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-41">object store</a> in
 the transaction’s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-11">scope</a> is reverted to the value it had
 before the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-36">transaction</a> was started.</p>
-    <li data-md="">
-     <p>When the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-16">current number</a> of a key generator reaches above the
-value 2<sup>53</sup> (9007199254740992) any attempts to use the
-key generator to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-41">key</a> will result in a
-"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. It is still possible to insert <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-22">records</a> into the object store by specifying an explicit
-key, however the only way to use a key generator again for the
-object store is to delete the object store and create a new one.</p>
-     <aside class="note"> As long as key generators are used in a normal fashion this will
-  not be a problem. If you generate a new key 1000 times per
-  second day and night, you won’t run into this limit for over
-  285000 years. </aside>
-    <li data-md="">
-     <p>The <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-17">current number</a> for a key generator never decreases, other
-than as a result of database operations being reverted. Deleting a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-23">record</a> from an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-43">object store</a> never affects the
+   <p>The <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-8">current number</a> for a key generator never decreases, other
+than as a result of database operations being reverted. Deleting a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-20">record</a> from an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-42">object store</a> never affects the
 object store’s key generator. Even clearing all records from an
 object store, for example using the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-clear" id="ref-for-dom-idbobjectstore-clear-1">clear()</a></code> method, does not
-affect the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-18">current number</a> of the object store’s key
+affect the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-9">current number</a> of the object store’s key
 generator.</p>
-   </ul>
+   <p>When a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-21">record</a> is stored and a <a data-link-type="dfn" href="#key" id="ref-for-key-37">key</a> is not specified
+in the call to store the record, a key is generated.</p>
+   <div class="algorithm">
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="generate-a-key">generate a key</dfn> for an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-43">object store</a> <var>store</var>, run the following steps:</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>generator</var> be the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-5">key generator</a> associated with <var>store</var>.</p>
+     <li data-md="">
+      <p>Let <var>key</var> be <var>generator</var>’s <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-10">current number</a>.</p>
+     <li data-md="">
+      <p>If <var>key</var> is greater than 2<sup>53</sup> (9007199254740992), then return failure.</p>
+     <li data-md="">
+      <p>Increase <var>generator</var>’s <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-11">current number</a> by 1.</p>
+     <li data-md="">
+      <p>Return <var>key</var>.</p>
+    </ol>
+   </div>
+   <p>When a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-22">record</a> is stored and a <a data-link-type="dfn" href="#key" id="ref-for-key-38">key</a> is specified
+in the call to store the record, the associated <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-6">key generator</a> may
+be updated.</p>
+   <div class="algorithm">
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="possibly-update-the-key-generator">possibly update the key generator</dfn> for an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-44">object store</a> <var>store</var> with <var>key</var>,
+  run the following steps:</p>
+    <ol>
+     <li data-md="">
+      <p>If the <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-4">type</a> of <var>key</var> is not <i>number</i>, abort these steps.</p>
+     <li data-md="">
+      <p>Let <var>value</var> be the <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-4">value</a> of <var>key</var>.</p>
+     <li data-md="">
+      <p>Let <var>value</var> be the minimum of <var>value</var> and 2<sup>53</sup> (9007199254740992).</p>
+     <li data-md="">
+      <p>Let <var>value</var> be the largest integer not greater than <var>value</var>.</p>
+     <li data-md="">
+      <p>Let <var>generator</var> be the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-7">key generator</a> associated with <var>store</var>.</p>
+     <li data-md="">
+      <p>If <var>value</var> is greater than or equal to <var>generator</var>’s <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-12">current number</a>,
+  then set <var>generator</var>’s <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-13">current number</a> to <var>value</var> + 1.</p>
+    </ol>
+   </div>
+   <aside class="note">
+     A key can be specified both for object stores which use <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-1">in-line keys</a>, by setting the property on the stored value
+  which the object store’s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-2">key path</a> points to,
+  and for object stores which use <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-1">out-of-line keys</a>, by passing
+  a key argument to the call to store the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-23">record</a>. 
+    <p>Only specified keys of <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-5">type</a> <i>number</i> may affect the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-14">current number</a> of the key generator. Keys of <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-6">type</a> <i>date</i>, <i>array</i> (regardless of the other keys they
+  contain), <i>binary</i>, or <i>string</i> (regardless of whether
+  they could be parsed as numbers) have no effect on the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-15">current
+  number</a> of the key generator. Keys of <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-7">type</a> <i>number</i> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-5">value</a> less than 1 do not affect the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-16">current number</a> since they are always lower than the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-17">current number</a>.</p>
+   </aside>
+   <p>When the <a data-link-type="dfn" href="#key-generator-current-number" id="ref-for-key-generator-current-number-18">current number</a> of a key generator reaches above the
+value 2<sup>53</sup> (9007199254740992) any attempts to use the
+key generator to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-39">key</a> will result in a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. It is still possible to insert <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-24">records</a> into the object store by specifying an explicit
+key, however the only way to use a key generator again for the
+object store is to delete the object store and create a new one.</p>
+   <aside class="note">
+     This limit arises because integers greater than 9007199254740992
+  cannot be uniquely represented as ECMAScript <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type">Numbers</a>.
+  As an example, <code>9007199254740992 + 1 === 9007199254740992</code> in ECMAScript. 
+    <p>As long as key generators are used in a normal fashion this limit will
+  not be a problem. If you generate a new key 1000 times per
+  second day and night, you won’t run into this limit for over
+  285000 years.</p>
+   </aside>
    <p>A practical result of this is that the first key generated for an
 object store is always 1 (unless a higher numeric key is inserted
 first) and the key generated for an object store is always a positive
@@ -2777,20 +2806,20 @@ store_t2<span class="p">.</span>put<span class="p">(</span><span class="s2">"c"<
    <aside class="example" id="example-bfe51756">
     <a class="self-link" href="#example-bfe51756"></a> 
     <p>The following examples illustrate the different behaviors when trying
-to use in-line <a data-link-type="dfn" href="#key" id="ref-for-key-42">keys</a> and <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-6">key generators</a> to save an object
-to an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-44">object store</a>.</p>
+to use in-line <a data-link-type="dfn" href="#key" id="ref-for-key-40">keys</a> and <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-8">key generators</a> to save an object
+to an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-45">object store</a>.</p>
     <p>If the following conditions are true:</p>
     <ul>
      <li data-md="">
-      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-45">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-7">key generator</a>.</p>
+      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-46">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-9">key generator</a>.</p>
      <li data-md="">
       <p>There is no in-line value for the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-3">key path</a> property.</p>
     </ul>
-    <p>Then the value provided by the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-8">key generator</a> is used to populate
+    <p>Then the value provided by the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-10">key generator</a> is used to populate
 the key value. In the example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-4">key path</a> for
 the object store is "<code>foo.bar</code>". The actual object has no
 value for the <code>bar</code> property, <code>{ foo: {} }</code>.
-When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-46">object store</a> the <code>bar</code> property is assigned a value of 1 because that is the next <a data-link-type="dfn" href="#key" id="ref-for-key-43">key</a> generated by the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-9">key generator</a>.</p>
+When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-47">object store</a> the <code>bar</code> property is assigned a value of 1 because that is the next <a data-link-type="dfn" href="#key" id="ref-for-key-41">key</a> generated by the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-11">key generator</a>.</p>
 <pre class="lang-javascript highlight"><span class="kd">var</span> store <span class="o">=</span> db<span class="p">.</span>createObjectStore<span class="p">(</span><span class="s2">"store"</span><span class="p">,</span> <span class="p">{</span> keyPath<span class="o">:</span> <span class="s2">"foo.bar"</span><span class="p">,</span>
                                             autoIncrement<span class="o">:</span> <span class="kc">true</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
 store<span class="p">.</span>put<span class="p">(</span><span class="p">{</span> foo<span class="o">:</span> <span class="p">{</span><span class="p">}</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span>onsuccess <span class="o">=</span> <span class="kd">function</span><span class="p">(</span>e<span class="p">)</span> <span class="p">{</span>
@@ -2801,15 +2830,15 @@ store<span class="p">.</span>put<span class="p">(</span><span class="p">{</span>
     <p>If the following conditions are true:</p>
     <ul>
      <li data-md="">
-      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-47">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-10">key generator</a>.</p>
+      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-48">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-12">key generator</a>.</p>
      <li data-md="">
       <p>There is a value for the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-5">key path</a> property.</p>
     </ul>
-    <p>Then the value associated with the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-6">key path</a> property is used. The auto-generated <a data-link-type="dfn" href="#key" id="ref-for-key-44">key</a> is not used. In the
-example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-7">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-48">object
+    <p>Then the value associated with the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-6">key path</a> property is used. The auto-generated <a data-link-type="dfn" href="#key" id="ref-for-key-42">key</a> is not used. In the
+example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-7">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-49">object
 store</a> is "<code>foo.bar</code>". The actual object has a value of
 10 for the <code>bar</code> property, <code>{ foo: { bar: 10}
-}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-49">object store</a> the <code>bar</code> property keeps its value of 10, because that is the
+}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-50">object store</a> the <code>bar</code> property keeps its value of 10, because that is the
 key value.</p>
 <pre class="lang-javascript highlight"><span class="kd">var</span> store <span class="o">=</span> db<span class="p">.</span>createObjectStore<span class="p">(</span><span class="s2">"store"</span><span class="p">,</span> <span class="p">{</span> keyPath<span class="o">:</span> <span class="s2">"foo.bar"</span><span class="p">,</span>
                                             autoIncrement<span class="o">:</span> <span class="kc">true</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
@@ -2819,14 +2848,14 @@ store<span class="p">.</span>put<span class="p">(</span><span class="p">{</span>
 <span class="p">}</span><span class="p">;</span>
 </pre>
     <p>The following example illustrates the scenario when the specified
-in-line <a data-link-type="dfn" href="#key" id="ref-for-key-45">key</a> is defined through a <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-8">key
+in-line <a data-link-type="dfn" href="#key" id="ref-for-key-43">key</a> is defined through a <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-8">key
 path</a> but there is no property matching it. The value provided by
-the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-11">key generator</a> is then used to populate the key value and
+the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-13">key generator</a> is then used to populate the key value and
 the system is responsible for creating as many properties as it
 requires to suffice the property dependencies on the hierarchy chain.
-In the example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-9">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-50">object store</a> is "<code>foo.bar.baz</code>". The actual
+In the example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-9">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-51">object store</a> is "<code>foo.bar.baz</code>". The actual
 object has no value for the <code>foo</code> property, <code>{ zip: {}
-}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-51">object store</a> the <code>foo</code>, <code>bar</code>, and <code>baz</code> properties are created each as a child of the other until a value for <code>foo.bar.baz</code> can be assigned. The value for <code>foo.bar.baz</code> is the next key generated by the object
+}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-52">object store</a> the <code>foo</code>, <code>bar</code>, and <code>baz</code> properties are created each as a child of the other until a value for <code>foo.bar.baz</code> can be assigned. The value for <code>foo.bar.baz</code> is the next key generated by the object
 store.</p>
 <pre class="lang-javascript highlight"><span class="kd">var</span> store <span class="o">=</span> db<span class="p">.</span>createObjectStore<span class="p">(</span><span class="s2">"store"</span><span class="p">,</span> <span class="p">{</span> keyPath<span class="o">:</span> <span class="s2">"foo.bar.baz"</span><span class="p">,</span>
                                             autoIncrement<span class="o">:</span> <span class="kc">true</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
@@ -3185,9 +3214,9 @@ null.</p>
     <dl class="domintro">
      <dt><var>result</var> = indexedDB . <code class="idl"><a data-link-type="idl" href="#dom-idbfactory-cmp" id="ref-for-dom-idbfactory-cmp-2">cmp</a></code>(<var>key1</var>, <var>key2</var>)
      <dd>
-       Compares two values as <a data-link-type="dfn" href="#key" id="ref-for-key-46">keys</a>. Returns -1 if <var>key1</var> precedes <var>key2</var>, 1 if <var>key2</var> precedes <var>key1</var>, and 0 if
+       Compares two values as <a data-link-type="dfn" href="#key" id="ref-for-key-44">keys</a>. Returns -1 if <var>key1</var> precedes <var>key2</var>, 1 if <var>key2</var> precedes <var>key1</var>, and 0 if
         the keys are equal. 
-      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if either input is not a valid <a data-link-type="dfn" href="#key" id="ref-for-key-47">key</a>.</p>
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if either input is not a valid <a data-link-type="dfn" href="#key" id="ref-for-key-45">key</a>.</p>
     </dl>
    </div>
    <div class="algorithm">
@@ -3260,22 +3289,22 @@ must return this <a data-link-type="dfn" href="#connection" id="ref-for-connecti
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-2">objectStoreNames</a></code>
-     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-52">object stores</a> in the database. 
+     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-53">object stores</a> in the database. 
      <dt><var>store</var> = <var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-2">createObjectStore</a></code>(<var>name</var> [, <var>options</var>])
      <dd>
-       Creates a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-53">object store</a> with the given <var>name</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-4">IDBObjectStore</a></code>. 
+       Creates a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-54">object store</a> with the given <var>name</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-4">IDBObjectStore</a></code>. 
       <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-20">upgrade transaction</a>.</p>
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-deleteobjectstore" id="ref-for-dom-idbdatabase-deleteobjectstore-2">deleteObjectStore</a></code>(<var>name</var>)
      <dd>
-       Deletes the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-54">object store</a> with the given <var>name</var>. 
+       Deletes the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-55">object store</a> with the given <var>name</var>. 
       <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-21">upgrade transaction</a>.</p>
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-objectstorenames">objectStoreNames</dfn> attribute’s
 getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-1">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-2">names</a> of
-the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-55">object stores</a> in this <a data-link-type="dfn" href="#connection" id="ref-for-connection-44">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-1">object store set</a>.</p>
+the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-56">object stores</a> in this <a data-link-type="dfn" href="#connection" id="ref-for-connection-44">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-1">object store set</a>.</p>
    <aside class="note"> As long as the <a data-link-type="dfn" href="#connection" id="ref-for-connection-45">connection</a> is open, this is the same as the
-  connected <a data-link-type="dfn" href="#database" id="ref-for-database-43">database</a>'s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-56">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-3">names</a>.
+  connected <a data-link-type="dfn" href="#database" id="ref-for-database-43">database</a>'s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-57">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-3">names</a>.
   Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-46">connection</a> has <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-4">closed</a>, this attribute
   will not reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-22">upgrade transaction</a>. </aside>
    <div class="algorithm">
@@ -3294,7 +3323,7 @@ the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-55">ob
       <p>If <var>keyPath</var> is not null and is not a <a data-link-type="dfn" href="#valid-key-path" id="ref-for-valid-key-path-1">valid key
 path</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-57">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-4">named</a> <var>name</var> already
+      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-58">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-4">named</a> <var>name</var> already
 exists in <var>database</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>autoIncrement</var> be set if <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstoreparameters-autoincrement" id="ref-for-dom-idbobjectstoreparameters-autoincrement-1">autoIncrement</a></code> member is true, or
@@ -3304,26 +3333,26 @@ unset otherwise.</p>
 sequence (empty or otherwise), <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-58">object store</a> in <var>database</var>. Set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-59">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-5">name</a> to <var>name</var>. If <var>autoIncrement</var> is set, then the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-60">object
-store</a> uses a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-12">key generator</a>. If <var>keyPath</var> is
-not null, set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-61">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-11">key path</a> to <var>keyPath</var>.</p>
+      <p>Let <var>store</var> be a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-59">object store</a> in <var>database</var>. Set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-60">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-5">name</a> to <var>name</var>. If <var>autoIncrement</var> is set, then the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-61">object
+store</a> uses a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-14">key generator</a>. If <var>keyPath</var> is
+not null, set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-62">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-11">key path</a> to <var>keyPath</var>.</p>
      <li data-md="">
       <p>Return a new <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-8">object store handle</a> associated with <var>store</var> and <var>transaction</var>.</p>
     </ol>
    </div>
-   <p>This method creates and returns a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-62">object store</a> with the given
+   <p>This method creates and returns a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-63">object store</a> with the given
 name in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-48">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-45">database</a>. Note that this method must
 only be called from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-24">upgrade transaction</a>.</p>
    <p>This method synchronously modifies the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-3">objectStoreNames</a></code> property on the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-7">IDBDatabase</a></code> instance on which it was called.</p>
    <p>In some implementations it is possible for the implementation to run
-into problems after queuing a task to create the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-63">object store</a> after the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-3">createObjectStore()</a></code> method has returned. For example in
-implementations where metadata about the newly created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-64">object
+into problems after queuing a task to create the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-64">object store</a> after the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-3">createObjectStore()</a></code> method has returned. For example in
+implementations where metadata about the newly created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-65">object
 store</a> is inserted into the database asynchronously, or where the
 implementation might need to ask the user for permission for quota
 reasons. Such implementations must still create and return an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-5">IDBObjectStore</a></code> object, and once the implementation determines that
-creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-65">object store</a> has failed, it must abort the
+creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-66">object store</a> has failed, it must abort the
 transaction using the steps to <a data-link-type="dfn" href="#abort-a-transaction" id="ref-for-abort-a-transaction-3">abort a transaction</a> using the
-appropriate error. For example if creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-66">object store</a> failed due to quota reasons, a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as
+appropriate error. For example if creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-67">object store</a> failed due to quota reasons, a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as
 error.</p>
    <div class="algorithm">
     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="method" data-export="" id="dom-idbdatabase-deleteobjectstore">deleteObjectStore(<var>name</var>)</dfn> method, when invoked, must run these steps:</p>
@@ -3336,7 +3365,7 @@ error.</p>
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-7">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-67">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-6">named</a> <var>name</var> in <var>database</var>,
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-68">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-6">named</a> <var>name</var> in <var>database</var>,
 or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
       <p>Remove <var>store</var> from this <a data-link-type="dfn" href="#connection" id="ref-for-connection-50">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-2">object
@@ -3347,14 +3376,14 @@ store set</a>.</p>
       <p>Destroy <var>store</var>.</p>
     </ol>
    </div>
-   <p>This method destroys the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-68">object store</a> with the given name in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-51">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-47">database</a>. Note that this method must only be called
+   <p>This method destroys the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-69">object store</a> with the given name in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-51">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-47">database</a>. Note that this method must only be called
 from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-26">upgrade transaction</a>.</p>
    <p>This method synchronously modifies the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-4">objectStoreNames</a></code> property on the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-8">IDBDatabase</a></code> instance on which it was called.</p>
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>transaction</var> = <var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-4">transaction</a></code>(<var>scope</var> [, <var>mode</var> = "readonly"])
      <dd> Returns a new <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-37">transaction</a> with the given <var>mode</var> (<code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-3">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-4">"readwrite"</a></code>)
-        and <var>scope</var> which can be a single <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-69">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-7">name</a> or an array of <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-8">names</a>. 
+        and <var>scope</var> which can be a single <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-70">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-7">name</a> or an array of <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-8">names</a>. 
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-close" id="ref-for-dom-idbdatabase-close-3">close</a></code>()
      <dd> Closes the <a data-link-type="dfn" href="#connection" id="ref-for-connection-52">connection</a> once all running <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-38">transactions</a> have finished. 
     </dl>
@@ -3374,13 +3403,13 @@ from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-u
       <p>Let <var>scope</var> be the set of unique strings in <var>storeNames</var> if it is a
 sequence, or a set containing one string equal to <var>storeNames</var> otherwise.</p>
      <li data-md="">
-      <p>If any string in <var>scope</var> is not the name of an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-70">object
+      <p>If any string in <var>scope</var> is not the name of an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-71">object
 store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-53">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-48">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>scope</var> is empty, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be a newly <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-3">created</a> <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-39">transaction</a> with <var>connection</var>, <var>mode</var> and the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-71">object stores</a> named in <var>scope</var>.</p>
+      <p>Let <var>transaction</var> be a newly <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-3">created</a> <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-39">transaction</a> with <var>connection</var>, <var>mode</var> and the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-72">object stores</a> named in <var>scope</var>.</p>
      <li data-md="">
       <p>Set <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-cleanup-event-loop" id="ref-for-transaction-cleanup-event-loop-3">cleanup event loop</a> to the
 current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>.</p>
@@ -3465,13 +3494,13 @@ the event handler for the <code>versionchange</code> event.</p>
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-transaction" id="ref-for-dom-idbobjectstore-transaction-2">transaction</a></code>
      <dd> Returns the associated <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-40">transaction</a>. 
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-autoincrement" id="ref-for-dom-idbobjectstore-autoincrement-2">autoIncrement</a></code>
-     <dd> Returns true if the store has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-13">key generator</a>, and false otherwise. 
+     <dd> Returns true if the store has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-15">key generator</a>, and false otherwise. 
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-name">name</dfn> attribute’s getter
 must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-11">object store handle</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-11">name</a>.</p>
    <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-41">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-7">finished</a>,
-  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-72">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-12">name</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-42">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-8">finished</a>, this attribute will not reflect changes made with a
+  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-73">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-12">name</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-42">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-8">finished</a>, this attribute will not reflect changes made with a
   later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-29">upgrade transaction</a>. </aside>
    <div class="algorithm">
     <p>The <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-4">name</a></code> attribute’s setter must run these steps:</p>
@@ -3492,7 +3521,7 @@ must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for
       <p>If <var>store</var>’s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-13">name</a> is equal to <var>name</var>,
 terminate these steps.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-73">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-14">named</a> <var>name</var> already exists in <var>store</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-49">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-74">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-14">named</a> <var>name</var> already exists in <var>store</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-49">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Set <var>store</var>’s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-15">name</a> to <var>name</var>.</p>
@@ -3510,20 +3539,20 @@ path</a>, or null if none.</p>
    <p>The conversion is done following the normal <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> binding logic
 for <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> values, as
 appropriate.</p>
-   <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-74">object store</a> was created. However, if this attribute returns
+   <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-75">object store</a> was created. However, if this attribute returns
 an object (specifically an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>), it returns the same object
 instance every time it is inspected. Changing the properties of the
-object has no effect on the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-75">object store</a>.</p>
+object has no effect on the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-76">object store</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-indexnames">indexNames</dfn> attribute’s
 getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-2">sorted list</a> of the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-2">names</a> of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-20">indexes</a> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-16">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-2">index set</a>.</p>
    <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-43">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-9">finished</a>,
-  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-76">object store</a>'s list
+  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-77">object store</a>'s list
   of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-21">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-3">names</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-44">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-10">finished</a>, this attribute will not
   reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-31">upgrade transaction</a>. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-transaction">transaction</dfn> attribute’s
 getter must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-17">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-3">transaction</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-autoincrement">autoIncrement</dfn> attribute’s
-getter must return true if this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-18">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-5">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-14">key generator</a>,
+getter must return true if this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-18">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-5">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-16">key generator</a>,
 and false otherwise.</p>
    <div class="note" role="note">
      The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called within a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-9">read-only transaction</a>, and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if
@@ -3532,19 +3561,19 @@ and false otherwise.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-put" id="ref-for-dom-idbobjectstore-put-2">put</a></code>(<var>value</var> [, <var>key</var>]) 
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-add" id="ref-for-dom-idbobjectstore-add-2">add</a></code>(<var>value</var> [, <var>key</var>]) 
      <dd>
-       Adds or updates a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-24">record</a> in <var>store</var> with the given <var>value</var> and <var>key</var>. If the store uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-2">in-line keys</a>, then <var>key</var> must
+       Adds or updates a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-25">record</a> in <var>store</var> with the given <var>value</var> and <var>key</var>. If the store uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-2">in-line keys</a>, then <var>key</var> must
        not be specified, or a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> will be thrown. 
-      <p>If <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-put" id="ref-for-dom-idbobjectstore-put-3">put()</a></code> is used, any existing <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-25">record</a> with the <a data-link-type="dfn" href="#key" id="ref-for-key-48">key</a> will be replaced. If <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-add" id="ref-for-dom-idbobjectstore-add-3">add()</a></code> is used, and if a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-26">record</a> with the <a data-link-type="dfn" href="#key" id="ref-for-key-49">key</a> already exists
+      <p>If <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-put" id="ref-for-dom-idbobjectstore-put-3">put()</a></code> is used, any existing <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-26">record</a> with the <a data-link-type="dfn" href="#key" id="ref-for-key-46">key</a> will be replaced. If <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-add" id="ref-for-dom-idbobjectstore-add-3">add()</a></code> is used, and if a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-27">record</a> with the <a data-link-type="dfn" href="#key" id="ref-for-key-47">key</a> already exists
        the <var>request</var> will fail, with <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-error" id="ref-for-dom-idbrequest-error-3">error</a></code> set to a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-6">result</a></code> will be the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-27">record</a>'s <a data-link-type="dfn" href="#key" id="ref-for-key-50">key</a>.</p>
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-6">result</a></code> will be the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-28">record</a>'s <a data-link-type="dfn" href="#key" id="ref-for-key-48">key</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-delete" id="ref-for-dom-idbobjectstore-delete-2">delete</a></code>(<var>query</var>) 
      <dd>
-       Deletes <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-28">records</a> in <var>store</var> with the given <a data-link-type="dfn" href="#key" id="ref-for-key-51">key</a> or in the given <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-20">key range</a> in <var>query</var>. 
+       Deletes <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-29">records</a> in <var>store</var> with the given <a data-link-type="dfn" href="#key" id="ref-for-key-49">key</a> or in the given <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-20">key range</a> in <var>query</var>. 
       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-7">result</a></code> will
        be <code>undefined</code>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-clear" id="ref-for-dom-idbobjectstore-clear-4">clear</a></code>() 
      <dd>
-       Deletes all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-29">records</a> in <var>store</var>. 
+       Deletes all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-30">records</a> in <var>store</var>. 
       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-8">result</a></code> will
        be <code>undefined</code>.</p>
     </dl>
@@ -3566,7 +3595,7 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-3">in-line keys</a> and <var>key</var> was given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-2">out-of-line keys</a> and has no <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-15">key
+      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-2">out-of-line keys</a> and has no <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-17">key
 generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
@@ -3597,7 +3626,7 @@ exceptions.</p>
        <li data-md="">
         <p>If <var>kpk</var> is not failure, let <var>key</var> be <var>kpk</var>.</p>
        <li data-md="">
-        <p>Otherwise, if <var>store</var> does not have a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-16">key
+        <p>Otherwise, if <var>store</var> does not have a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-18">key
 generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
@@ -3627,7 +3656,7 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-5">in-line keys</a> and <var>key</var> was given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-3">out-of-line keys</a> and has no <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-17">key
+      <p>If <var>store</var> uses <a data-link-type="dfn" href="#object-store-out-of-line-keys" id="ref-for-object-store-out-of-line-keys-3">out-of-line keys</a> and has no <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-19">key
 generator</a> and <var>key</var> was not given, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
@@ -3658,7 +3687,7 @@ exceptions.</p>
        <li data-md="">
         <p>If <var>kpk</var> is not failure, let <var>key</var> be <var>kpk</var>.</p>
        <li data-md="">
-        <p>Otherwise, if <var>store</var> does not have a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-18">key
+        <p>Otherwise, if <var>store</var> does not have a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-20">key
 generator</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
@@ -3694,7 +3723,7 @@ run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-ob
 the steps to <a data-link-type="dfn" href="#delete-records-from-an-object-store" id="ref-for-delete-records-from-an-object-store-1">delete records from an object store</a> as <var>operation</var>, using <var>store</var> and <var>range</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-52">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-1">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-30">records</a> keys to be
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-50">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-1">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-31">records</a> keys to be
 deleted.</p>
    <aside class="note"> Unlike other methods which take keys or key ranges, this method does <strong>not</strong> allow null to be given as key. This is to
   reduce the risk that a small bug would clear a whole object store. </aside>
@@ -3726,30 +3755,30 @@ the steps to <a data-link-type="dfn" href="#clear-an-object-store" id="ref-for-c
      <dl class="domintro">
       <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-get" id="ref-for-dom-idbobjectstore-get-2">get</a></code>(<var>query</var>) 
       <dd>
-        Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-10">value</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-31">record</a> matching the
-       given <a data-link-type="dfn" href="#key" id="ref-for-key-53">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-21">key range</a> in <var>query</var>. 
-       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-9">result</a></code> will be the <a data-link-type="dfn" href="#value" id="ref-for-value-11">value</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-32">record</a>.</p>
+        Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-10">value</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-32">record</a> matching the
+       given <a data-link-type="dfn" href="#key" id="ref-for-key-51">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-21">key range</a> in <var>query</var>. 
+       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-9">result</a></code> will be the <a data-link-type="dfn" href="#value" id="ref-for-value-11">value</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-33">record</a>.</p>
       <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-getkey" id="ref-for-dom-idbobjectstore-getkey-2">getKey</a></code>(<var>query</var>) 
       <dd>
-        Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-54">key</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-33">record</a> matching the
-       given <a data-link-type="dfn" href="#key" id="ref-for-key-55">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-22">key range</a> in <var>query</var>. 
-       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-10">result</a></code> will be the <a data-link-type="dfn" href="#key" id="ref-for-key-56">key</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-34">record</a>.</p>
+        Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-52">key</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-34">record</a> matching the
+       given <a data-link-type="dfn" href="#key" id="ref-for-key-53">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-22">key range</a> in <var>query</var>. 
+       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-10">result</a></code> will be the <a data-link-type="dfn" href="#key" id="ref-for-key-54">key</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-35">record</a>.</p>
       <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-getall" id="ref-for-dom-idbobjectstore-getall-2">getAll</a></code>(<var>query</var> [, <var>count</var>]) 
       <dd>
-        Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-12">values</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-35">records</a> matching the
-       given <a data-link-type="dfn" href="#key" id="ref-for-key-57">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-23">key range</a> in <var>query</var> (up to <var>count</var> if given). 
+        Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-12">values</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-36">records</a> matching the
+       given <a data-link-type="dfn" href="#key" id="ref-for-key-55">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-23">key range</a> in <var>query</var> (up to <var>count</var> if given). 
        <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-11">result</a></code> will
        be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> of the <a data-link-type="dfn" href="#value" id="ref-for-value-13">values</a>.</p>
       <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-getallkeys" id="ref-for-dom-idbobjectstore-getallkeys-2">getAllKeys</a></code>(<var>query</var> [, <var>count</var>]) 
       <dd>
-        Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-58">keys</a> of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-36">records</a> matching the
-       given <a data-link-type="dfn" href="#key" id="ref-for-key-59">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-24">key range</a> in <var>query</var> (up to <var>count</var> if given). 
+        Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-56">keys</a> of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-37">records</a> matching the
+       given <a data-link-type="dfn" href="#key" id="ref-for-key-57">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-24">key range</a> in <var>query</var> (up to <var>count</var> if given). 
        <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-12">result</a></code> will
-       be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> of the <a data-link-type="dfn" href="#key" id="ref-for-key-60">keys</a>.</p>
+       be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> of the <a data-link-type="dfn" href="#key" id="ref-for-key-58">keys</a>.</p>
       <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-count" id="ref-for-dom-idbobjectstore-count-2">count</a></code>(<var>query</var>) 
       <dd>
-        Retrieves the number of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-37">records</a> matching the
-       given <a data-link-type="dfn" href="#key" id="ref-for-key-61">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-25">key range</a> in <var>query</var>. 
+        Retrieves the number of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-38">records</a> matching the
+       given <a data-link-type="dfn" href="#key" id="ref-for-key-59">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-25">key range</a> in <var>query</var>. 
        <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-13">result</a></code> will be the count.</p>
      </dl>
     </div>
@@ -3775,7 +3804,7 @@ invoked, must run these steps:</p>
   an object store</a> as <var>operation</var>, using the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, <var>store</var> and <var>range</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-62">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-2">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-38">record</a> to be retrieved. If a
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-60">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-2">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-39">record</a> to be retrieved. If a
 range is specified, the method retrieves the first existing value in
 that range.</p>
    <aside class="note"> This method produces the same result if a record with the given key
@@ -3806,7 +3835,7 @@ invoked, must run these steps:</p>
   object store</a> as <var>operation</var>, using <var>store</var> and <var>range</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-63">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-3">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-39">record</a> key to be
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-61">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-3">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-40">record</a> key to be
 retrieved. If a range is specified, the method retrieves
 the first existing key in that range.</p>
    <aside class="advisement"> 🚧
@@ -3837,7 +3866,7 @@ run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-ob
 steps to <a data-link-type="dfn" href="#retrieve-multiple-values-from-an-object-store" id="ref-for-retrieve-multiple-values-from-an-object-store-1">retrieve multiple values from an object store</a> as <var>operation</var>, using the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, <var>store</var>, <var>range</var>, and <var>count</var> if given.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-64">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-4">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-40">records</a> to be retrieved. If null or not given,
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-62">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-4">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-41">records</a> to be retrieved. If null or not given,
 an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-3">unbounded key range</a> is used. If <var>count</var> is specified and
 there are more than <var>count</var> records in range, only the first <var>count</var> will be retrieved.</p>
    <aside class="advisement"> 🚧
@@ -3867,7 +3896,7 @@ run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-ob
 steps to <a data-link-type="dfn" href="#retrieve-multiple-keys-from-an-object-store" id="ref-for-retrieve-multiple-keys-from-an-object-store-1">retrieve multiple keys from an object store</a> as <var>operation</var>, using <var>store</var>, <var>range</var>, and <var>count</var> if given.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-65">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-5">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-41">records</a> keys to be retrieved. If null or not
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-63">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-5">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-42">records</a> keys to be retrieved. If null or not
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-4">unbounded key range</a> is used. If <var>count</var> is specified
 and there are more than <var>count</var> keys in range, only the first <var>count</var> will be retrieved.</p>
    <aside class="advisement"> 🚧
@@ -3898,7 +3927,7 @@ run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-ob
 steps to <a data-link-type="dfn" href="#count-the-records-in-a-range" id="ref-for-count-the-records-in-a-range-1">count the records in a range</a> as <var>operation</var>, with <var>source</var> and <var>range</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-66">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-6">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-42">records</a> keys to be counted. If null or not
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-64">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-6">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-43">records</a> keys to be counted. If null or not
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-5">unbounded key range</a> is used.</p>
    <div class="note" role="note">
      The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
@@ -3906,14 +3935,14 @@ given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unboun
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-opencursor" id="ref-for-dom-idbobjectstore-opencursor-3">openCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
      <dd>
-       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-16">cursor</a> over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-43">records</a> matching <var>query</var>,
-       ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-44">records</a> in <var>store</var> are matched. 
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-14">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursorwithvalue" id="ref-for-idbcursorwithvalue-1">IDBCursorWithValue</a></code> pointing at the first matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-45">record</a>, or null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-46">records</a>.</p>
+       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-16">cursor</a> over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-44">records</a> matching <var>query</var>,
+       ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-45">records</a> in <var>store</var> are matched. 
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-14">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursorwithvalue" id="ref-for-idbcursorwithvalue-1">IDBCursorWithValue</a></code> pointing at the first matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-46">record</a>, or null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-47">records</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-openkeycursor" id="ref-for-dom-idbobjectstore-openkeycursor-2">openKeyCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
      <dd>
-       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-17">cursor</a> with <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-1">key only flag</a> set over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-47">records</a> matching <var>query</var>, ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-48">records</a> in <var>store</var> are matched. 
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-15">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-3">IDBCursor</a></code> pointing at the first matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-49">record</a>, or
-       null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-50">records</a>.</p>
+       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-17">cursor</a> with <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-1">key only flag</a> set over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-48">records</a> matching <var>query</var>, ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-49">records</a> in <var>store</var> are matched. 
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-15">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-3">IDBCursor</a></code> pointing at the first matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-50">record</a>, or
+       null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-51">records</a>.</p>
     </dl>
    </div>
    <div class="algorithm">
@@ -3943,7 +3972,7 @@ steps to <a data-link-type="dfn" href="#iterate-a-cursor" id="ref-for-iterate-a-
 the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, and <var>cursor</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-67">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-7">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-19">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-4">range</a>.
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-65">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-7">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-19">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-4">range</a>.
 If null or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-6">unbounded key range</a> is used.</p>
    <div class="algorithm">
     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="method" data-export="" data-lt="openKeyCursor(query, direction)|openKeyCursor(query)|openKeyCursor()" id="dom-idbobjectstore-openkeycursor">openKeyCursor(<var>query</var>, <var>direction</var>)</dfn> method, when invoked, must run these steps:</p>
@@ -3973,7 +4002,7 @@ the steps to <a data-link-type="dfn" href="#iterate-a-cursor" id="ref-for-iterat
 using the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, and <var>cursor</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-68">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-8">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-21">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-6">range</a>. If null
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-66">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-8">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-21">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-6">range</a>. If null
 or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-7">unbounded key range</a> is used.</p>
    <aside class="advisement"> 🚧
   The <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-openkeycursor" id="ref-for-dom-idbobjectstore-openkeycursor-3">openKeyCursor()</a></code> method is new in this edition.
@@ -4037,7 +4066,7 @@ set, set <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-fl
     </ol>
    </div>
    <p>This method creates and returns a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-27">index</a> with the
-given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-77">object store</a>. Note that this method
+given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-78">object store</a>. Note that this method
 must only be called from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-36">upgrade transaction</a>.</p>
    <p>The index that is requested to be created can contain constraints on
 the data allowed in the index’s <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-7">referenced</a> object store, such
@@ -4129,7 +4158,7 @@ when invoked, must run these steps:</p>
       <p>Destroy <var>index</var>.</p>
     </ol>
    </div>
-   <p>This method destroys the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-31">index</a> with the given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-78">object store</a>. Note that this method must only be called from
+   <p>This method destroys the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-31">index</a> with the given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-79">object store</a>. Note that this method must only be called from
 within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-40">upgrade transaction</a>.</p>
    <p>This method synchronously modifies the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-4">indexNames</a></code> property on the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-13">IDBObjectStore</a></code> instance on which it was called.
 Although this method does not return an <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-30">IDBRequest</a></code> object, the
@@ -4198,12 +4227,12 @@ return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handl
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-25">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-79">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-80">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-12">name</a> is equal to <var>name</var>, terminate these steps.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-33">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-13">named</a> <var>name</var> already exists in <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-80">object
+      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-33">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-13">named</a> <var>name</var> already exists in <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-81">object
 store</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Set <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-14">name</a> to <var>name</var>.</p>
@@ -4239,25 +4268,25 @@ otherwise.</p>
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-get" id="ref-for-dom-idbindex-get-2">get</a></code>(<var>query</var>) 
      <dd>
-       Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-14">value</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-51">record</a> matching the
-       given <a data-link-type="dfn" href="#key" id="ref-for-key-69">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-26">key range</a> in <var>query</var>. 
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-16">result</a></code> will be the <a data-link-type="dfn" href="#value" id="ref-for-value-15">value</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-52">record</a>.</p>
+       Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-14">value</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-52">record</a> matching the
+       given <a data-link-type="dfn" href="#key" id="ref-for-key-67">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-26">key range</a> in <var>query</var>. 
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-16">result</a></code> will be the <a data-link-type="dfn" href="#value" id="ref-for-value-15">value</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-53">record</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-getkey" id="ref-for-dom-idbindex-getkey-2">getKey</a></code>(<var>query</var>) 
      <dd>
-       Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-70">key</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-53">record</a> matching the
-       given <a data-link-type="dfn" href="#key" id="ref-for-key-71">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-27">key range</a> in <var>query</var>. 
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-17">result</a></code> will be the <a data-link-type="dfn" href="#key" id="ref-for-key-72">key</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-54">record</a>.</p>
+       Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-68">key</a> of the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-54">record</a> matching the
+       given <a data-link-type="dfn" href="#key" id="ref-for-key-69">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-27">key range</a> in <var>query</var>. 
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-17">result</a></code> will be the <a data-link-type="dfn" href="#key" id="ref-for-key-70">key</a>, or <code>undefined</code> if there was no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-55">record</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-getall" id="ref-for-dom-idbindex-getall-2">getAll</a></code>(<var>query</var> [, <var>count</var>]) 
      <dd>
-       Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-16">values</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-55">records</a> matching the given <a data-link-type="dfn" href="#key" id="ref-for-key-73">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-28">key range</a> in <var>query</var> (up to <var>count</var> if given). 
+       Retrieves the <a data-link-type="dfn" href="#value" id="ref-for-value-16">values</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-56">records</a> matching the given <a data-link-type="dfn" href="#key" id="ref-for-key-71">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-28">key range</a> in <var>query</var> (up to <var>count</var> if given). 
       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-18">result</a></code> will be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> of the <a data-link-type="dfn" href="#value" id="ref-for-value-17">values</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-getallkeys" id="ref-for-dom-idbindex-getallkeys-2">getAllKeys</a></code>(<var>query</var> [, <var>count</var>]) 
      <dd>
-       Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-74">keys</a> of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-56">records</a> matching the given <a data-link-type="dfn" href="#key" id="ref-for-key-75">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-29">key range</a> in <var>query</var> (up to <var>count</var> if given). 
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-19">result</a></code> will be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> of the <a data-link-type="dfn" href="#key" id="ref-for-key-76">keys</a>.</p>
+       Retrieves the <a data-link-type="dfn" href="#key" id="ref-for-key-72">keys</a> of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-57">records</a> matching the given <a data-link-type="dfn" href="#key" id="ref-for-key-73">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-29">key range</a> in <var>query</var> (up to <var>count</var> if given). 
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-19">result</a></code> will be an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> of the <a data-link-type="dfn" href="#key" id="ref-for-key-74">keys</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-count" id="ref-for-dom-idbindex-count-2">count</a></code>(<var>query</var>) 
      <dd>
-       Retrieves the number of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-57">records</a> matching the given <a data-link-type="dfn" href="#key" id="ref-for-key-77">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-30">key range</a> in <var>query</var>. 
+       Retrieves the number of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-58">records</a> matching the given <a data-link-type="dfn" href="#key" id="ref-for-key-75">key</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-30">key range</a> in <var>query</var>. 
       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-20">result</a></code> will be the
        count.</p>
     </dl>
@@ -4271,7 +4300,7 @@ must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-18">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-6">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-81">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-82">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-27">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4285,7 +4314,7 @@ been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn
   the steps to <a data-link-type="dfn" href="#retrieve-a-referenced-value-from-an-index" id="ref-for-retrieve-a-referenced-value-from-an-index-1">retrieve a referenced value from an index</a> as <var>operation</var>, using the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, <var>index</var> and <var>range</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-78">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-9">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-58">record</a> to be retrieved. If a
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-76">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-9">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-59">record</a> to be retrieved. If a
 range is specified, the method retrieves the first existing record in
 that range.</p>
    <aside class="note"> This method produces the same result if a record with the given key
@@ -4302,7 +4331,7 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-21">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-7">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-82">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-83">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-28">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -4315,7 +4344,7 @@ return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-
 run with this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-22">index handle</a> as <var>source</var> and the steps to <a data-link-type="dfn" href="#retrieve-a-value-from-an-index" id="ref-for-retrieve-a-value-from-an-index-1">retrieve a value from an index</a> as <var>operation</var>, using <var>index</var> and <var>range</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-79">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-10">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-59">record</a> key to be retrieved.
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-77">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-10">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-60">record</a> key to be retrieved.
 If a range is specified, the method retrieves the first existing key
 in that range.</p>
    <div class="algorithm">
@@ -4327,7 +4356,7 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-24">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-8">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-83">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-84">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-29">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4341,7 +4370,7 @@ return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-
 run with this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-25">index handle</a> as <var>source</var> and the steps to <a data-link-type="dfn" href="#retrieve-multiple-referenced-values-from-an-index" id="ref-for-retrieve-multiple-referenced-values-from-an-index-1">retrieve multiple referenced values from an index</a> as <var>operation</var>, using the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, <var>index</var>, <var>range</var>, and <var>count</var> if given.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-80">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-11">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-60">records</a> to be retrieved. If null or not given,
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-78">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-11">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-61">records</a> to be retrieved. If null or not given,
 an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-8">unbounded key range</a> is used. If <var>count</var> is specified and
 there are more than <var>count</var> records in range, only the first <var>count</var> will be retrieved.</p>
    <aside class="advisement"> 🚧
@@ -4356,7 +4385,7 @@ there are more than <var>count</var> records in range, only the first <var>count
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-27">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-9">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-84">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-85">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-30">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4370,7 +4399,7 @@ return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-
 run with this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-28">index handle</a> as <var>source</var> and the steps to <a data-link-type="dfn" href="#retrieve-multiple-values-from-an-index" id="ref-for-retrieve-multiple-values-from-an-index-1">retrieve multiple values from an index</a> as <var>operation</var>, using <var>index</var>, <var>range</var>, and <var>count</var> if given.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-81">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-12">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-61">records</a> keys to be retrieved. If null or not
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-79">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-12">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-62">records</a> keys to be retrieved. If null or not
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-9">unbounded key range</a> is used. If <var>count</var> is specified
 and there are more than <var>count</var> keys in range, only the first <var>count</var> will be retrieved.</p>
    <aside class="advisement"> 🚧
@@ -4386,7 +4415,7 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-30">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-10">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-85">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-86">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-31">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4400,7 +4429,7 @@ return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-
 run with this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-31">index handle</a> as <var>source</var> and the steps to <a data-link-type="dfn" href="#count-the-records-in-a-range" id="ref-for-count-the-records-in-a-range-2">count the records in a range</a> as <var>operation</var>, with <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-36">index</a> as <var>source</var> and <var>range</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-82">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-13">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-62">records</a> keys to be counted. If null or not
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-80">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-13">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-63">records</a> keys to be counted. If null or not
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-10">unbounded key range</a> is used.</p>
    <div class="note" role="note">
      The following methods throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
@@ -4408,13 +4437,13 @@ given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unboun
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-opencursor" id="ref-for-dom-idbindex-opencursor-3">openCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
      <dd>
-       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-22">cursor</a> over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-63">records</a> matching <var>query</var>,
-       ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-64">records</a> in <var>index</var> are matched. 
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-21">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursorwithvalue" id="ref-for-idbcursorwithvalue-2">IDBCursorWithValue</a></code>, or null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-65">records</a>.</p>
+       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-22">cursor</a> over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-64">records</a> matching <var>query</var>,
+       ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-65">records</a> in <var>index</var> are matched. 
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-21">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursorwithvalue" id="ref-for-idbcursorwithvalue-2">IDBCursorWithValue</a></code>, or null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-66">records</a>.</p>
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-openkeycursor" id="ref-for-dom-idbindex-openkeycursor-2">openKeyCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
      <dd>
-       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-23">cursor</a> with <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-3">key only flag</a> set over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-66">records</a> matching <var>query</var>, ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-67">records</a> in <var>index</var> are matched. 
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-22">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-4">IDBCursor</a></code>, or null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-68">records</a>.</p>
+       Opens a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-23">cursor</a> with <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-3">key only flag</a> set over the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-67">records</a> matching <var>query</var>, ordered by <var>direction</var>. If <var>query</var> is null, all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-68">records</a> in <var>index</var> are matched. 
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-22">result</a></code> will be an <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-4">IDBCursor</a></code>, or null if there were no matching <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-69">records</a>.</p>
     </dl>
    </div>
    <div class="algorithm">
@@ -4425,7 +4454,7 @@ given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unboun
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-33">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-11">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-86">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-87">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-33">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -4441,7 +4470,7 @@ return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-
 run with this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-34">index handle</a> as <var>source</var> and the steps to <a data-link-type="dfn" href="#iterate-a-cursor" id="ref-for-iterate-a-cursor-3">iterate a cursor</a> as <var>operation</var>, using the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, and <var>cursor</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-83">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-14">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-25">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-8">range</a>. If null
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-81">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-14">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-25">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-8">range</a>. If null
 or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-11">unbounded key range</a> is used.</p>
    <div class="algorithm">
     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBIndex" data-dfn-type="method" data-export="" data-lt="openKeyCursor(query, direction)|openKeyCursor(query)|openKeyCursor()" id="dom-idbindex-openkeycursor">openKeyCursor(<var>query</var>, <var>direction</var>)</dfn> method, when invoked, must run these steps:</p>
@@ -4451,7 +4480,7 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-36">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-12">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-87">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-88">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-34">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4470,7 +4499,7 @@ run with this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-han
 steps to <a data-link-type="dfn" href="#iterate-a-cursor" id="ref-for-iterate-a-cursor-4">iterate a cursor</a> as <var>operation</var>, using the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current Realm</a> as <var>targetRealm</var>, and <var>cursor</var>.</p>
     </ol>
    </div>
-   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-84">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-15">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-27">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-10">range</a>. If null
+   <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-82">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-15">IDBKeyRange</a></code> to use as the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-27">cursor</a>'s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-10">range</a>. If null
 or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-12">unbounded key range</a> is used.</p>
    <h3 class="heading settled" data-level="4.7" id="keyrange"><span class="secno">4.7. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-16">IDBKeyRange</a></code> interface</span><a class="self-link" href="#keyrange"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-17">IDBKeyRange</a></code> interface represents a <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-31">key range</a>.</p>
@@ -4586,7 +4615,7 @@ value to a key</a> with <var>upper</var>. Rethrow any exceptions.</p>
      <li data-md="">
       <p>If <var>upperKey</var> is invalid, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>lowerKey</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-5">greater than</a> <var>upperKey</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+      <p>If <var>lowerKey</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-4">greater than</a> <var>upperKey</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Create and return a new <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-35">key range</a> with <a data-link-type="dfn" href="#lower-bound" id="ref-for-lower-bound-12">lower bound</a> set to <var>lowerKey</var>, <a data-link-type="dfn" href="#lower-open-flag" id="ref-for-lower-open-flag-8">lower open flag</a> set if <var>lowerOpen</var> is
@@ -4684,22 +4713,22 @@ does not modify the contents of the database.</p>
    <div class="note" role="note">
      The following methods advance a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-32">cursor</a>. Once the cursor has
   advanced, a <code>success</code> event will be fired at the
-  same <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-47">IDBRequest</a></code> returned when the cursor was opened. The <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-23">result</a></code> will be the same cursor if a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-69">record</a> was
+  same <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-47">IDBRequest</a></code> returned when the cursor was opened. The <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-23">result</a></code> will be the same cursor if a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-70">record</a> was
   in range, or <code>undefined</code> otherwise. 
     <p>If called while the cursor is already advancing, an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> will be thrown.</p>
     <p>The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
   when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-54">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-36">active</a>.</p>
     <dl class="domintro">
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-advance" id="ref-for-dom-idbcursor-advance-2">advance</a></code>(<var>count</var>)
-     <dd> Advances the cursor through the next <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-70">records</a> in
+     <dd> Advances the cursor through the next <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-71">records</a> in
       range. 
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-continue" id="ref-for-dom-idbcursor-continue-2">continue</a></code>()
-     <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-71">record</a> in range. 
+     <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-72">record</a> in range. 
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-continue" id="ref-for-dom-idbcursor-continue-3">continue</a></code>(<var>key</var>)
-     <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-72">record</a> in range matching or
+     <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-73">record</a> in range matching or
       after <var>key</var>. 
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-continueprimarykey" id="ref-for-dom-idbcursor-continueprimarykey-2">continuePrimaryKey</a></code>(<var>key</var>, <var>primaryKey</var>)
-     <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-73">record</a> in range matching
+     <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-74">record</a> in range matching
       or after <var>key</var> and <var>primaryKey</var>. Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-15">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-37">index</a>. 
     </dl>
    </div>
@@ -4764,7 +4793,7 @@ value to a key</a> with <var>key</var>. Rethrow any exceptions.</p>
        <li data-md="">
         <p>If <var>key</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-3">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-4">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-8">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-8">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-4">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-nextunique" id="ref-for-dom-idbcursordirection-nextunique-3">"nextunique"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
        <li data-md="">
-        <p>If <var>key</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-6">greater than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-5">equal to</a> this
+        <p>If <var>key</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-5">greater than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-5">equal to</a> this
 cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-9">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-9">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-4">"prev"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prevunique" id="ref-for-dom-idbcursordirection-prevunique-3">"prevunique"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
       </ol>
      <li data-md="">
@@ -4819,11 +4848,11 @@ a key</a> with <var>key</var>. Rethrow any exceptions.</p>
      <li data-md="">
       <p>If <var>key</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-4">less than</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-10">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-11">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-6">"next"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>key</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-7">greater than</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-11">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-12">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-6">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>key</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-6">greater than</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-11">position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-12">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-6">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>key</var> is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-6">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-12">position</a> and <var>primaryKey</var> is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-5">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-7">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-3">object store position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-13">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-7">"next"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>key</var> is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-8">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-13">position</a> and <var>primaryKey</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-8">greater than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-9">equal to</a> this
+      <p>If <var>key</var> is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-8">equal to</a> this cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-13">position</a> and <var>primaryKey</var> is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-7">greater than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-9">equal to</a> this
 cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-4">object store position</a> and this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-14">direction</a> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-7">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
@@ -4854,12 +4883,12 @@ this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-41">cursor</a>, <
     <dl class="domintro">
      <dt><var>request</var> = <var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-update" id="ref-for-dom-idbcursor-update-2">update</a></code>(<var>value</var>)
      <dd>
-       Updated the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-74">record</a> pointed at by the cursor with a new value. 
-      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-5">effective object store</a> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-7">in-line keys</a> and the <a data-link-type="dfn" href="#key" id="ref-for-key-85">key</a> would have changed.</p>
-      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-24">result</a></code> will be the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-75">record</a>'s <a data-link-type="dfn" href="#key" id="ref-for-key-86">key</a>.</p>
+       Updated the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-75">record</a> pointed at by the cursor with a new value. 
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dataerror">DataError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-5">effective object store</a> uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-7">in-line keys</a> and the <a data-link-type="dfn" href="#key" id="ref-for-key-83">key</a> would have changed.</p>
+      <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-24">result</a></code> will be the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-76">record</a>'s <a data-link-type="dfn" href="#key" id="ref-for-key-84">key</a>.</p>
      <dt><var>request</var> = <var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-delete" id="ref-for-dom-idbcursor-delete-2">delete</a></code>()
      <dd>
-       Delete the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-76">record</a> pointed at by the cursor with a new value. 
+       Delete the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-77">record</a> pointed at by the cursor with a new value. 
       <p>If successful, <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-25">result</a></code> will be <code>undefined</code>.</p>
     </dl>
    </div>
@@ -4987,7 +5016,7 @@ the contents of the database.</p>
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstorenames" id="ref-for-dom-idbtransaction-objectstorenames-2">objectStoreNames</a></code>
-     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-88">object stores</a> in the
+     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-89">object stores</a> in the
       transaction’s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-12">scope</a>. For an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-45">upgrade transaction</a> this is all object stores in the <a data-link-type="dfn" href="#database" id="ref-for-database-50">database</a>. 
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-mode" id="ref-for-dom-idbtransaction-mode-2">mode</a></code>
      <dd> Returns the <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-9">mode</a> the transaction was created with
@@ -5005,10 +5034,10 @@ the contents of the database.</p>
     <ol>
      <li data-md="">
       <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-57">transaction</a> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-47">upgrade transaction</a>,
-return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-3">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-16">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-89">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
+return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-3">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-16">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-90">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
 set</a>.</p>
      <li data-md="">
-      <p>Otherwise, return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-4">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-17">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-90">object stores</a> in
+      <p>Otherwise, return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-4">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-17">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-91">object stores</a> in
 this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-59">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-13">scope</a>.</p>
     </ol>
    </div>
@@ -5018,7 +5047,7 @@ this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction
   🚧 </aside>
    <aside class="note"> The contents of each list returned by this attribute does not
   change, but subsequent calls to this attribute during an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-48">upgrade
-  transaction</a> may return lists with different contents as <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-91">object stores</a> are created and deleted. </aside>
+  transaction</a> may return lists with different contents as <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-92">object stores</a> are created and deleted. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-mode">mode</dfn> attribute’s getter
 must return the <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-10">mode</a> of the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-60">transaction</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-db">db</dfn> attribute’s getter must
@@ -5050,7 +5079,7 @@ when invoked, must run these steps:</p>
       <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-14">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-92">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">named</a> <var>name</var> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-67">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-15">scope</a>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">named</a> <var>name</var> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-67">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-15">scope</a>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
       <p>Return an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-63">object store handle</a> associated with <var>store</var> and this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-68">transaction</a>.</p>
@@ -5101,7 +5130,7 @@ database <var>name</var>, a database <var>version</var>, and a <var>request</var
       <p>If <var>version</var> is undefined, let <var>version</var> be 1 if <var>db</var> is null, or <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-8">version</a> otherwise.</p>
      <li data-md="">
       <p>If <var>db</var> is null, let <var>db</var> be a new <a data-link-type="dfn" href="#database" id="ref-for-database-54">database</a> with <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-5">name</a> <var>name</var>, <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-9">version</a> 0 (zero), and with
-no <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a>. If this fails for any reason, return an
+no <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-94">object stores</a>. If this fails for any reason, return an
 appropriate error (e.g. a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" or
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>).</p>
      <li data-md="">
@@ -5252,8 +5281,8 @@ takes two arguments: the <var>transaction</var> to abort, and <var>error</var>.<
     <ol>
      <li data-md="">
       <p>All the changes made to the <a data-link-type="dfn" href="#database" id="ref-for-database-61">database</a> by the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-74">transaction</a> are reverted. For <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-51">upgrade transactions</a> this includes changes
-to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-94">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-39">indexes</a>, as well as the
-change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-17">version</a>. Any <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-95">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-40">indexes</a> which were created during the transaction are now
+to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-95">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-39">indexes</a>, as well as the
+change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-17">version</a>. Any <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-96">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-40">indexes</a> which were created during the transaction are now
 considered deleted for the purposes of other algorithms.</p>
      <li data-md="">
       <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-52">upgrade transaction</a>, run the steps
@@ -5358,7 +5387,7 @@ for the <a data-link-type="dfn" href="#database" id="ref-for-database-63">databa
      <li data-md="">
       <p>Let <var>db</var> be <var>connection</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-64">database</a>.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be a new <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a> with <var>connection</var> used as <a data-link-type="dfn" href="#connection" id="ref-for-connection-67">connection</a>. The <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-16">scope</a> of <var>transaction</var> includes every <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-96">object store</a> in <var>connection</var>.</p>
+      <p>Let <var>transaction</var> be a new <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a> with <var>connection</var> used as <a data-link-type="dfn" href="#connection" id="ref-for-connection-67">connection</a>. The <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-16">scope</a> of <var>transaction</var> includes every <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-97">object store</a> in <var>connection</var>.</p>
      <li data-md="">
       <p>Unset <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-6">active flag</a>.</p>
      <li data-md="">
@@ -5403,7 +5432,7 @@ transaction</a> with the <var>error</var> property set to a newly <a data-link-t
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="abort-an-upgrade-transaction">abort an upgrade transaction</dfn> with <var>transaction</var> are as follows.</p>
     <aside class="note"> The steps are run after the normal steps to <a data-link-type="dfn" href="#abort-a-transaction" id="ref-for-abort-a-transaction-11">abort a
   transaction</a>, which revert changes to the <a data-link-type="dfn" href="#database" id="ref-for-database-66">database</a> including
-  the set of associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-97">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-41">indexes</a>, as well
+  the set of associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-98">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-41">indexes</a>, as well
   as the change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-19">version</a>. </aside>
     <ol>
      <li data-md="">
@@ -5415,12 +5444,12 @@ transaction</a> with the <var>error</var> property set to a newly <a data-link-t
 if <var>database</var> was newly created.</p>
       <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-version" id="ref-for-dom-idbdatabase-version-3">version</a></code> returned by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-12">IDBDatabase</a></code> object. </aside>
      <li data-md="">
-      <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-4">object store set</a> to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-98">object stores</a> in <var>database</var> if <var>database</var> previously
+      <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-4">object store set</a> to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-99">object stores</a> in <var>database</var> if <var>database</var> previously
 existed, or the empty set if <var>database</var> was newly created.</p>
       <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-5">objectStoreNames</a></code> returned
   by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-13">IDBDatabase</a></code> object. </aside>
      <li data-md="">
-      <p>For each <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-65">object store handle</a> <var>handle</var> associated with <var>transaction</var>, including those for <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-99">object stores</a> that
+      <p>For each <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-65">object store handle</a> <var>handle</var> associated with <var>transaction</var>, including those for <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-100">object stores</a> that
 were created or deleted during <var>transaction</var>, run these substeps:</p>
       <ol>
        <li data-md="">
@@ -5433,7 +5462,7 @@ reference its <a data-link-type="dfn" href="#object-store-handle-object-store" i
       <aside class="note"> This reverts the values of <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-6">name</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-5">indexNames</a></code> returned by related <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-23">IDBObjectStore</a></code> objects. </aside>
       <details class="note">
        <summary>How is this observable?</summary>
-        Although script cannot access an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-100">object store</a> by using the <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstore" id="ref-for-dom-idbtransaction-objectstore-3">objectStore()</a></code> method on an <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-10">IDBTransaction</a></code> instance after
+        Although script cannot access an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-101">object store</a> by using the <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstore" id="ref-for-dom-idbtransaction-objectstore-3">objectStore()</a></code> method on an <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-10">IDBTransaction</a></code> instance after
   the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-80">transaction</a> is aborted, it may still have references to <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-24">IDBObjectStore</a></code> instances where the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-7">name</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-6">indexNames</a></code> properties can be queried. 
       </details>
      <li data-md="">
@@ -5516,7 +5545,7 @@ to <a data-link-type="dfn" href="#abort-a-transaction" id="ref-for-abort-a-trans
     </ol>
    </div>
    <h2 class="heading settled" data-level="6" id="database-operations"><span class="secno">6. </span><span class="content">Database operations</span><a class="self-link" href="#database-operations"></a></h2>
-   <p>This section describes various operations done on the data in <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-101">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-45">indexes</a> in a <a data-link-type="dfn" href="#database" id="ref-for-database-69">database</a>.
+   <p>This section describes various operations done on the data in <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-102">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-45">indexes</a> in a <a data-link-type="dfn" href="#database" id="ref-for-database-69">database</a>.
 These operations are run by the steps to <a data-link-type="dfn" href="#asynchronously-execute-a-request" id="ref-for-asynchronously-execute-a-request-26">asynchronously execute
 a request</a>.</p>
    <aside class="note"> Invocations of <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclone">StructuredClone</a>() in the operation steps below
@@ -5539,35 +5568,32 @@ key from a value using a key path</a> with <var>value</var> and <var>store</var>
         <p>If <var>kpk</var> is not failure, let <var>key</var> be <var>kpk</var>.</p>
       </ol>
      <li data-md="">
-      <p>If <var>store</var> uses a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-19">key generator</a>, run these substeps:</p>
+      <p>If <var>store</var> uses a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-21">key generator</a>, run these substeps:</p>
       <ol>
        <li data-md="">
         <p>If <var>key</var> is undefined, run these substeps:</p>
         <ol>
          <li data-md="">
-          <p>If the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-20">key generator</a>'s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-19">current number</a> is
-greater than 2<sup>53</sup> (9007199254740992), then this
-operation failed with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. Abort this
+          <p>Let <var>key</var> be the result of running the steps to <a data-link-type="dfn" href="#generate-a-key" id="ref-for-generate-a-key-1">generate a key</a> for <var>store</var>.</p>
+         <li data-md="">
+          <p>If <var>key</var> is failure, then this operation failed with a
+"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. Abort this
 algorithm without taking any further steps.</p>
-         <li data-md="">
-          <p>Set <var>key</var> to the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-21">key generator</a>'s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-20">current number</a>.</p>
-         <li data-md="">
-          <p>Increase the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-22">key generator</a>'s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-21">current number</a> by 1.</p>
          <li data-md="">
           <p>If <var>store</var> also uses <a data-link-type="dfn" href="#object-store-in-line-keys" id="ref-for-object-store-in-line-keys-10">in-line keys</a>, then run the
 steps to <a data-link-type="dfn" href="#inject-a-key-into-a-value-using-a-key-path" id="ref-for-inject-a-key-into-a-value-using-a-key-path-1">inject a key into a value using a key path</a> with <var>value</var>, <var>key</var> and <var>store</var>’s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-19">key
 path</a>.</p>
         </ol>
        <li data-md="">
-        <p>Otherwise, if the <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-8">type</a> of <var>key</var> is <i>number</i> and the <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-6">value</a> is greater than or equal to the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-23">key generator</a>'s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-22">current number</a>, set the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-23">current number</a> to lowest integer greater than <var>key</var>.</p>
+        <p>Otherwise, run the steps to <a data-link-type="dfn" href="#possibly-update-the-key-generator" id="ref-for-possibly-update-the-key-generator-1">possibly update the key generator</a> for <var>store</var> with <var>key</var>.</p>
       </ol>
      <li data-md="">
       <p>If the <var>no-overwrite flag</var> was given to these steps and is set, and
-a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-77">record</a> already exists in <var>store</var> with its key <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-11">equal to</a> <var>key</var>, then this operation failed with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.
+a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-78">record</a> already exists in <var>store</var> with its key <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-11">equal to</a> <var>key</var>, then this operation failed with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.
 Abort this algorithm without taking any further steps.</p>
      <li data-md="">
-      <p>If a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-78">record</a> already exists in <var>store</var> with its key <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-12">equal
-to</a> <var>key</var>, then remove the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-79">record</a> from <var>store</var> using the
+      <p>If a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-79">record</a> already exists in <var>store</var> with its key <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-12">equal
+to</a> <var>key</var>, then remove the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-80">record</a> from <var>store</var> using the
 steps to <a data-link-type="dfn" href="#delete-records-from-an-object-store" id="ref-for-delete-records-from-an-object-store-3">delete records from an object store</a>.</p>
      <li data-md="">
       <p>Store a record in <var>store</var> containing <var>key</var> as its key and <var>value</var> as its value. The record is stored in the object store’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-1">list of records</a> such that the list is sorted
@@ -5583,13 +5609,13 @@ further actions for this index, and continue these substeps
 for the next index.</p>
         <aside class="note"> An exception thrown in this step is not rethrown. </aside>
        <li data-md="">
-        <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-7">multiEntry flag</a> is unset, or if <var>index key</var> is not an <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-5">array key</a>, and if <var>index</var> already contains a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-80">record</a> with <a data-link-type="dfn" href="#key" id="ref-for-key-87">key</a> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-13">equal to</a> <var>index
+        <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-7">multiEntry flag</a> is unset, or if <var>index key</var> is not an <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-5">array key</a>, and if <var>index</var> already contains a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-81">record</a> with <a data-link-type="dfn" href="#key" id="ref-for-key-85">key</a> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-13">equal to</a> <var>index
 key</var>, and <var>index</var> has its <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-8">unique flag</a> set, then this
 operation failed with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. Abort this
 algorithm without taking any further steps.</p>
        <li data-md="">
         <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-8">multiEntry flag</a> is set and <var>index key</var> is
-an <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-6">array key</a>, and if <var>index</var> already contains a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-81">record</a> with <a data-link-type="dfn" href="#key" id="ref-for-key-88">key</a> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-14">equal to</a> any of the <a data-link-type="dfn" href="#subkeys" id="ref-for-subkeys-2">subkeys</a> of <var>index key</var>, and <var>index</var> has its <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-9">unique
+an <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-6">array key</a>, and if <var>index</var> already contains a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-82">record</a> with <a data-link-type="dfn" href="#key" id="ref-for-key-86">key</a> <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-14">equal to</a> any of the <a data-link-type="dfn" href="#subkeys" id="ref-for-subkeys-2">subkeys</a> of <var>index key</var>, and <var>index</var> has its <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-9">unique
 flag</a> set, then this operation failed with a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. Abort this algorithm without taking any
 further steps.</p>
@@ -5620,7 +5646,7 @@ ascending order.</p>
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="retrieve-a-value-from-an-object-store">retrieve a value from an object store</dfn> with <var>targetRealm</var>, <var>store</var> and <var>range</var> are as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>record</var> be the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-82">record</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-2">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-3">in</a> <var>range</var>, if
+      <p>Let <var>record</var> be the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-83">record</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-2">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-3">in</a> <var>range</var>, if
 any.</p>
      <li data-md="">
       <p>If <var>record</var> was not found, return undefined.</p>
@@ -5637,7 +5663,7 @@ store</dfn> with <var>targetRealm</var>, <var>store</var>, <var>range</var> and 
      <li data-md="">
       <p>If <var>count</var> is not given or is 0 (zero), let <var>count</var> be infinity.</p>
      <li data-md="">
-      <p>Let <var>records</var> be a list containing the first <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-83">records</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-3">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-4">in</a> <var>range</var>.</p>
+      <p>Let <var>records</var> be a list containing the first <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-84">records</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-3">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-4">in</a> <var>range</var>.</p>
      <li data-md="">
       <p>Let <var>list</var> be an empty list.</p>
      <li data-md="">
@@ -5658,7 +5684,7 @@ store</dfn> with <var>targetRealm</var>, <var>store</var>, <var>range</var> and 
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="retrieve-a-key-from-an-object-store">retrieve a key from an object store</dfn> with <var>store</var> and <var>range</var> are as follows:</p>
     <ol>
      <li data-md="">
-      <p>Let <var>record</var> be the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-84">record</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-4">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-5">in</a> <var>range</var>, if
+      <p>Let <var>record</var> be the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-85">record</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-4">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-5">in</a> <var>range</var>, if
 any.</p>
      <li data-md="">
       <p>If <var>record</var> was not found, return undefined.</p>
@@ -5673,7 +5699,7 @@ key to a value</a> with <var>record</var>’s key.</p>
      <li data-md="">
       <p>If <var>count</var> is not given or is 0 (zero), let <var>count</var> be infinity.</p>
      <li data-md="">
-      <p>Let <var>records</var> be a list containing the first <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-85">records</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-5">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-6">in</a> <var>range</var>.</p>
+      <p>Let <var>records</var> be a list containing the first <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-86">records</a> in <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-5">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-6">in</a> <var>range</var>.</p>
      <li data-md="">
       <p>Let <var>list</var> be an empty list.</p>
      <li data-md="">
@@ -5694,7 +5720,7 @@ key to a value</a> with <var>record</var>’s key.</p>
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="retrieve-a-referenced-value-from-an-index">retrieve a referenced value from an index</dfn> with <var>targetRealm</var>, <var>index</var> and <var>range</var> are as follows.</p>
     <ol>
      <li data-md="">
-      <p>Let <var>record</var> be the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-86">record</a> in <var>index</var>’s <a data-link-type="dfn" href="#index-list-of-records" id="ref-for-index-list-of-records-3">list of
+      <p>Let <var>record</var> be the first <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-87">record</a> in <var>index</var>’s <a data-link-type="dfn" href="#index-list-of-records" id="ref-for-index-list-of-records-3">list of
 records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-7">in</a> <var>range</var>, if any.</p>
      <li data-md="">
       <p>If <var>record</var> was not found, return undefined.</p>
@@ -5711,7 +5737,7 @@ index</dfn> with <var>targetRealm</var>, <var>index</var>, <var>range</var> and 
      <li data-md="">
       <p>If <var>count</var> is not given or is 0 (zero), let <var>count</var> be infinity.</p>
      <li data-md="">
-      <p>Let <var>records</var> be a list containing the first <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-87">records</a> in <var>index</var>’s <a data-link-type="dfn" href="#index-list-of-records" id="ref-for-index-list-of-records-4">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-8">in</a> <var>range</var>.</p>
+      <p>Let <var>records</var> be a list containing the first <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-88">records</a> in <var>index</var>’s <a data-link-type="dfn" href="#index-list-of-records" id="ref-for-index-list-of-records-4">list of records</a> whose key is <a data-link-type="dfn" href="#in" id="ref-for-in-8">in</a> <var>range</var>.</p>
      <li data-md="">
       <p>Let <var>list</var> be an empty list.</p>
      <li data-md="">
@@ -5728,7 +5754,7 @@ index</dfn> with <var>targetRealm</var>, <var>index</var>, <var>range</var> and 
       <p>Return <var>list</var> converted to a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;any></a>.</p>
     </ol>
    </div>
-   <aside class="note"> The <a data-link-type="dfn" href="#index-values" id="ref-for-index-values-1">values</a> of an <a data-link-type="dfn" href="#index-records" id="ref-for-index-records-2">record</a> in an index are the keys of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-88">records</a> in the <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-10">referenced</a> object store. </aside>
+   <aside class="note"> The <a data-link-type="dfn" href="#index-values" id="ref-for-index-values-1">values</a> of an <a data-link-type="dfn" href="#index-records" id="ref-for-index-records-2">record</a> in an index are the keys of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-89">records</a> in the <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-10">referenced</a> object store. </aside>
    <div class="algorithm">
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="retrieve-a-value-from-an-index">retrieve a value from an index</dfn> with <var>index</var> and <var>range</var> are as follows.</p>
     <ol>
@@ -5772,7 +5798,7 @@ key to a value</a> with <var>record</var>’s value.</p>
       <p>Remove all records, if any, from <var>store</var>’s <a data-link-type="dfn" href="#object-store-list-of-records" id="ref-for-object-store-list-of-records-6">list
 of records</a> with key <a data-link-type="dfn" href="#in" id="ref-for-in-11">in</a> <var>range</var>.</p>
      <li data-md="">
-      <p>For each <var>index</var> which <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-11">references</a> <var>store</var>, remove every <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-89">record</a> from <var>index</var>’s <a data-link-type="dfn" href="#index-list-of-records" id="ref-for-index-list-of-records-7">list of records</a> whose value is <a data-link-type="dfn" href="#in" id="ref-for-in-12">in</a> <var>range</var>, if any such records exist.</p>
+      <p>For each <var>index</var> which <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-11">references</a> <var>store</var>, remove every <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-90">record</a> from <var>index</var>’s <a data-link-type="dfn" href="#index-list-of-records" id="ref-for-index-list-of-records-7">list of records</a> whose value is <a data-link-type="dfn" href="#in" id="ref-for-in-12">in</a> <var>range</var>, if any such records exist.</p>
      <li data-md="">
       <p>Return undefined.</p>
     </ol>
@@ -5795,7 +5821,7 @@ records with key <a data-link-type="dfn" href="#in" id="ref-for-in-13">in</a> <v
      <li data-md="">
       <p>Remove all records from <var>store</var>.</p>
      <li data-md="">
-      <p>In all <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-46">indexes</a> which <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-12">reference</a> <var>store</var>, remove all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-90">records</a>.</p>
+      <p>In all <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-46">indexes</a> which <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-12">reference</a> <var>store</var>, remove all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-91">records</a>.</p>
      <li data-md="">
       <p>Return undefined.</p>
     </ol>
@@ -5812,10 +5838,10 @@ follows.</p>
      <li data-md="">
       <p class="assertion">Assert: if <var>primaryKey</var> is given, <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-47">index</a> and <var>direction</var> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-8">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-8">"prev"</a></code>.</p>
      <li data-md="">
-      <p>Let <var>records</var> be the list of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-91">records</a> in <var>source</var>.</p>
-      <aside class="note"> <var>records</var> is always sorted in ascending <a data-link-type="dfn" href="#key" id="ref-for-key-89">key</a> order.
+      <p>Let <var>records</var> be the list of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-92">records</a> in <var>source</var>.</p>
+      <aside class="note"> <var>records</var> is always sorted in ascending <a data-link-type="dfn" href="#key" id="ref-for-key-87">key</a> order.
   In the case of <var>source</var> being an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-48">index</a>, <var>records</var> is secondarily sorted in ascending <a data-link-type="dfn" href="#value" id="ref-for-value-21">value</a> order
-  (where the value in an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-49">index</a> is the <a data-link-type="dfn" href="#key" id="ref-for-key-90">key</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-92">record</a> in the referenced <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-102">object store</a>). </aside>
+  (where the value in an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-49">index</a> is the <a data-link-type="dfn" href="#key" id="ref-for-key-88">key</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-93">record</a> in the referenced <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-103">object store</a>). </aside>
      <li data-md="">
       <p>Let <var>range</var> be <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-11">range</a>.</p>
      <li data-md="">
@@ -5836,18 +5862,18 @@ follows.</p>
     satisfy all of the following requirements: 
           <ul>
            <li data-md="">
-            <p>If <var>key</var> is defined, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-9">greater
+            <p>If <var>key</var> is defined, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-8">greater
 than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-15">equal to</a> <var>key</var>.</p>
            <li data-md="">
             <p>If <var>primaryKey</var> is defined, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-16">equal
-to</a> <var>key</var> and the record’s value is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-10">greater
+to</a> <var>key</var> and the record’s value is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-9">greater
 than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-17">equal to</a> <var>primaryKey</var>, or the
-record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-11">greater than</a> <var>key</var>.</p>
+record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-10">greater than</a> <var>key</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-103">object store</a>, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-12">greater than</a> <var>position</var>.</p>
+            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-104">object store</a>, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-11">greater than</a> <var>position</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-50">index</a>, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-18">equal to</a> <var>position</var> and the record’s value is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-13">greater
-than</a> <var>object store position</var> or the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-14">greater than</a> <var>position</var>.</p>
+            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-50">index</a>, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-18">equal to</a> <var>position</var> and the record’s value is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-12">greater
+than</a> <var>object store position</var> or the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-13">greater than</a> <var>position</var>.</p>
            <li data-md="">
             <p>The record’s key is <a data-link-type="dfn" href="#in" id="ref-for-in-14">in</a> <var>range</var>.</p>
           </ul>
@@ -5857,10 +5883,10 @@ than</a> <var>object store position</var> or the record’s key is <a data-link-
     satisfy all of the following requirements: 
           <ul>
            <li data-md="">
-            <p>If <var>key</var> is defined, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-15">greater
+            <p>If <var>key</var> is defined, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-14">greater
 than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-19">equal to</a> <var>key</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-16">greater
+            <p>If <var>position</var> is defined, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-15">greater
 than</a> <var>position</var>.</p>
            <li data-md="">
             <p>The record’s key is <a data-link-type="dfn" href="#in" id="ref-for-in-15">in</a> <var>range</var>.</p>
@@ -5877,7 +5903,7 @@ than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-20">eq
             <p>If <var>primaryKey</var> is defined, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-21">equal
 to</a> <var>key</var> and the record’s value is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-7">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-22">equal to</a> <var>primaryKey</var>, or the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-8">less than</a> <var>key</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-104">object store</a>, the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-9">less
+            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-105">object store</a>, the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-9">less
 than</a> <var>position</var>.</p>
            <li data-md="">
             <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-51">index</a>, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-23">equal to</a> <var>position</var> and the record’s value is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-10">less than</a> <var>object store position</var> or the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-11">less than</a> <var>position</var>.</p>
@@ -5943,7 +5969,7 @@ store position</a> to <var>object store position</var>.</p>
     </ol>
    </div>
    <h2 class="heading settled" data-level="7" id="binding"><span class="secno">7. </span><span class="content">ECMAScript binding</span><a class="self-link" href="#binding"></a></h2>
-   <p>This section defines how <a data-link-type="dfn" href="#key" id="ref-for-key-91">key</a> values defined in this specification
+   <p>This section defines how <a data-link-type="dfn" href="#key" id="ref-for-key-89">key</a> values defined in this specification
 are converted to and from ECMAScript values, and how they may be
 extracted from and injected into ECMAScript values using <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-3">key
 paths</a>. This section references types and algorithms and uses some
@@ -5951,7 +5977,7 @@ algorithm conventions from the ECMAScript Language Specification. <a data-link-t
    <h3 class="heading settled" data-level="7.1" id="extract-key-from-value"><span class="secno">7.1. </span><span class="content">Extract a key from a value</span><a class="self-link" href="#extract-key-from-value"></a></h3>
    <div class="algorithm">
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extract-a-key-from-a-value-using-a-key-path">extract a key from a value using a key path</dfn> with <var>value</var>, <var>keyPath</var> and an optional <var>multiEntry flag</var> are as
-follows. The result of these steps is a <a data-link-type="dfn" href="#key" id="ref-for-key-92">key</a>, invalid, or
+follows. The result of these steps is a <a data-link-type="dfn" href="#key" id="ref-for-key-90">key</a>, invalid, or
 failure, or the steps may throw an exception.</p>
     <ol>
      <li data-md="">
@@ -6099,7 +6125,7 @@ key to a value</a>.</p>
     </ol>
    </div>
    <aside class="note"> The <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-5">key path</a> used here is always a string and never a sequence,
-  since it is not possible to create a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-105">object store</a> which has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-24">key generator</a> and also has a <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-20">key path</a> that is a
+  since it is not possible to create a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-106">object store</a> which has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-22">key generator</a> and also has a <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-20">key path</a> that is a
   sequence. </aside>
    <aside class="note"> Assertions can be made in the above steps because this algorithm is
   only applied to values that are the output of <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclone">StructuredClone</a>. </aside>
@@ -6109,9 +6135,9 @@ key to a value</a>.</p>
 steps take one argument, <var>key</var>, and return an ECMAScript value.</p>
     <ol>
      <li data-md="">
-      <p>Let <var>type</var> be <var>key</var>’s <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-9">type</a>.</p>
+      <p>Let <var>type</var> be <var>key</var>’s <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-8">type</a>.</p>
      <li data-md="">
-      <p>Let <var>value</var> be <var>key</var>’s <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-7">value</a>.</p>
+      <p>Let <var>value</var> be <var>key</var>’s <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-6">value</a>.</p>
      <li data-md="">
       <p>Switch on <var>type</var>:</p>
       <dl class="switch">
@@ -6182,7 +6208,7 @@ entry of <var>value</var> as input.</p>
    <div class="algorithm">
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="convert-a-value-to-a-key">convert a value to a key</dfn> are as follows. These
 steps take two arguments, an ECMAScript value <var>input</var>, and an optional
-set <var>seen</var>. The result of these steps is a <a data-link-type="dfn" href="#key" id="ref-for-key-93">key</a> or invalid, or the
+set <var>seen</var>. The result of these steps is a <a data-link-type="dfn" href="#key" id="ref-for-key-91">key</a> or invalid, or the
 steps may throw an exception.</p>
     <ol>
      <li data-md="">
@@ -6198,7 +6224,7 @@ steps may throw an exception.</p>
          <li data-md="">
           <p>If <var>input</var> is NaN then return invalid.</p>
          <li data-md="">
-          <p>Otherwise, return a new <a data-link-type="dfn" href="#key" id="ref-for-key-94">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-10">type</a> <i>number</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-8">value</a> <var>input</var>.</p>
+          <p>Otherwise, return a new <a data-link-type="dfn" href="#key" id="ref-for-key-92">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-9">type</a> <i>number</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-7">value</a> <var>input</var>.</p>
         </ol>
        <dt>If <var>input</var> is a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-date-objects">Date</a> (has a [[DateValue]] internal slot)
        <dd>
@@ -6209,13 +6235,13 @@ steps may throw an exception.</p>
          <li data-md="">
           <p>If <var>ms</var> is NaN then return invalid.</p>
          <li data-md="">
-          <p>Otherwise, return a new <a data-link-type="dfn" href="#key" id="ref-for-key-95">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-11">type</a> <i>date</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-9">value</a> <var>ms</var>.</p>
+          <p>Otherwise, return a new <a data-link-type="dfn" href="#key" id="ref-for-key-93">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-10">type</a> <i>date</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-8">value</a> <var>ms</var>.</p>
         </ol>
        <dt>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>input</var>) is String
        <dd>
         <ol>
          <li data-md="">
-          <p>Return a new <a data-link-type="dfn" href="#key" id="ref-for-key-96">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-12">type</a> <i>string</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-10">value</a> <var>input</var>.</p>
+          <p>Return a new <a data-link-type="dfn" href="#key" id="ref-for-key-94">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-11">type</a> <i>string</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-9">value</a> <var>input</var>.</p>
         </ol>
        <dt> If <var>input</var> is a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-buffer-source-type">buffer source type</a>
        <dd>
@@ -6223,7 +6249,7 @@ steps may throw an exception.</p>
          <li data-md="">
           <p>Let <var>octets</var> be the result of running the steps to <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">get a copy of the bytes held by the buffer source</a> <var>value</var>. Rethrow any exceptions.</p>
          <li data-md="">
-          <p>Return a new <a data-link-type="dfn" href="#key" id="ref-for-key-97">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-13">type</a> <i>binary</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-11">value</a> <var>octets</var>.</p>
+          <p>Return a new <a data-link-type="dfn" href="#key" id="ref-for-key-95">key</a> with <a data-link-type="dfn" href="#key-type" id="ref-for-key-type-12">type</a> <i>binary</i> and <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-10">value</a> <var>octets</var>.</p>
         </ol>
        <dt>If <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-isarray">IsArray</a>(<var>input</var>)
        <dd>
@@ -6259,7 +6285,7 @@ invalid.</p>
             <p>Increase <var>index</var> by 1.</p>
           </ol>
          <li data-md="">
-          <p>Return a new <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-12">array key</a> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-12">value</a> <var>keys</var>.</p>
+          <p>Return a new <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-12">array key</a> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-11">value</a> <var>keys</var>.</p>
         </ol>
        <dt>Otherwise
        <dd>Return invalid.
@@ -6269,7 +6295,7 @@ invalid.</p>
    <div class="algorithm">
     <p>The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="convert-a-value-to-a-multientry-key">convert a value to a multiEntry key</dfn> are as
 follows. These steps take one argument, an ECMAScript value <var>input</var>.
-The result of these steps is a <a data-link-type="dfn" href="#key" id="ref-for-key-98">key</a> or invalid, or the
+The result of these steps is a <a data-link-type="dfn" href="#key" id="ref-for-key-96">key</a> or invalid, or the
 steps may throw an exception.</p>
     <ol>
      <li data-md="">
@@ -6301,7 +6327,7 @@ steps may throw an exception.</p>
           <p>Increase <var>index</var> by 1.</p>
         </ol>
        <li data-md="">
-        <p>Return a new <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-13">array key</a> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-13">value</a> set to
+        <p>Return a new <a data-link-type="dfn" href="#array-key" id="ref-for-array-key-13">array key</a> with <a data-link-type="dfn" href="#key-value" id="ref-for-key-value-12">value</a> set to
 a list of the members of <var>keys</var>.</p>
       </ol>
      <li data-md="">
@@ -6488,7 +6514,7 @@ described the firing of a "<code>close</code>" event, and <code class="idl"><a d
 (<a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=22540">bug #22540</a>)</p>
     <li data-md="">
      <p>Converted specification to a more algorithmic style,
-and define abstract types such as <a data-link-type="dfn" href="#key" id="ref-for-key-99">key</a> more rigorously.
+and define abstract types such as <a data-link-type="dfn" href="#key" id="ref-for-key-97">key</a> more rigorously.
 (<a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=17681">bug #17681</a>)</p>
     <li data-md="">
      <p>Added <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-getall" id="ref-for-dom-idbobjectstore-getall-4">getAll()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-getallkeys" id="ref-for-dom-idbobjectstore-getallkeys-4">getAllKeys()</a></code> on <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-27">IDBObjectStore</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-idbindex-getall" id="ref-for-dom-idbindex-getall-4">getAll()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbindex-getallkeys" id="ref-for-dom-idbindex-getallkeys-4">getAllKeys()</a></code> on <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-19">IDBIndex</a></code>.
@@ -6500,7 +6526,7 @@ and define abstract types such as <a data-link-type="dfn" href="#key" id="ref-fo
      <p>Added <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstorenames" id="ref-for-dom-idbtransaction-objectstorenames-4">objectStoreNames</a></code> on <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-11">IDBTransaction</a></code>.
 (<a href="https://github.com/w3c/IndexedDB/issues/18">bug #18</a>)</p>
     <li data-md="">
-     <p>Added <i>binary</i> <a data-link-type="dfn" href="#key" id="ref-for-key-100">keys</a>, including comparisons and ECMAScript bindings.
+     <p>Added <i>binary</i> <a data-link-type="dfn" href="#key" id="ref-for-key-98">keys</a>, including comparisons and ECMAScript bindings.
 (<a href="https://github.com/w3c/IndexedDB/issues/21">bug #21</a>)</p>
     <li data-md="">
      <p>Allow renaming stores and indexes via <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-28">IDBObjectStore</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-8">name</a></code> and <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-20">IDBIndex</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-idbindex-name" id="ref-for-dom-idbindex-name-8">name</a></code> attribute setters.
@@ -6681,7 +6707,7 @@ specification.</p>
    <li><a href="#dom-idbobjectstore-createindex">createIndex(name, keyPath, options)</a><span>, in §4.5</span>
    <li><a href="#dom-idbdatabase-createobjectstore">createObjectStore(name)</a><span>, in §4.4</span>
    <li><a href="#dom-idbdatabase-createobjectstore">createObjectStore(name, options)</a><span>, in §4.4</span>
-   <li><a href="#current-number">current number</a><span>, in §2.11</span>
+   <li><a href="#key-generator-current-number">current number</a><span>, in §2.11</span>
    <li><a href="#cursor">cursor</a><span>, in §2.10</span>
    <li><a href="#database">database</a><span>, in §2.1</span>
    <li><a href="#database-access-task-source">database access task source</a><span>, in §4</span>
@@ -6721,6 +6747,7 @@ specification.</p>
    <li><a href="#fire-an-error-event">fire an error event</a><span>, in §5.10</span>
    <li><a href="#fire-a-success-event">fire a success event</a><span>, in §5.9</span>
    <li><a href="#fire-a-version-change-event">fire a version change event</a><span>, in §4.2</span>
+   <li><a href="#generate-a-key">generate a key</a><span>, in §2.11</span>
    <li>
     getAll()
     <ul>
@@ -6976,6 +7003,7 @@ specification.</p>
    <li><a href="#dom-idbrequestreadystate-pending">"pending"</a><span>, in §4.1</span>
    <li><a href="#request-placed">placed</a><span>, in §2.8</span>
    <li><a href="#cursor-position">position</a><span>, in §2.10</span>
+   <li><a href="#possibly-update-the-key-generator">possibly update the key generator</a><span>, in §2.11</span>
    <li><a href="#dom-idbcursordirection-prev">prev</a><span>, in §4.8</span>
    <li><a href="#dom-idbcursordirection-prev">"prev"</a><span>, in §4.8</span>
    <li><a href="#dom-idbcursordirection-prevunique">"prevunique"</a><span>, in §4.8</span>
@@ -7557,18 +7585,18 @@ specification.</p>
     <li><a href="#ref-for-object-store-30">2.7.2. Upgrade Transactions</a> <a href="#ref-for-object-store-31">(2)</a>
     <li><a href="#ref-for-object-store-32">2.9. Key Range</a>
     <li><a href="#ref-for-object-store-33">2.10. Cursor</a> <a href="#ref-for-object-store-34">(2)</a> <a href="#ref-for-object-store-35">(3)</a> <a href="#ref-for-object-store-36">(4)</a> <a href="#ref-for-object-store-37">(5)</a> <a href="#ref-for-object-store-38">(6)</a>
-    <li><a href="#ref-for-object-store-39">2.11. Key Generators</a> <a href="#ref-for-object-store-40">(2)</a> <a href="#ref-for-object-store-41">(3)</a> <a href="#ref-for-object-store-42">(4)</a> <a href="#ref-for-object-store-43">(5)</a> <a href="#ref-for-object-store-44">(6)</a> <a href="#ref-for-object-store-45">(7)</a> <a href="#ref-for-object-store-46">(8)</a> <a href="#ref-for-object-store-47">(9)</a> <a href="#ref-for-object-store-48">(10)</a> <a href="#ref-for-object-store-49">(11)</a> <a href="#ref-for-object-store-50">(12)</a> <a href="#ref-for-object-store-51">(13)</a>
-    <li><a href="#ref-for-object-store-52">4.4. The IDBDatabase interface</a> <a href="#ref-for-object-store-53">(2)</a> <a href="#ref-for-object-store-54">(3)</a> <a href="#ref-for-object-store-55">(4)</a> <a href="#ref-for-object-store-56">(5)</a> <a href="#ref-for-object-store-57">(6)</a> <a href="#ref-for-object-store-58">(7)</a> <a href="#ref-for-object-store-59">(8)</a> <a href="#ref-for-object-store-60">(9)</a> <a href="#ref-for-object-store-61">(10)</a> <a href="#ref-for-object-store-62">(11)</a> <a href="#ref-for-object-store-63">(12)</a> <a href="#ref-for-object-store-64">(13)</a> <a href="#ref-for-object-store-65">(14)</a> <a href="#ref-for-object-store-66">(15)</a> <a href="#ref-for-object-store-67">(16)</a> <a href="#ref-for-object-store-68">(17)</a> <a href="#ref-for-object-store-69">(18)</a> <a href="#ref-for-object-store-70">(19)</a> <a href="#ref-for-object-store-71">(20)</a>
-    <li><a href="#ref-for-object-store-72">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-73">(2)</a> <a href="#ref-for-object-store-74">(3)</a> <a href="#ref-for-object-store-75">(4)</a> <a href="#ref-for-object-store-76">(5)</a> <a href="#ref-for-object-store-77">(6)</a> <a href="#ref-for-object-store-78">(7)</a>
-    <li><a href="#ref-for-object-store-79">4.6. The IDBIndex interface</a> <a href="#ref-for-object-store-80">(2)</a> <a href="#ref-for-object-store-81">(3)</a> <a href="#ref-for-object-store-82">(4)</a> <a href="#ref-for-object-store-83">(5)</a> <a href="#ref-for-object-store-84">(6)</a> <a href="#ref-for-object-store-85">(7)</a> <a href="#ref-for-object-store-86">(8)</a> <a href="#ref-for-object-store-87">(9)</a>
-    <li><a href="#ref-for-object-store-88">4.9. The IDBTransaction interface</a> <a href="#ref-for-object-store-89">(2)</a> <a href="#ref-for-object-store-90">(3)</a> <a href="#ref-for-object-store-91">(4)</a> <a href="#ref-for-object-store-92">(5)</a>
-    <li><a href="#ref-for-object-store-93">5.1. Opening a database</a>
-    <li><a href="#ref-for-object-store-94">5.5. Aborting a transaction</a> <a href="#ref-for-object-store-95">(2)</a>
-    <li><a href="#ref-for-object-store-96">5.7. Running an upgrade transaction</a>
-    <li><a href="#ref-for-object-store-97">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-object-store-98">(2)</a> <a href="#ref-for-object-store-99">(3)</a> <a href="#ref-for-object-store-100">(4)</a>
-    <li><a href="#ref-for-object-store-101">6. Database operations</a>
-    <li><a href="#ref-for-object-store-102">6.7. Cursor Iteration Operation</a> <a href="#ref-for-object-store-103">(2)</a> <a href="#ref-for-object-store-104">(3)</a>
-    <li><a href="#ref-for-object-store-105">7.2. Inject a key into a value</a>
+    <li><a href="#ref-for-object-store-39">2.11. Key Generators</a> <a href="#ref-for-object-store-40">(2)</a> <a href="#ref-for-object-store-41">(3)</a> <a href="#ref-for-object-store-42">(4)</a> <a href="#ref-for-object-store-43">(5)</a> <a href="#ref-for-object-store-44">(6)</a> <a href="#ref-for-object-store-45">(7)</a> <a href="#ref-for-object-store-46">(8)</a> <a href="#ref-for-object-store-47">(9)</a> <a href="#ref-for-object-store-48">(10)</a> <a href="#ref-for-object-store-49">(11)</a> <a href="#ref-for-object-store-50">(12)</a> <a href="#ref-for-object-store-51">(13)</a> <a href="#ref-for-object-store-52">(14)</a>
+    <li><a href="#ref-for-object-store-53">4.4. The IDBDatabase interface</a> <a href="#ref-for-object-store-54">(2)</a> <a href="#ref-for-object-store-55">(3)</a> <a href="#ref-for-object-store-56">(4)</a> <a href="#ref-for-object-store-57">(5)</a> <a href="#ref-for-object-store-58">(6)</a> <a href="#ref-for-object-store-59">(7)</a> <a href="#ref-for-object-store-60">(8)</a> <a href="#ref-for-object-store-61">(9)</a> <a href="#ref-for-object-store-62">(10)</a> <a href="#ref-for-object-store-63">(11)</a> <a href="#ref-for-object-store-64">(12)</a> <a href="#ref-for-object-store-65">(13)</a> <a href="#ref-for-object-store-66">(14)</a> <a href="#ref-for-object-store-67">(15)</a> <a href="#ref-for-object-store-68">(16)</a> <a href="#ref-for-object-store-69">(17)</a> <a href="#ref-for-object-store-70">(18)</a> <a href="#ref-for-object-store-71">(19)</a> <a href="#ref-for-object-store-72">(20)</a>
+    <li><a href="#ref-for-object-store-73">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-74">(2)</a> <a href="#ref-for-object-store-75">(3)</a> <a href="#ref-for-object-store-76">(4)</a> <a href="#ref-for-object-store-77">(5)</a> <a href="#ref-for-object-store-78">(6)</a> <a href="#ref-for-object-store-79">(7)</a>
+    <li><a href="#ref-for-object-store-80">4.6. The IDBIndex interface</a> <a href="#ref-for-object-store-81">(2)</a> <a href="#ref-for-object-store-82">(3)</a> <a href="#ref-for-object-store-83">(4)</a> <a href="#ref-for-object-store-84">(5)</a> <a href="#ref-for-object-store-85">(6)</a> <a href="#ref-for-object-store-86">(7)</a> <a href="#ref-for-object-store-87">(8)</a> <a href="#ref-for-object-store-88">(9)</a>
+    <li><a href="#ref-for-object-store-89">4.9. The IDBTransaction interface</a> <a href="#ref-for-object-store-90">(2)</a> <a href="#ref-for-object-store-91">(3)</a> <a href="#ref-for-object-store-92">(4)</a> <a href="#ref-for-object-store-93">(5)</a>
+    <li><a href="#ref-for-object-store-94">5.1. Opening a database</a>
+    <li><a href="#ref-for-object-store-95">5.5. Aborting a transaction</a> <a href="#ref-for-object-store-96">(2)</a>
+    <li><a href="#ref-for-object-store-97">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-object-store-98">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-object-store-99">(2)</a> <a href="#ref-for-object-store-100">(3)</a> <a href="#ref-for-object-store-101">(4)</a>
+    <li><a href="#ref-for-object-store-102">6. Database operations</a>
+    <li><a href="#ref-for-object-store-103">6.7. Cursor Iteration Operation</a> <a href="#ref-for-object-store-104">(2)</a> <a href="#ref-for-object-store-105">(3)</a>
+    <li><a href="#ref-for-object-store-106">7.2. Inject a key into a value</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="object-store-list-of-records">
@@ -7586,16 +7614,16 @@ specification.</p>
     <li><a href="#ref-for-object-store-record-2">2.4. Keys</a> <a href="#ref-for-object-store-record-3">(2)</a>
     <li><a href="#ref-for-object-store-record-4">2.6. Index</a> <a href="#ref-for-object-store-record-5">(2)</a> <a href="#ref-for-object-store-record-6">(3)</a> <a href="#ref-for-object-store-record-7">(4)</a> <a href="#ref-for-object-store-record-8">(5)</a> <a href="#ref-for-object-store-record-9">(6)</a> <a href="#ref-for-object-store-record-10">(7)</a> <a href="#ref-for-object-store-record-11">(8)</a> <a href="#ref-for-object-store-record-12">(9)</a> <a href="#ref-for-object-store-record-13">(10)</a> <a href="#ref-for-object-store-record-14">(11)</a>
     <li><a href="#ref-for-object-store-record-15">2.10. Cursor</a> <a href="#ref-for-object-store-record-16">(2)</a> <a href="#ref-for-object-store-record-17">(3)</a>
-    <li><a href="#ref-for-object-store-record-18">2.11. Key Generators</a> <a href="#ref-for-object-store-record-19">(2)</a> <a href="#ref-for-object-store-record-20">(3)</a> <a href="#ref-for-object-store-record-21">(4)</a> <a href="#ref-for-object-store-record-22">(5)</a> <a href="#ref-for-object-store-record-23">(6)</a>
-    <li><a href="#ref-for-object-store-record-24">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-record-25">(2)</a> <a href="#ref-for-object-store-record-26">(3)</a> <a href="#ref-for-object-store-record-27">(4)</a> <a href="#ref-for-object-store-record-28">(5)</a> <a href="#ref-for-object-store-record-29">(6)</a> <a href="#ref-for-object-store-record-30">(7)</a> <a href="#ref-for-object-store-record-31">(8)</a> <a href="#ref-for-object-store-record-32">(9)</a> <a href="#ref-for-object-store-record-33">(10)</a> <a href="#ref-for-object-store-record-34">(11)</a> <a href="#ref-for-object-store-record-35">(12)</a> <a href="#ref-for-object-store-record-36">(13)</a> <a href="#ref-for-object-store-record-37">(14)</a> <a href="#ref-for-object-store-record-38">(15)</a> <a href="#ref-for-object-store-record-39">(16)</a> <a href="#ref-for-object-store-record-40">(17)</a> <a href="#ref-for-object-store-record-41">(18)</a> <a href="#ref-for-object-store-record-42">(19)</a> <a href="#ref-for-object-store-record-43">(20)</a> <a href="#ref-for-object-store-record-44">(21)</a> <a href="#ref-for-object-store-record-45">(22)</a> <a href="#ref-for-object-store-record-46">(23)</a> <a href="#ref-for-object-store-record-47">(24)</a> <a href="#ref-for-object-store-record-48">(25)</a> <a href="#ref-for-object-store-record-49">(26)</a> <a href="#ref-for-object-store-record-50">(27)</a>
-    <li><a href="#ref-for-object-store-record-51">4.6. The IDBIndex interface</a> <a href="#ref-for-object-store-record-52">(2)</a> <a href="#ref-for-object-store-record-53">(3)</a> <a href="#ref-for-object-store-record-54">(4)</a> <a href="#ref-for-object-store-record-55">(5)</a> <a href="#ref-for-object-store-record-56">(6)</a> <a href="#ref-for-object-store-record-57">(7)</a> <a href="#ref-for-object-store-record-58">(8)</a> <a href="#ref-for-object-store-record-59">(9)</a> <a href="#ref-for-object-store-record-60">(10)</a> <a href="#ref-for-object-store-record-61">(11)</a> <a href="#ref-for-object-store-record-62">(12)</a> <a href="#ref-for-object-store-record-63">(13)</a> <a href="#ref-for-object-store-record-64">(14)</a> <a href="#ref-for-object-store-record-65">(15)</a> <a href="#ref-for-object-store-record-66">(16)</a> <a href="#ref-for-object-store-record-67">(17)</a> <a href="#ref-for-object-store-record-68">(18)</a>
-    <li><a href="#ref-for-object-store-record-69">4.8. The IDBCursor interface</a> <a href="#ref-for-object-store-record-70">(2)</a> <a href="#ref-for-object-store-record-71">(3)</a> <a href="#ref-for-object-store-record-72">(4)</a> <a href="#ref-for-object-store-record-73">(5)</a> <a href="#ref-for-object-store-record-74">(6)</a> <a href="#ref-for-object-store-record-75">(7)</a> <a href="#ref-for-object-store-record-76">(8)</a>
-    <li><a href="#ref-for-object-store-record-77">6.1. Object Store Storage Operation</a> <a href="#ref-for-object-store-record-78">(2)</a> <a href="#ref-for-object-store-record-79">(3)</a> <a href="#ref-for-object-store-record-80">(4)</a> <a href="#ref-for-object-store-record-81">(5)</a>
-    <li><a href="#ref-for-object-store-record-82">6.2. Object Store Retrieval Operations</a> <a href="#ref-for-object-store-record-83">(2)</a> <a href="#ref-for-object-store-record-84">(3)</a> <a href="#ref-for-object-store-record-85">(4)</a>
-    <li><a href="#ref-for-object-store-record-86">6.3. Index Retrieval Operations</a> <a href="#ref-for-object-store-record-87">(2)</a> <a href="#ref-for-object-store-record-88">(3)</a>
-    <li><a href="#ref-for-object-store-record-89">6.4. Object Store Deletion Operation</a>
-    <li><a href="#ref-for-object-store-record-90">6.6. Object Store Clear Operation</a>
-    <li><a href="#ref-for-object-store-record-91">6.7. Cursor Iteration Operation</a> <a href="#ref-for-object-store-record-92">(2)</a>
+    <li><a href="#ref-for-object-store-record-18">2.11. Key Generators</a> <a href="#ref-for-object-store-record-19">(2)</a> <a href="#ref-for-object-store-record-20">(3)</a> <a href="#ref-for-object-store-record-21">(4)</a> <a href="#ref-for-object-store-record-22">(5)</a> <a href="#ref-for-object-store-record-23">(6)</a> <a href="#ref-for-object-store-record-24">(7)</a>
+    <li><a href="#ref-for-object-store-record-25">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-record-26">(2)</a> <a href="#ref-for-object-store-record-27">(3)</a> <a href="#ref-for-object-store-record-28">(4)</a> <a href="#ref-for-object-store-record-29">(5)</a> <a href="#ref-for-object-store-record-30">(6)</a> <a href="#ref-for-object-store-record-31">(7)</a> <a href="#ref-for-object-store-record-32">(8)</a> <a href="#ref-for-object-store-record-33">(9)</a> <a href="#ref-for-object-store-record-34">(10)</a> <a href="#ref-for-object-store-record-35">(11)</a> <a href="#ref-for-object-store-record-36">(12)</a> <a href="#ref-for-object-store-record-37">(13)</a> <a href="#ref-for-object-store-record-38">(14)</a> <a href="#ref-for-object-store-record-39">(15)</a> <a href="#ref-for-object-store-record-40">(16)</a> <a href="#ref-for-object-store-record-41">(17)</a> <a href="#ref-for-object-store-record-42">(18)</a> <a href="#ref-for-object-store-record-43">(19)</a> <a href="#ref-for-object-store-record-44">(20)</a> <a href="#ref-for-object-store-record-45">(21)</a> <a href="#ref-for-object-store-record-46">(22)</a> <a href="#ref-for-object-store-record-47">(23)</a> <a href="#ref-for-object-store-record-48">(24)</a> <a href="#ref-for-object-store-record-49">(25)</a> <a href="#ref-for-object-store-record-50">(26)</a> <a href="#ref-for-object-store-record-51">(27)</a>
+    <li><a href="#ref-for-object-store-record-52">4.6. The IDBIndex interface</a> <a href="#ref-for-object-store-record-53">(2)</a> <a href="#ref-for-object-store-record-54">(3)</a> <a href="#ref-for-object-store-record-55">(4)</a> <a href="#ref-for-object-store-record-56">(5)</a> <a href="#ref-for-object-store-record-57">(6)</a> <a href="#ref-for-object-store-record-58">(7)</a> <a href="#ref-for-object-store-record-59">(8)</a> <a href="#ref-for-object-store-record-60">(9)</a> <a href="#ref-for-object-store-record-61">(10)</a> <a href="#ref-for-object-store-record-62">(11)</a> <a href="#ref-for-object-store-record-63">(12)</a> <a href="#ref-for-object-store-record-64">(13)</a> <a href="#ref-for-object-store-record-65">(14)</a> <a href="#ref-for-object-store-record-66">(15)</a> <a href="#ref-for-object-store-record-67">(16)</a> <a href="#ref-for-object-store-record-68">(17)</a> <a href="#ref-for-object-store-record-69">(18)</a>
+    <li><a href="#ref-for-object-store-record-70">4.8. The IDBCursor interface</a> <a href="#ref-for-object-store-record-71">(2)</a> <a href="#ref-for-object-store-record-72">(3)</a> <a href="#ref-for-object-store-record-73">(4)</a> <a href="#ref-for-object-store-record-74">(5)</a> <a href="#ref-for-object-store-record-75">(6)</a> <a href="#ref-for-object-store-record-76">(7)</a> <a href="#ref-for-object-store-record-77">(8)</a>
+    <li><a href="#ref-for-object-store-record-78">6.1. Object Store Storage Operation</a> <a href="#ref-for-object-store-record-79">(2)</a> <a href="#ref-for-object-store-record-80">(3)</a> <a href="#ref-for-object-store-record-81">(4)</a> <a href="#ref-for-object-store-record-82">(5)</a>
+    <li><a href="#ref-for-object-store-record-83">6.2. Object Store Retrieval Operations</a> <a href="#ref-for-object-store-record-84">(2)</a> <a href="#ref-for-object-store-record-85">(3)</a> <a href="#ref-for-object-store-record-86">(4)</a>
+    <li><a href="#ref-for-object-store-record-87">6.3. Index Retrieval Operations</a> <a href="#ref-for-object-store-record-88">(2)</a> <a href="#ref-for-object-store-record-89">(3)</a>
+    <li><a href="#ref-for-object-store-record-90">6.4. Object Store Deletion Operation</a>
+    <li><a href="#ref-for-object-store-record-91">6.6. Object Store Clear Operation</a>
+    <li><a href="#ref-for-object-store-record-92">6.7. Cursor Iteration Operation</a> <a href="#ref-for-object-store-record-93">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="object-store-name">
@@ -7703,17 +7731,17 @@ specification.</p>
     <li><a href="#ref-for-key-22">2.6. Index</a> <a href="#ref-for-key-23">(2)</a> <a href="#ref-for-key-24">(3)</a>
     <li><a href="#ref-for-key-25">2.9. Key Range</a> <a href="#ref-for-key-26">(2)</a> <a href="#ref-for-key-27">(3)</a> <a href="#ref-for-key-28">(4)</a> <a href="#ref-for-key-29">(5)</a> <a href="#ref-for-key-30">(6)</a> <a href="#ref-for-key-31">(7)</a> <a href="#ref-for-key-32">(8)</a>
     <li><a href="#ref-for-key-33">2.10. Cursor</a> <a href="#ref-for-key-34">(2)</a> <a href="#ref-for-key-35">(3)</a> <a href="#ref-for-key-36">(4)</a>
-    <li><a href="#ref-for-key-37">2.11. Key Generators</a> <a href="#ref-for-key-38">(2)</a> <a href="#ref-for-key-39">(3)</a> <a href="#ref-for-key-40">(4)</a> <a href="#ref-for-key-41">(5)</a> <a href="#ref-for-key-42">(6)</a> <a href="#ref-for-key-43">(7)</a> <a href="#ref-for-key-44">(8)</a> <a href="#ref-for-key-45">(9)</a>
-    <li><a href="#ref-for-key-46">4.3. The IDBFactory interface</a> <a href="#ref-for-key-47">(2)</a>
-    <li><a href="#ref-for-key-48">4.5. The IDBObjectStore interface</a> <a href="#ref-for-key-49">(2)</a> <a href="#ref-for-key-50">(3)</a> <a href="#ref-for-key-51">(4)</a> <a href="#ref-for-key-52">(5)</a> <a href="#ref-for-key-53">(6)</a> <a href="#ref-for-key-54">(7)</a> <a href="#ref-for-key-55">(8)</a> <a href="#ref-for-key-56">(9)</a> <a href="#ref-for-key-57">(10)</a> <a href="#ref-for-key-58">(11)</a> <a href="#ref-for-key-59">(12)</a> <a href="#ref-for-key-60">(13)</a> <a href="#ref-for-key-61">(14)</a> <a href="#ref-for-key-62">(15)</a> <a href="#ref-for-key-63">(16)</a> <a href="#ref-for-key-64">(17)</a> <a href="#ref-for-key-65">(18)</a> <a href="#ref-for-key-66">(19)</a> <a href="#ref-for-key-67">(20)</a> <a href="#ref-for-key-68">(21)</a>
-    <li><a href="#ref-for-key-69">4.6. The IDBIndex interface</a> <a href="#ref-for-key-70">(2)</a> <a href="#ref-for-key-71">(3)</a> <a href="#ref-for-key-72">(4)</a> <a href="#ref-for-key-73">(5)</a> <a href="#ref-for-key-74">(6)</a> <a href="#ref-for-key-75">(7)</a> <a href="#ref-for-key-76">(8)</a> <a href="#ref-for-key-77">(9)</a> <a href="#ref-for-key-78">(10)</a> <a href="#ref-for-key-79">(11)</a> <a href="#ref-for-key-80">(12)</a> <a href="#ref-for-key-81">(13)</a> <a href="#ref-for-key-82">(14)</a> <a href="#ref-for-key-83">(15)</a> <a href="#ref-for-key-84">(16)</a>
-    <li><a href="#ref-for-key-85">4.8. The IDBCursor interface</a> <a href="#ref-for-key-86">(2)</a>
-    <li><a href="#ref-for-key-87">6.1. Object Store Storage Operation</a> <a href="#ref-for-key-88">(2)</a>
-    <li><a href="#ref-for-key-89">6.7. Cursor Iteration Operation</a> <a href="#ref-for-key-90">(2)</a>
-    <li><a href="#ref-for-key-91">7. ECMAScript binding</a>
-    <li><a href="#ref-for-key-92">7.1. Extract a key from a value</a>
-    <li><a href="#ref-for-key-93">7.4. Convert a value to a key</a> <a href="#ref-for-key-94">(2)</a> <a href="#ref-for-key-95">(3)</a> <a href="#ref-for-key-96">(4)</a> <a href="#ref-for-key-97">(5)</a> <a href="#ref-for-key-98">(6)</a>
-    <li><a href="#ref-for-key-99">10. Revision History</a> <a href="#ref-for-key-100">(2)</a>
+    <li><a href="#ref-for-key-37">2.11. Key Generators</a> <a href="#ref-for-key-38">(2)</a> <a href="#ref-for-key-39">(3)</a> <a href="#ref-for-key-40">(4)</a> <a href="#ref-for-key-41">(5)</a> <a href="#ref-for-key-42">(6)</a> <a href="#ref-for-key-43">(7)</a>
+    <li><a href="#ref-for-key-44">4.3. The IDBFactory interface</a> <a href="#ref-for-key-45">(2)</a>
+    <li><a href="#ref-for-key-46">4.5. The IDBObjectStore interface</a> <a href="#ref-for-key-47">(2)</a> <a href="#ref-for-key-48">(3)</a> <a href="#ref-for-key-49">(4)</a> <a href="#ref-for-key-50">(5)</a> <a href="#ref-for-key-51">(6)</a> <a href="#ref-for-key-52">(7)</a> <a href="#ref-for-key-53">(8)</a> <a href="#ref-for-key-54">(9)</a> <a href="#ref-for-key-55">(10)</a> <a href="#ref-for-key-56">(11)</a> <a href="#ref-for-key-57">(12)</a> <a href="#ref-for-key-58">(13)</a> <a href="#ref-for-key-59">(14)</a> <a href="#ref-for-key-60">(15)</a> <a href="#ref-for-key-61">(16)</a> <a href="#ref-for-key-62">(17)</a> <a href="#ref-for-key-63">(18)</a> <a href="#ref-for-key-64">(19)</a> <a href="#ref-for-key-65">(20)</a> <a href="#ref-for-key-66">(21)</a>
+    <li><a href="#ref-for-key-67">4.6. The IDBIndex interface</a> <a href="#ref-for-key-68">(2)</a> <a href="#ref-for-key-69">(3)</a> <a href="#ref-for-key-70">(4)</a> <a href="#ref-for-key-71">(5)</a> <a href="#ref-for-key-72">(6)</a> <a href="#ref-for-key-73">(7)</a> <a href="#ref-for-key-74">(8)</a> <a href="#ref-for-key-75">(9)</a> <a href="#ref-for-key-76">(10)</a> <a href="#ref-for-key-77">(11)</a> <a href="#ref-for-key-78">(12)</a> <a href="#ref-for-key-79">(13)</a> <a href="#ref-for-key-80">(14)</a> <a href="#ref-for-key-81">(15)</a> <a href="#ref-for-key-82">(16)</a>
+    <li><a href="#ref-for-key-83">4.8. The IDBCursor interface</a> <a href="#ref-for-key-84">(2)</a>
+    <li><a href="#ref-for-key-85">6.1. Object Store Storage Operation</a> <a href="#ref-for-key-86">(2)</a>
+    <li><a href="#ref-for-key-87">6.7. Cursor Iteration Operation</a> <a href="#ref-for-key-88">(2)</a>
+    <li><a href="#ref-for-key-89">7. ECMAScript binding</a>
+    <li><a href="#ref-for-key-90">7.1. Extract a key from a value</a>
+    <li><a href="#ref-for-key-91">7.4. Convert a value to a key</a> <a href="#ref-for-key-92">(2)</a> <a href="#ref-for-key-93">(3)</a> <a href="#ref-for-key-94">(4)</a> <a href="#ref-for-key-95">(5)</a> <a href="#ref-for-key-96">(6)</a>
+    <li><a href="#ref-for-key-97">10. Revision History</a> <a href="#ref-for-key-98">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="key-type">
@@ -7721,9 +7749,8 @@ specification.</p>
    <ul>
     <li><a href="#ref-for-key-type-1">2.4. Keys</a> <a href="#ref-for-key-type-2">(2)</a> <a href="#ref-for-key-type-3">(3)</a>
     <li><a href="#ref-for-key-type-4">2.11. Key Generators</a> <a href="#ref-for-key-type-5">(2)</a> <a href="#ref-for-key-type-6">(3)</a> <a href="#ref-for-key-type-7">(4)</a>
-    <li><a href="#ref-for-key-type-8">6.1. Object Store Storage Operation</a>
-    <li><a href="#ref-for-key-type-9">7.3. Convert a key to a value</a>
-    <li><a href="#ref-for-key-type-10">7.4. Convert a value to a key</a> <a href="#ref-for-key-type-11">(2)</a> <a href="#ref-for-key-type-12">(3)</a> <a href="#ref-for-key-type-13">(4)</a>
+    <li><a href="#ref-for-key-type-8">7.3. Convert a key to a value</a>
+    <li><a href="#ref-for-key-type-9">7.4. Convert a value to a key</a> <a href="#ref-for-key-type-10">(2)</a> <a href="#ref-for-key-type-11">(3)</a> <a href="#ref-for-key-type-12">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="key-value">
@@ -7731,9 +7758,8 @@ specification.</p>
    <ul>
     <li><a href="#ref-for-key-value-1">2.4. Keys</a> <a href="#ref-for-key-value-2">(2)</a> <a href="#ref-for-key-value-3">(3)</a>
     <li><a href="#ref-for-key-value-4">2.11. Key Generators</a> <a href="#ref-for-key-value-5">(2)</a>
-    <li><a href="#ref-for-key-value-6">6.1. Object Store Storage Operation</a>
-    <li><a href="#ref-for-key-value-7">7.3. Convert a key to a value</a>
-    <li><a href="#ref-for-key-value-8">7.4. Convert a value to a key</a> <a href="#ref-for-key-value-9">(2)</a> <a href="#ref-for-key-value-10">(3)</a> <a href="#ref-for-key-value-11">(4)</a> <a href="#ref-for-key-value-12">(5)</a> <a href="#ref-for-key-value-13">(6)</a>
+    <li><a href="#ref-for-key-value-6">7.3. Convert a key to a value</a>
+    <li><a href="#ref-for-key-value-7">7.4. Convert a value to a key</a> <a href="#ref-for-key-value-8">(2)</a> <a href="#ref-for-key-value-9">(3)</a> <a href="#ref-for-key-value-10">(4)</a> <a href="#ref-for-key-value-11">(5)</a> <a href="#ref-for-key-value-12">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="array-key">
@@ -7765,10 +7791,9 @@ specification.</p>
    <ul>
     <li><a href="#ref-for-greater-than-1">2.9. Key Range</a> <a href="#ref-for-greater-than-2">(2)</a>
     <li><a href="#ref-for-greater-than-3">2.10. Cursor</a>
-    <li><a href="#ref-for-greater-than-4">2.11. Key Generators</a>
-    <li><a href="#ref-for-greater-than-5">4.7. The IDBKeyRange interface</a>
-    <li><a href="#ref-for-greater-than-6">4.8. The IDBCursor interface</a> <a href="#ref-for-greater-than-7">(2)</a> <a href="#ref-for-greater-than-8">(3)</a>
-    <li><a href="#ref-for-greater-than-9">6.7. Cursor Iteration Operation</a> <a href="#ref-for-greater-than-10">(2)</a> <a href="#ref-for-greater-than-11">(3)</a> <a href="#ref-for-greater-than-12">(4)</a> <a href="#ref-for-greater-than-13">(5)</a> <a href="#ref-for-greater-than-14">(6)</a> <a href="#ref-for-greater-than-15">(7)</a> <a href="#ref-for-greater-than-16">(8)</a>
+    <li><a href="#ref-for-greater-than-4">4.7. The IDBKeyRange interface</a>
+    <li><a href="#ref-for-greater-than-5">4.8. The IDBCursor interface</a> <a href="#ref-for-greater-than-6">(2)</a> <a href="#ref-for-greater-than-7">(3)</a>
+    <li><a href="#ref-for-greater-than-8">6.7. Cursor Iteration Operation</a> <a href="#ref-for-greater-than-9">(2)</a> <a href="#ref-for-greater-than-10">(3)</a> <a href="#ref-for-greater-than-11">(4)</a> <a href="#ref-for-greater-than-12">(5)</a> <a href="#ref-for-greater-than-13">(6)</a> <a href="#ref-for-greater-than-14">(7)</a> <a href="#ref-for-greater-than-15">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="less-than">
@@ -8440,18 +8465,29 @@ specification.</p>
    <b><a href="#key-generator">#key-generator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-generator-1">2.2. Object Store</a> <a href="#ref-for-key-generator-2">(2)</a>
-    <li><a href="#ref-for-key-generator-3">2.11. Key Generators</a> <a href="#ref-for-key-generator-4">(2)</a> <a href="#ref-for-key-generator-5">(3)</a> <a href="#ref-for-key-generator-6">(4)</a> <a href="#ref-for-key-generator-7">(5)</a> <a href="#ref-for-key-generator-8">(6)</a> <a href="#ref-for-key-generator-9">(7)</a> <a href="#ref-for-key-generator-10">(8)</a> <a href="#ref-for-key-generator-11">(9)</a>
-    <li><a href="#ref-for-key-generator-12">4.4. The IDBDatabase interface</a>
-    <li><a href="#ref-for-key-generator-13">4.5. The IDBObjectStore interface</a> <a href="#ref-for-key-generator-14">(2)</a> <a href="#ref-for-key-generator-15">(3)</a> <a href="#ref-for-key-generator-16">(4)</a> <a href="#ref-for-key-generator-17">(5)</a> <a href="#ref-for-key-generator-18">(6)</a>
-    <li><a href="#ref-for-key-generator-19">6.1. Object Store Storage Operation</a> <a href="#ref-for-key-generator-20">(2)</a> <a href="#ref-for-key-generator-21">(3)</a> <a href="#ref-for-key-generator-22">(4)</a> <a href="#ref-for-key-generator-23">(5)</a>
-    <li><a href="#ref-for-key-generator-24">7.2. Inject a key into a value</a>
+    <li><a href="#ref-for-key-generator-3">2.11. Key Generators</a> <a href="#ref-for-key-generator-4">(2)</a> <a href="#ref-for-key-generator-5">(3)</a> <a href="#ref-for-key-generator-6">(4)</a> <a href="#ref-for-key-generator-7">(5)</a> <a href="#ref-for-key-generator-8">(6)</a> <a href="#ref-for-key-generator-9">(7)</a> <a href="#ref-for-key-generator-10">(8)</a> <a href="#ref-for-key-generator-11">(9)</a> <a href="#ref-for-key-generator-12">(10)</a> <a href="#ref-for-key-generator-13">(11)</a>
+    <li><a href="#ref-for-key-generator-14">4.4. The IDBDatabase interface</a>
+    <li><a href="#ref-for-key-generator-15">4.5. The IDBObjectStore interface</a> <a href="#ref-for-key-generator-16">(2)</a> <a href="#ref-for-key-generator-17">(3)</a> <a href="#ref-for-key-generator-18">(4)</a> <a href="#ref-for-key-generator-19">(5)</a> <a href="#ref-for-key-generator-20">(6)</a>
+    <li><a href="#ref-for-key-generator-21">6.1. Object Store Storage Operation</a>
+    <li><a href="#ref-for-key-generator-22">7.2. Inject a key into a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-number">
-   <b><a href="#current-number">#current-number</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="key-generator-current-number">
+   <b><a href="#key-generator-current-number">#key-generator-current-number</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-number-1">2.11. Key Generators</a> <a href="#ref-for-current-number-2">(2)</a> <a href="#ref-for-current-number-3">(3)</a> <a href="#ref-for-current-number-4">(4)</a> <a href="#ref-for-current-number-5">(5)</a> <a href="#ref-for-current-number-6">(6)</a> <a href="#ref-for-current-number-7">(7)</a> <a href="#ref-for-current-number-8">(8)</a> <a href="#ref-for-current-number-9">(9)</a> <a href="#ref-for-current-number-10">(10)</a> <a href="#ref-for-current-number-11">(11)</a> <a href="#ref-for-current-number-12">(12)</a> <a href="#ref-for-current-number-13">(13)</a> <a href="#ref-for-current-number-14">(14)</a> <a href="#ref-for-current-number-15">(15)</a> <a href="#ref-for-current-number-16">(16)</a> <a href="#ref-for-current-number-17">(17)</a> <a href="#ref-for-current-number-18">(18)</a>
-    <li><a href="#ref-for-current-number-19">6.1. Object Store Storage Operation</a> <a href="#ref-for-current-number-20">(2)</a> <a href="#ref-for-current-number-21">(3)</a> <a href="#ref-for-current-number-22">(4)</a> <a href="#ref-for-current-number-23">(5)</a>
+    <li><a href="#ref-for-key-generator-current-number-1">2.11. Key Generators</a> <a href="#ref-for-key-generator-current-number-2">(2)</a> <a href="#ref-for-key-generator-current-number-3">(3)</a> <a href="#ref-for-key-generator-current-number-4">(4)</a> <a href="#ref-for-key-generator-current-number-5">(5)</a> <a href="#ref-for-key-generator-current-number-6">(6)</a> <a href="#ref-for-key-generator-current-number-7">(7)</a> <a href="#ref-for-key-generator-current-number-8">(8)</a> <a href="#ref-for-key-generator-current-number-9">(9)</a> <a href="#ref-for-key-generator-current-number-10">(10)</a> <a href="#ref-for-key-generator-current-number-11">(11)</a> <a href="#ref-for-key-generator-current-number-12">(12)</a> <a href="#ref-for-key-generator-current-number-13">(13)</a> <a href="#ref-for-key-generator-current-number-14">(14)</a> <a href="#ref-for-key-generator-current-number-15">(15)</a> <a href="#ref-for-key-generator-current-number-16">(16)</a> <a href="#ref-for-key-generator-current-number-17">(17)</a> <a href="#ref-for-key-generator-current-number-18">(18)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="generate-a-key">
+   <b><a href="#generate-a-key">#generate-a-key</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-generate-a-key-1">6.1. Object Store Storage Operation</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="possibly-update-the-key-generator">
+   <b><a href="#possibly-update-the-key-generator">#possibly-update-the-key-generator</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-possibly-update-the-key-generator-1">6.1. Object Store Storage Operation</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="idbrequest">

--- a/index.html
+++ b/index.html
@@ -1455,7 +1455,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-07">7 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-08">8 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:


### PR DESCRIPTION
Address the spec gaps pointed out in https://github.com/w3c/IndexedDB/issues/147

This pins the key generator to the maximum value (2^53). The logic around incrementing/updating the generator is made algorithmic rather than being duplicated between the object store storage operation steps and the prose definition of the key generator.