### PR TITLE
Clarify purpose and lifetime of upgrade transactions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1170,12 +1170,14 @@ that all other transactions are [=transaction/finished=].
 As long as an [=upgrade transaction=] is running, attempts to open
 more [=/connections=] to the same [=database=] are delayed, and
 any attempts to use the same [=/connection=] to start additional
-transactions will result in an exception being thrown. Thus [=upgrade
-transactions=] not only ensure that no other transactions are
-running concurrently, but also ensure that no other transactions are
-queued against the same [=database=] as long as the transaction is
-running.
+transactions will result in an exception being thrown.
 
+<aside class=note>
+  Thus [=upgrade transactions=] not only ensure that no other
+  transactions are running concurrently, but also ensure that no other
+  transactions are queued against the same [=database=] as long as the
+  transaction is running.
+</aside>
 
 <!-- ============================================================ -->
 <h3 id=request-construct>Requests</h3>

--- a/index.bs
+++ b/index.bs
@@ -1150,34 +1150,39 @@ The following constraints define when a [=/transaction=] can be
 An <dfn>upgrade transaction</dfn> is a [=/transaction=] with [=transaction/mode=]
 {{"versionchange"}}.
 
-An [=upgrade transaction=] is automatically created when running
+An [=upgrade transaction=] is automatically created when running the
 [=steps for running an upgrade transaction=] after a [=/connection=]
-is opened to a [=database=] giving a greater [=database/version=] than
-the current [=database/version=]. This [=/transaction=] will be active
-inside the <code>[=upgradeneeded=]</code> event handler, allowing the
-creation of new [=/object stores=] and [=/indexes=].
-
-An [=upgrade transaction=] is never run concurrently with other
-transactions. When a database is opened with a [=database/version=]
-number higher than the current [=database/version=], a new [=upgrade
-transaction=] is automatically created and made available through the
-[=open request=] when the <code>[=upgradeneeded=]</code> event is
-fired. The <code>[=upgradeneeded=]</code> event isn't fired, and thus
-the [=upgrade transaction=] isn't started, until all other
-[=/connections=] to the same [=database=] are closed. This ensures
-that all other transactions are [=transaction/finished=].
-
-As long as an [=upgrade transaction=] is running, attempts to open
-more [=/connections=] to the same [=database=] are delayed, and
-any attempts to use the same [=/connection=] to start additional
-transactions will result in an exception being thrown.
+is opened to a [=/database=], if a [=database/version=] greater than
+the current [=database/version=] is specified. This [=/transaction=]
+will be active inside the <code>[=upgradeneeded=]</code> event
+handler.
 
 <aside class=note>
-  Thus [=upgrade transactions=] not only ensure that no other
-  transactions are running concurrently, but also ensure that no other
-  transactions are queued against the same [=database=] as long as the
-  transaction is running.
+  An [=upgrade transaction=] enables the creation, renaming, and
+  deletion of [=/object stores=] and [=/indexes=] in a [=/database=].
+
+  An [=upgrade transaction=] is exclusive. The [=steps for opening a
+  database=] ensure that only one [=/connection=] to the database is
+  open when an [=upgrade transaction=] is running.
+  The <code>[=upgradeneeded=]</code> event isn't fired, and thus the
+  [=upgrade transaction=] isn't started, until all other
+  [=/connections=] to the same [=/database=] are closed. This ensures
+  that all previous transactions are [=transaction/finished=]. As long
+  as an [=upgrade transaction=] is running, attempts to open more
+  [=/connections=] to the same [=/database=] are delayed, and any
+  attempts to use the same [=/connection=] to start additional
+  transactions by calling {{IDBDatabase/transaction()}} will throw an
+  exception. Thus [=upgrade transactions=] not only ensure that no
+  other transactions are running concurrently, but also ensure that no
+  new transactions are queued against the same [=/database=] as long
+  as the transaction is running.
+
+  This ensures that once an [=upgrade transaction=] is complete, the
+  set of [=/object stores=] and [=/indexes=] in a [=/database=] remain
+  constant for the lifetime of all subsequent [=/connections=] and
+  [=/transactions=].
 </aside>
+
 
 <!-- ============================================================ -->
 <h3 id=request-construct>Requests</h3>

--- a/index.html
+++ b/index.html
@@ -1455,7 +1455,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-23">23 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-24">24 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2433,26 +2433,30 @@ implementation must not indefinitely prevent a pending <a data-link-type="dfn" h
    </div>
    <h4 class="heading settled" data-level="2.7.2" id="upgrade-transaction-construct"><span class="secno">2.7.2. </span><span class="content">Upgrade Transactions</span><a class="self-link" href="#upgrade-transaction-construct"></a></h4>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="upgrade-transaction">upgrade transaction</dfn> is a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-24">transaction</a> with <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-8">mode</a> <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-versionchange" id="ref-for-dom-idbtransactionmode-versionchange-2">"versionchange"</a></code>.</p>
-   <p>An <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-7">upgrade transaction</a> is automatically created when running <a data-link-type="dfn" href="#steps-for-running-an-upgrade-transaction" id="ref-for-steps-for-running-an-upgrade-transaction-1">steps for running an upgrade transaction</a> after a <a data-link-type="dfn" href="#connection" id="ref-for-connection-22">connection</a> is opened to a <a data-link-type="dfn" href="#database" id="ref-for-database-21">database</a> giving a greater <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-2">version</a> than
-the current <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-3">version</a>. This <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-25">transaction</a> will be active
-inside the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-4">upgradeneeded</a></code> event handler, allowing the
-creation of new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-30">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-11">indexes</a>.</p>
-   <p>An <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-8">upgrade transaction</a> is never run concurrently with other
-transactions. When a database is opened with a <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-4">version</a> number higher than the current <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-5">version</a>, a new <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-9">upgrade
-transaction</a> is automatically created and made available through the <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-1">open request</a> when the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-5">upgradeneeded</a></code> event is
-fired. The <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-6">upgradeneeded</a></code> event isn’t fired, and thus
-the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-10">upgrade transaction</a> isn’t started, until all other <a data-link-type="dfn" href="#connection" id="ref-for-connection-23">connections</a> to the same <a data-link-type="dfn" href="#database" id="ref-for-database-22">database</a> are closed. This ensures
-that all other transactions are <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-4">finished</a>.</p>
-   <p>As long as an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-11">upgrade transaction</a> is running, attempts to open
-more <a data-link-type="dfn" href="#connection" id="ref-for-connection-24">connections</a> to the same <a data-link-type="dfn" href="#database" id="ref-for-database-23">database</a> are delayed, and
-any attempts to use the same <a data-link-type="dfn" href="#connection" id="ref-for-connection-25">connection</a> to start additional
-transactions will result in an exception being thrown. Thus <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-12">upgrade
-transactions</a> not only ensure that no other transactions are
-running concurrently, but also ensure that no other transactions are
-queued against the same <a data-link-type="dfn" href="#database" id="ref-for-database-24">database</a> as long as the transaction is
-running.</p>
+   <p>An <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-7">upgrade transaction</a> is automatically created when running the <a data-link-type="dfn" href="#steps-for-running-an-upgrade-transaction" id="ref-for-steps-for-running-an-upgrade-transaction-1">steps for running an upgrade transaction</a> after a <a data-link-type="dfn" href="#connection" id="ref-for-connection-22">connection</a> is opened to a <a data-link-type="dfn" href="#database" id="ref-for-database-21">database</a>, if a <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-2">version</a> greater than
+the current <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-3">version</a> is specified. This <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-25">transaction</a> will be active inside the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-4">upgradeneeded</a></code> event
+handler.</p>
+   <aside class="note">
+     An <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-8">upgrade transaction</a> enables the creation, renaming, and
+  deletion of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-30">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-11">indexes</a> in a <a data-link-type="dfn" href="#database" id="ref-for-database-22">database</a>. 
+    <p>An <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-9">upgrade transaction</a> is exclusive. The <a data-link-type="dfn" href="#steps-for-opening-a-database" id="ref-for-steps-for-opening-a-database-1">steps for opening a
+  database</a> ensure that only one <a data-link-type="dfn" href="#connection" id="ref-for-connection-23">connection</a> to the database is
+  open when an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-10">upgrade transaction</a> is running.
+  The <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-5">upgradeneeded</a></code> event isn’t fired, and thus the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-11">upgrade transaction</a> isn’t started, until all other <a data-link-type="dfn" href="#connection" id="ref-for-connection-24">connections</a> to the same <a data-link-type="dfn" href="#database" id="ref-for-database-23">database</a> are closed. This ensures
+  that all previous transactions are <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-4">finished</a>. As long
+  as an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-12">upgrade transaction</a> is running, attempts to open more <a data-link-type="dfn" href="#connection" id="ref-for-connection-25">connections</a> to the same <a data-link-type="dfn" href="#database" id="ref-for-database-24">database</a> are delayed, and any
+  attempts to use the same <a data-link-type="dfn" href="#connection" id="ref-for-connection-26">connection</a> to start additional
+  transactions by calling <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-1">transaction()</a></code> will throw an
+  exception. Thus <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-13">upgrade transactions</a> not only ensure that no
+  other transactions are running concurrently, but also ensure that no
+  new transactions are queued against the same <a data-link-type="dfn" href="#database" id="ref-for-database-25">database</a> as long
+  as the transaction is running.</p>
+    <p>This ensures that once an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-14">upgrade transaction</a> is complete, the
+  set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-31">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-12">indexes</a> in a <a data-link-type="dfn" href="#database" id="ref-for-database-26">database</a> remain
+  constant for the lifetime of all subsequent <a data-link-type="dfn" href="#connection" id="ref-for-connection-27">connections</a> and <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-26">transactions</a>.</p>
+   </aside>
    <h3 class="heading settled" data-level="2.8" id="request-construct"><span class="secno">2.8. </span><span class="content">Requests</span><a class="self-link" href="#request-construct"></a></h3>
-   <p>Each asynchronous operation on a <a data-link-type="dfn" href="#database" id="ref-for-database-25">database</a> is done using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="request">request</dfn>. Every request represents one
+   <p>Each asynchronous operation on a <a data-link-type="dfn" href="#database" id="ref-for-database-27">database</a> is done using a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="request">request</dfn>. Every request represents one
 operation.</p>
    <div>
     <p>A <a data-link-type="dfn" href="#request" id="ref-for-request-8">request</a> has a <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-done-flag">done flag</dfn> which is initially unset.</p>
@@ -2460,7 +2464,7 @@ operation.</p>
     <p>A <a data-link-type="dfn" href="#request" id="ref-for-request-10">request</a> has a <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-result">result</dfn> and an <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-error">error</dfn>, neither
 of which are accessible until the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-1">done flag</a> is set.</p>
     <p>A <a data-link-type="dfn" href="#request" id="ref-for-request-11">request</a> has a <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-transaction">transaction</dfn> which is initially null.
-This will be set when a request is <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-placed">placed</dfn> against a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-26">transaction</a> using the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-1">steps for asynchronously executing a
+This will be set when a request is <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-placed">placed</dfn> against a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-27">transaction</a> using the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-1">steps for asynchronously executing a
 request</a>.</p>
     <p>When a request is made, a new <a data-link-type="dfn" href="#request" id="ref-for-request-12">request</a> is returned with its <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-2">done
 flag</a> unset. If a request completes successfully, the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-3">done flag</a> is set, the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-1">result</a> is set to the result of the request,
@@ -2470,32 +2474,32 @@ type <code>error</code> is fired at the request.</p>
     <p>A <a data-link-type="dfn" href="#request" id="ref-for-request-14">request</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#get-the-parent">get the parent</a> algorithm returns the request’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-1">transaction</a>.</p>
     <aside class="note"> Requests are not typically re-used, but there are exceptions. When a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-1">cursor</a> is iterated, the success of the iteration is reported
   on the same <a data-link-type="dfn" href="#request" id="ref-for-request-15">request</a> object used to open the cursor. And when
-  an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-13">upgrade transaction</a> is necessary, the same <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-2">open
-  request</a> is used for both the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-7">upgradeneeded</a></code> event and final result of the open operation itself. In both cases,
+  an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-15">upgrade transaction</a> is necessary, the same <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-1">open
+  request</a> is used for both the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-6">upgradeneeded</a></code> event and final result of the open operation itself. In both cases,
   the request’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-5">done flag</a> will be unset then set again, and the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-2">result</a> may change. </aside>
     <h4 class="heading settled" data-level="2.8.1" id="open-requests"><span class="secno">2.8.1. </span><span class="content">Open Requests</span><a class="self-link" href="#open-requests"></a></h4>
     <p>An <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-open-request">open request</dfn> is a special type of <a data-link-type="dfn" href="#request" id="ref-for-request-16">request</a> used
-when opening a <a data-link-type="dfn" href="#connection" id="ref-for-connection-26">connection</a> or deleting a <a data-link-type="dfn" href="#database" id="ref-for-database-26">database</a>.
-In addition to <code>success</code> and <code>error</code> events, <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-blocked"><code>blocked</code></dfn> and <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-upgradeneeded"><code>upgradeneeded</code></dfn> may be fired at an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-3">open
+when opening a <a data-link-type="dfn" href="#connection" id="ref-for-connection-28">connection</a> or deleting a <a data-link-type="dfn" href="#database" id="ref-for-database-28">database</a>.
+In addition to <code>success</code> and <code>error</code> events, <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-blocked"><code>blocked</code></dfn> and <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-upgradeneeded"><code>upgradeneeded</code></dfn> may be fired at an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-2">open
 request</a> to indicate progress.</p>
-    <p>The <a data-link-type="dfn" href="#request-source" id="ref-for-request-source-1">source</a> of an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-4">open request</a> is always null.</p>
-    <p>The <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-2">transaction</a> of an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-5">open request</a> is null
-unless an <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-8">upgradeneeded</a></code> event has been fired.</p>
-    <p>An <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-6">open request</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#get-the-parent">get the parent</a> algorithm returns null.</p>
-    <p><a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-7">Open requests</a> are processed in a <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-connection-queue">connection queue</dfn>.
-The queue contains all <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-8">open requests</a> associated with an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> and a <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-1">name</a>. Requests added to the <a data-link-type="dfn" href="#request-connection-queue" id="ref-for-request-connection-queue-1">connection queue</a> processed in order and each request must run
+    <p>The <a data-link-type="dfn" href="#request-source" id="ref-for-request-source-1">source</a> of an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-3">open request</a> is always null.</p>
+    <p>The <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-2">transaction</a> of an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-4">open request</a> is null
+unless an <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-7">upgradeneeded</a></code> event has been fired.</p>
+    <p>An <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-5">open request</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#get-the-parent">get the parent</a> algorithm returns null.</p>
+    <p><a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-6">Open requests</a> are processed in a <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-connection-queue">connection queue</dfn>.
+The queue contains all <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-7">open requests</a> associated with an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> and a <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-1">name</a>. Requests added to the <a data-link-type="dfn" href="#request-connection-queue" id="ref-for-request-connection-queue-1">connection queue</a> processed in order and each request must run
 to completion before the next request is processed. An open request
-may be blocked on other <a data-link-type="dfn" href="#connection" id="ref-for-connection-27">connections</a>, requiring those
+may be blocked on other <a data-link-type="dfn" href="#connection" id="ref-for-connection-29">connections</a>, requiring those
 connections to <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-1">close</a> before the request can complete and allow
 further requests to be processed.</p>
     <aside class="note"> A <a data-link-type="dfn" href="#request-connection-queue" id="ref-for-request-connection-queue-2">connection queue</a> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queue</a> associated with
   an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>, as the requests are processed outside any
   specific <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>. The delivery of events to
-  completed <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-9">open request</a> still goes through a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queue</a> associated with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> of the context where the
+  completed <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-8">open request</a> still goes through a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queue</a> associated with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> of the context where the
   request was made. </aside>
    </div>
    <h3 class="heading settled" data-level="2.9" id="range-construct"><span class="secno">2.9. </span><span class="content">Key Range</span><a class="self-link" href="#range-construct"></a></h3>
-   <p>Records can be retrieved from <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-31">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-12">indexes</a> using either <a data-link-type="dfn" href="#key" id="ref-for-key-25">keys</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-1">key ranges</a>. A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-range">key range</dfn> is a
+   <p>Records can be retrieved from <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-32">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-13">indexes</a> using either <a data-link-type="dfn" href="#key" id="ref-for-key-25">keys</a> or <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-1">key ranges</a>. A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-range">key range</dfn> is a
 continuous interval over some data type used for keys.</p>
    <p>A <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-2">key range</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="lower-bound">lower bound</dfn> (null or a <a data-link-type="dfn" href="#key" id="ref-for-key-26">key</a>).</p>
    <p>A <a data-link-type="dfn" href="#key-range" id="ref-for-key-range-3">key range</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="upper-bound">upper bound</dfn> (null or a <a data-link-type="dfn" href="#key" id="ref-for-key-27">key</a>).</p>
@@ -2553,11 +2557,11 @@ a value to a key</a> with <var>value</var>. Rethrow any exceptions.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="2.10" id="cursor-construct"><span class="secno">2.10. </span><span class="content">Cursor</span><a class="self-link" href="#cursor-construct"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cursor">cursor</dfn> is used to iterate over a range of records in an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-13">index</a> or an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-32">object store</a> in a specific direction.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cursor">cursor</dfn> is used to iterate over a range of records in an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-14">index</a> or an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-33">object store</a> in a specific direction.</p>
    <div>
-    <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-2">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-transaction">transaction</dfn>, the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-27">transaction</a> that was <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-5">active</a> when the cursor was created.</p>
-    <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-3">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-range">range</dfn> of records in either an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-14">index</a> or an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-33">object store</a>.</p>
-    <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-4">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-source">source</dfn> that indicates which <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-15">index</a> or an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-34">object store</a> is associated with the records over which
+    <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-2">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-transaction">transaction</dfn>, the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-28">transaction</a> that was <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-5">active</a> when the cursor was created.</p>
+    <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-3">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-range">range</dfn> of records in either an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-15">index</a> or an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-34">object store</a>.</p>
+    <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-4">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-source">source</dfn> that indicates which <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-16">index</a> or an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-35">object store</a> is associated with the records over which
 the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-5">cursor</a> is iterating.</p>
     <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-6">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-direction">direction</dfn> that determines whether it
 moves in monotonically increasing or decreasing order of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-15">record</a> keys when iterated, and if it skips duplicated values
@@ -2572,7 +2576,7 @@ the cursor initial position is at the start of its <a data-link-type="dfn" href=
      <dd> This direction causes the cursor to be opened at the start of the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-3">source</a>. When iterated, the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-8">cursor</a> should not yield
     records with the same key, but otherwise yield all records, in
     monotonically increasing order of keys. For every key with
-    duplicate values, only the first record is yielded. When the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-4">source</a> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-35">object store</a> or an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-16">index</a> with
+    duplicate values, only the first record is yielded. When the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-4">source</a> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-36">object store</a> or an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-17">index</a> with
     the <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-1">unique flag</a> set, this direction has exactly the same
     behavior as <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-2">"next"</a></code>. 
      <dt><code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-1">"prev"</a></code>
@@ -2583,7 +2587,7 @@ the cursor initial position is at the start of its <a data-link-type="dfn" href=
      <dd> This direction causes the cursor to be opened at the end of the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-6">source</a>. When iterated, the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-10">cursor</a> should not
     yield records with the same key, but otherwise yield all records,
     in monotonically decreasing order of keys. For every key with
-    duplicate values, only the first record is yielded. When the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-7">source</a> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-36">object store</a> or an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-17">index</a> with the <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-2">unique flag</a> set, this direction
+    duplicate values, only the first record is yielded. When the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-7">source</a> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-37">object store</a> or an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-18">index</a> with the <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-2">unique flag</a> set, this direction
     has exactly the same behavior as <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-2">"prev"</a></code>. 
     </dl>
     <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-11">cursor</a> has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-position">position</dfn> within its range. It is
@@ -2609,15 +2613,15 @@ the cursor is either in the process of loading the next value or it
 has reached the end of its <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-2">range</a>. When it is set, it indicates
 that the cursor is currently holding a value and that it is ready to
 iterate to the next one.</p>
-    <p>If the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-8">source</a> of a cursor is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-37">object store</a>, the <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-effective-object-store">effective object store</dfn> of the cursor is that object store
-and the <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-effective-key">effective key</dfn> of the cursor is the cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-3">position</a>. If the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-9">source</a> of a cursor is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-18">index</a>,
+    <p>If the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-8">source</a> of a cursor is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-38">object store</a>, the <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-effective-object-store">effective object store</dfn> of the cursor is that object store
+and the <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-effective-key">effective key</dfn> of the cursor is the cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-3">position</a>. If the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-9">source</a> of a cursor is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-19">index</a>,
 the <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-1">effective object store</a> of the cursor is that index’s <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-6">referenced</a> object store and the <a data-link-type="dfn" href="#cursor-effective-key" id="ref-for-cursor-effective-key-1">effective key</a> is the cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-2">object store position</a>.</p>
     <p>A <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-15">cursor</a> also has a <dfn class="dfn-paneled" data-dfn-for="cursor" data-dfn-type="dfn" data-noexport="" id="cursor-key-only-flag">key only flag</dfn>, that indicates
 whether the cursor’s <a data-link-type="dfn" href="#cursor-value" id="ref-for-cursor-value-1">value</a> is exposed via the API. Unless
 stated otherwise it is unset.</p>
    </div>
    <h3 class="heading settled" data-level="2.11" id="key-generator-construct"><span class="secno">2.11. </span><span class="content">Key Generators</span><a class="self-link" href="#key-generator-construct"></a></h3>
-   <p>When a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-38">object store</a> is created it can be specified to use a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-generator">key generator</dfn>. A <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-3">key generator</a> keeps an internal <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-number">current number</dfn>. The <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-1">current number</a> is always a positive
+   <p>When a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-39">object store</a> is created it can be specified to use a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-generator">key generator</dfn>. A <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-3">key generator</a> keeps an internal <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-number">current number</dfn>. The <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-1">current number</a> is always a positive
 integer. Whenever the key generator is used to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-37">key</a>, the generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-2">current number</a> is returned and <strong>then</strong> incremented to prepare for the next time a new <a data-link-type="dfn" href="#key" id="ref-for-key-38">key</a> is needed. Implementations must use the following rules for
 generating numbers when a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-4">key generator</a> is used.</p>
    <ul>
@@ -2627,11 +2631,11 @@ generator. I.e. interacting with one object store never affects
 the key generator of any other object store.</p>
     <li data-md="">
      <p>The <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-3">current number</a> of a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-5">key generator</a> is always set to
-1 when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-39">object store</a> for that key generator is first
+1 when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-40">object store</a> for that key generator is first
 created.</p>
     <li data-md="">
      <p>When a key generator is used to generate a new <a data-link-type="dfn" href="#key" id="ref-for-key-39">key</a> for
-a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-40">object store</a>, the key generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-4">current
+a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-41">object store</a>, the key generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-4">current
 number</a> is used as the new key value and then the key
 generator’s <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-5">current number</a> is increased by 1.</p>
     <li data-md="">
@@ -2659,10 +2663,10 @@ number</a> getting increased by 1 when the key generator is used,
 and to modifications that happen due to a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-20">record</a> being
 stored with a key value specified in the call to store the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-21">record</a>.</p>
     <li data-md="">
-     <p>Likewise, if a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-28">transaction</a> is aborted, the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-15">current
-number</a> of the key generator for each <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-41">object store</a> in
+     <p>Likewise, if a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-29">transaction</a> is aborted, the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-15">current
+number</a> of the key generator for each <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-42">object store</a> in
 the transaction’s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-11">scope</a> is reverted to the value it had
-before the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-29">transaction</a> was started.</p>
+before the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-30">transaction</a> was started.</p>
     <li data-md="">
      <p>When the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-16">current number</a> of a key generator reaches above the
 value 2<sup>53</sup> (9007199254740992) any attempts to use the
@@ -2676,7 +2680,7 @@ object store is to delete the object store and create a new one.</p>
   285000 years. </aside>
     <li data-md="">
      <p>The <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-17">current number</a> for a key generator never decreases, other
-than as a result of database operations being reverted. Deleting a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-23">record</a> from an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-42">object store</a> never affects the
+than as a result of database operations being reverted. Deleting a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-23">record</a> from an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-43">object store</a> never affects the
 object store’s key generator. Even clearing all records from an
 object store, for example using the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-clear" id="ref-for-dom-idbobjectstore-clear-1">clear()</a></code> method, does not
 affect the <a data-link-type="dfn" href="#current-number" id="ref-for-current-number-18">current number</a> of the object store’s key
@@ -2758,11 +2762,11 @@ store_t2<span class="p">.</span>put<span class="p">(</span><span class="s2">"c"<
     <a class="self-link" href="#example-bfe51756"></a> 
     <p>The following examples illustrate the different behaviors when trying
 to use in-line <a data-link-type="dfn" href="#key" id="ref-for-key-42">keys</a> and <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-6">key generators</a> to save an object
-to an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-43">object store</a>.</p>
+to an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-44">object store</a>.</p>
     <p>If the following conditions are true:</p>
     <ul>
      <li data-md="">
-      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-44">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-7">key generator</a>.</p>
+      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-45">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-7">key generator</a>.</p>
      <li data-md="">
       <p>There is no in-line value for the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-3">key path</a> property.</p>
     </ul>
@@ -2770,7 +2774,7 @@ to an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-43">
 the key value. In the example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-4">key path</a> for
 the object store is "<code>foo.bar</code>". The actual object has no
 value for the <code>bar</code> property, <code>{ foo: {} }</code>.
-When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-45">object store</a> the <code>bar</code> property is assigned a value of 1 because that is the next <a data-link-type="dfn" href="#key" id="ref-for-key-43">key</a> generated by the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-9">key generator</a>.</p>
+When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-46">object store</a> the <code>bar</code> property is assigned a value of 1 because that is the next <a data-link-type="dfn" href="#key" id="ref-for-key-43">key</a> generated by the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-9">key generator</a>.</p>
 <pre class="lang-javascript highlight"><span class="kd">var</span> store <span class="o">=</span> db<span class="p">.</span>createObjectStore<span class="p">(</span><span class="s2">"store"</span><span class="p">,</span> <span class="p">{</span> keyPath<span class="o">:</span> <span class="s2">"foo.bar"</span><span class="p">,</span>
                                             autoIncrement<span class="o">:</span> <span class="kc">true</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
 store<span class="p">.</span>put<span class="p">(</span><span class="p">{</span> foo<span class="o">:</span> <span class="p">{</span><span class="p">}</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span>onsuccess <span class="o">=</span> <span class="kd">function</span><span class="p">(</span>e<span class="p">)</span> <span class="p">{</span>
@@ -2781,15 +2785,15 @@ store<span class="p">.</span>put<span class="p">(</span><span class="p">{</span>
     <p>If the following conditions are true:</p>
     <ul>
      <li data-md="">
-      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-46">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-10">key generator</a>.</p>
+      <p>The <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-47">object store</a> has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-10">key generator</a>.</p>
      <li data-md="">
       <p>There is a value for the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-5">key path</a> property.</p>
     </ul>
     <p>Then the value associated with the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-6">key path</a> property is used. The auto-generated <a data-link-type="dfn" href="#key" id="ref-for-key-44">key</a> is not used. In the
-example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-7">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-47">object
+example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-7">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-48">object
 store</a> is "<code>foo.bar</code>". The actual object has a value of
 10 for the <code>bar</code> property, <code>{ foo: { bar: 10}
-}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-48">object store</a> the <code>bar</code> property keeps its value of 10, because that is the
+}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-49">object store</a> the <code>bar</code> property keeps its value of 10, because that is the
 key value.</p>
 <pre class="lang-javascript highlight"><span class="kd">var</span> store <span class="o">=</span> db<span class="p">.</span>createObjectStore<span class="p">(</span><span class="s2">"store"</span><span class="p">,</span> <span class="p">{</span> keyPath<span class="o">:</span> <span class="s2">"foo.bar"</span><span class="p">,</span>
                                             autoIncrement<span class="o">:</span> <span class="kc">true</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
@@ -2804,9 +2808,9 @@ path</a> but there is no property matching it. The value provided by
 the <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-11">key generator</a> is then used to populate the key value and
 the system is responsible for creating as many properties as it
 requires to suffice the property dependencies on the hierarchy chain.
-In the example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-9">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-49">object store</a> is "<code>foo.bar.baz</code>". The actual
+In the example below the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-9">key path</a> for the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-50">object store</a> is "<code>foo.bar.baz</code>". The actual
 object has no value for the <code>foo</code> property, <code>{ zip: {}
-}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-50">object store</a> the <code>foo</code>, <code>bar</code>, and <code>baz</code> properties are created each as a child of the other until a value for <code>foo.bar.baz</code> can be assigned. The value for <code>foo.bar.baz</code> is the next key generated by the object
+}</code>. When the object is saved in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-51">object store</a> the <code>foo</code>, <code>bar</code>, and <code>baz</code> properties are created each as a child of the other until a value for <code>foo.bar.baz</code> can be assigned. The value for <code>foo.bar.baz</code> is the next key generated by the object
 store.</p>
 <pre class="lang-javascript highlight"><span class="kd">var</span> store <span class="o">=</span> db<span class="p">.</span>createObjectStore<span class="p">(</span><span class="s2">"store"</span><span class="p">,</span> <span class="p">{</span> keyPath<span class="o">:</span> <span class="s2">"foo.bar.baz"</span><span class="p">,</span>
                                             autoIncrement<span class="o">:</span> <span class="kc">true</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
@@ -2915,13 +2919,13 @@ through the properties of the <code class="idl"><a data-link-type="idl" href="#i
 access task source<a class="self-link" href="#database-access-task-source"></a></dfn>.</p>
    <h3 class="heading settled" data-level="4.1" id="request-api"><span class="secno">4.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-3">IDBRequest</a></code> interface</span><a class="self-link" href="#request-api"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-4">IDBRequest</a></code> interface provides the means to access results of
-asynchronous requests to <a data-link-type="dfn" href="#database" id="ref-for-database-27">databases</a> and <a data-link-type="dfn" href="#database" id="ref-for-database-28">database</a> objects using <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
+asynchronous requests to <a data-link-type="dfn" href="#database" id="ref-for-database-29">databases</a> and <a data-link-type="dfn" href="#database" id="ref-for-database-30">database</a> objects using <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
    <p>Every method for making asynchronous requests returns an <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-5">IDBRequest</a></code> object that communicates back to the requesting
 application through events. This design means that any number of
-requests can be active on any <a data-link-type="dfn" href="#database" id="ref-for-database-29">database</a> at a time.</p>
+requests can be active on any <a data-link-type="dfn" href="#database" id="ref-for-database-31">database</a> at a time.</p>
    <aside class="example" id="example-1f3203ec">
     <a class="self-link" href="#example-1f3203ec"></a> 
-    <p>In the following example, we open a <a data-link-type="dfn" href="#database" id="ref-for-database-30">database</a> asynchronously.
+    <p>In the following example, we open a <a data-link-type="dfn" href="#database" id="ref-for-database-32">database</a> asynchronously.
 Various event handlers are registered for responding to various
 situations.</p>
 <pre class="lang-javascript highlight"><span class="kd">var</span> request <span class="o">=</span> indexedDB<span class="p">.</span>open<span class="p">(</span><span class="s1">'AddressBook'</span><span class="p">,</span> <span class="mi">15</span><span class="p">)</span><span class="p">;</span>
@@ -2957,11 +2961,11 @@ request<span class="p">.</span>onerror <span class="o">=</span> <span class="kd"
      <dd> When a request is completed, returns the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-2">error</a> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>), or null if the request succeeded. Throws
         a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the request is still pending. 
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-source" id="ref-for-dom-idbrequest-source-2">source</a></code>
-     <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-2">IDBObjectStore</a></code>, <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-2">IDBIndex</a></code>, or <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-2">IDBCursor</a></code> the request was made against, or null if is was an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-10">open
+     <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-2">IDBObjectStore</a></code>, <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-2">IDBIndex</a></code>, or <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-2">IDBCursor</a></code> the request was made against, or null if is was an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-9">open
         request</a>. 
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-transaction" id="ref-for-dom-idbrequest-transaction-2">transaction</a></code>
      <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-2">IDBTransaction</a></code> the request was made within.
-        If this as an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-11">open request</a>, then it returns an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-14">upgrade transaction</a> while it is running, or null otherwise. 
+        If this as an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-10">open request</a>, then it returns an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-16">upgrade transaction</a> while it is running, or null otherwise. 
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-readystate" id="ref-for-dom-idbrequest-readystate-2">readyState</a></code>
      <dd> Returns <code class="idl"><a data-link-type="idl" href="#dom-idbrequestreadystate-pending" id="ref-for-dom-idbrequestreadystate-pending-1">"pending"</a></code> until a request is complete,
         then returns <code class="idl"><a data-link-type="idl" href="#dom-idbrequestreadystate-done" id="ref-for-dom-idbrequestreadystate-done-1">"done"</a></code>. 
@@ -2984,8 +2988,8 @@ must return <code class="idl"><a data-link-type="idl" href="#dom-idbrequestready
 event handler for the <code>success</code> event.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-onerror">onerror</dfn> attribute is the event
 handler for the <code>error</code> event.</p>
-   <p>Methods on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-1">IDBDatabase</a></code> that return a <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-12">open request</a> use an
-extended interface to allow listening to the <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-1">blocked</a></code> event and <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-9">upgradeneeded</a></code> event.</p>
+   <p>Methods on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-1">IDBDatabase</a></code> that return a <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-11">open request</a> use an
+extended interface to allow listening to the <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-1">blocked</a></code> event and <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-8">upgradeneeded</a></code> event.</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbopendbrequest">IDBOpenDBRequest</dfn> : <a class="n" data-link-type="idl-name" href="#idbrequest" id="ref-for-idbrequest-6">IDBRequest</a> {
   // Event handlers:
@@ -2995,7 +2999,7 @@ extended interface to allow listening to the <code><a data-link-type="dfn" href=
 </pre>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBOpenDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbopendbrequest-onblocked">onblocked</dfn> attribute is
 the event handler for the <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-2">blocked</a></code> event.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBOpenDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbopendbrequest-onupgradeneeded">onupgradeneeded</dfn> attribute is the event handler for the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-10">upgradeneeded</a></code> event.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBOpenDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbopendbrequest-onupgradeneeded">onupgradeneeded</dfn> attribute is the event handler for the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-9">upgradeneeded</a></code> event.</p>
    <h3 class="heading settled" data-level="4.2" id="events"><span class="secno">4.2. </span><span class="content">Event interfaces</span><a class="self-link" href="#events"></a></h3>
    <p>This specification fires events with the following custom interfaces:</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>),
@@ -3020,7 +3024,7 @@ events</a>, in <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>.</p>
 event must use the <code class="idl"><a data-link-type="idl" href="#idbversionchangeevent" id="ref-for-idbversionchangeevent-1">IDBVersionChangeEvent</a></code> interface with its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> set to <var>e</var>, its <code class="idl"><a data-link-type="idl" href="#dom-idbversionchangeevent-oldversion" id="ref-for-dom-idbversionchangeevent-oldversion-2">oldVersion</a></code> attribute set to <var>oldVersion</var>, and its <code class="idl"><a data-link-type="idl" href="#dom-idbversionchangeevent-newversion" id="ref-for-dom-idbversionchangeevent-newversion-2">newVersion</a></code> attribute set to <var>newVersion</var>.
 This event must not bubble or be cancelable.</p>
    <h3 class="heading settled" data-level="4.3" id="factory-interface"><span class="secno">4.3. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#idbfactory" id="ref-for-idbfactory-1">IDBFactory</a></code> interface</span><a class="self-link" href="#factory-interface"></a></h3>
-   <p><a data-link-type="dfn" href="#database" id="ref-for-database-31">Database</a> objects are accessed through methods on the <code class="idl"><a data-link-type="idl" href="#idbfactory" id="ref-for-idbfactory-2">IDBFactory</a></code> interface. A single object implementing this
+   <p><a data-link-type="dfn" href="#database" id="ref-for-database-33">Database</a> objects are accessed through methods on the <code class="idl"><a data-link-type="idl" href="#idbfactory" id="ref-for-idbfactory-2">IDBFactory</a></code> interface. A single object implementing this
 interface is present in the global scope of environments that support
 Indexed DB operations.</p>
 <pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">WindowOrWorkerGlobalScope</a> {
@@ -3041,18 +3045,18 @@ of indexed databases.</p>
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>request</var> = indexedDB . <code class="idl"><a data-link-type="idl" href="#dom-idbfactory-open" id="ref-for-dom-idbfactory-open-3">open</a></code>(<var>name</var>)
-     <dd> Attempts to open a <a data-link-type="dfn" href="#connection" id="ref-for-connection-28">connection</a> to the named <a data-link-type="dfn" href="#database" id="ref-for-database-32">database</a> with the current version, or 1 if it does not already exist.
-        If the request is successful <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-3">result</a></code> will be the <a data-link-type="dfn" href="#connection" id="ref-for-connection-29">connection</a>. 
+     <dd> Attempts to open a <a data-link-type="dfn" href="#connection" id="ref-for-connection-30">connection</a> to the named <a data-link-type="dfn" href="#database" id="ref-for-database-34">database</a> with the current version, or 1 if it does not already exist.
+        If the request is successful <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-3">result</a></code> will be the <a data-link-type="dfn" href="#connection" id="ref-for-connection-31">connection</a>. 
      <dt><var>request</var> = indexedDB . <code class="idl"><a data-link-type="idl" href="#dom-idbfactory-open" id="ref-for-dom-idbfactory-open-4">open</a></code>(<var>name</var>, <var>version</var>)
-     <dd> Attempts to open a <a data-link-type="dfn" href="#connection" id="ref-for-connection-30">connection</a> to the named <a data-link-type="dfn" href="#database" id="ref-for-database-33">database</a> with the specified version. If the database already exists
-        with a lower version and there are open <a data-link-type="dfn" href="#connection" id="ref-for-connection-31">connections</a> that don’t close in response to a <code>versionchange</code> event, the request will be <a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-3">blocked</a> until all they close, then an upgrade
+     <dd> Attempts to open a <a data-link-type="dfn" href="#connection" id="ref-for-connection-32">connection</a> to the named <a data-link-type="dfn" href="#database" id="ref-for-database-35">database</a> with the specified version. If the database already exists
+        with a lower version and there are open <a data-link-type="dfn" href="#connection" id="ref-for-connection-33">connections</a> that don’t close in response to a <code>versionchange</code> event, the request will be <a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-3">blocked</a> until all they close, then an upgrade
         will occur. If the database already exists with a higher
         version the request will fail. If the request is
         successful <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-4">result</a></code> will
-        be the <a data-link-type="dfn" href="#connection" id="ref-for-connection-32">connection</a>. 
+        be the <a data-link-type="dfn" href="#connection" id="ref-for-connection-34">connection</a>. 
      <dt><var>request</var> = indexedDB . <code class="idl"><a data-link-type="idl" href="#dom-idbfactory-deletedatabase" id="ref-for-dom-idbfactory-deletedatabase-2">deleteDatabase</a></code>(<var>name</var>)
-     <dd> Attempts to delete the named <a data-link-type="dfn" href="#database" id="ref-for-database-34">database</a>. If the
-        database already exists and there are open <a data-link-type="dfn" href="#connection" id="ref-for-connection-33">connections</a> that don’t close in response to a <code>versionchange</code> event, the request will be <a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-4">blocked</a> until all they close. If the request
+     <dd> Attempts to delete the named <a data-link-type="dfn" href="#database" id="ref-for-database-36">database</a>. If the
+        database already exists and there are open <a data-link-type="dfn" href="#connection" id="ref-for-connection-35">connections</a> that don’t close in response to a <code>versionchange</code> event, the request will be <a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-4">blocked</a> until all they close. If the request
         is successful <var>request</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-result" id="ref-for-dom-idbrequest-result-5">result</a></code> will be null. 
     </dl>
    </div>
@@ -3069,19 +3073,19 @@ to access this <code class="idl"><a data-link-type="idl" href="#idbfactory" id="
       <p>If <var>origin</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
      <li data-md="">
-      <p>Let <var>request</var> be a new <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-13">open request</a>.</p>
+      <p>Let <var>request</var> be a new <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-12">open request</a>.</p>
      <li data-md="">
       <p>Run the following substeps in parallel:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of running the <a data-link-type="dfn" href="#steps-for-opening-a-database" id="ref-for-steps-for-opening-a-database-1">steps for
+        <p>Let <var>result</var> be the result of running the <a data-link-type="dfn" href="#steps-for-opening-a-database" id="ref-for-steps-for-opening-a-database-2">steps for
 opening a database</a>, with <var>origin</var>, <var>name</var>, <var>version</var> if given and undefined
 otherwise, and <var>request</var>.</p>
         <details class="note">
          <summary>What happens if <var>version</var> is not given?</summary>
-          If <var>version</var> is not given and a <a data-link-type="dfn" href="#database" id="ref-for-database-35">database</a> with that name already exists, a connection will be opened
-  without changing the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-6">version</a>. If <var>version</var> is not given and no <a data-link-type="dfn" href="#database" id="ref-for-database-36">database</a> with
-  that name exists, a new <a data-link-type="dfn" href="#database" id="ref-for-database-37">database</a> will be created with <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-7">version</a> equal to 1. 
+          If <var>version</var> is not given and a <a data-link-type="dfn" href="#database" id="ref-for-database-37">database</a> with that name already exists, a connection will be opened
+  without changing the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-4">version</a>. If <var>version</var> is not given and no <a data-link-type="dfn" href="#database" id="ref-for-database-38">database</a> with
+  that name exists, a new <a data-link-type="dfn" href="#database" id="ref-for-database-39">database</a> will be created with <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-5">version</a> equal to 1. 
         </details>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these substeps:</p>
@@ -3095,9 +3099,9 @@ cancelable.</p>
           <p>Otherwise, set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-5">result</a> of <var>request</var> to <var>result</var> and dispatch an event at <var>request</var>. The event
 must use the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">Event</a> interface and set the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to "<code>success</code>". The
 event does not bubble and is not cancelable. If the steps
-above resulted in an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-15">upgrade transaction</a> being run,
+above resulted in an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-17">upgrade transaction</a> being run,
 then firing the "<code>success</code>" event must be done
-after the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-16">upgrade transaction</a> completes.</p>
+after the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-18">upgrade transaction</a> completes.</p>
           <aside class="note"> The last requirement is to ensure that in case another
   version upgrade is about to happen, the success event is
   fired on the connection first so that the script gets a
@@ -3123,7 +3127,7 @@ to access this <code class="idl"><a data-link-type="idl" href="#idbfactory" id="
       <p>If <var>origin</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">opaque origin</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
      <li data-md="">
-      <p>Let <var>request</var> be a new <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-14">open request</a>.</p>
+      <p>Let <var>request</var> be a new <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-13">open request</a>.</p>
      <li data-md="">
       <p>Run the following substeps in parallel:</p>
       <ol>
@@ -3178,18 +3182,18 @@ value to a key</a> with <var>second</var>. Rethrow any exceptions.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="4.4" id="database-interface"><span class="secno">4.4. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-2">IDBDatabase</a></code> interface</span><a class="self-link" href="#database-interface"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-3">IDBDatabase</a></code> interface represents a <a data-link-type="dfn" href="#connection" id="ref-for-connection-34">connection</a> to a <a data-link-type="dfn" href="#database" id="ref-for-database-38">database</a>.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-3">IDBDatabase</a></code> interface represents a <a data-link-type="dfn" href="#connection" id="ref-for-connection-36">connection</a> to a <a data-link-type="dfn" href="#database" id="ref-for-database-40">database</a>.</p>
    <p>An <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-4">IDBDatabase</a></code> object must not be garbage collected if its
-associated <a data-link-type="dfn" href="#connection" id="ref-for-connection-35">connection</a>'s <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-2">close pending flag</a> is unset and it
+associated <a data-link-type="dfn" href="#connection" id="ref-for-connection-37">connection</a>'s <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-2">close pending flag</a> is unset and it
 has one or more event listeners registers whose type is one of <code>abort</code>, <code>error</code>, or <code>versionchange</code>.
-If an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-5">IDBDatabase</a></code> object is garbage collected, the associated <a data-link-type="dfn" href="#connection" id="ref-for-connection-36">connection</a> must be <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-2">closed</a>.</p>
+If an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-5">IDBDatabase</a></code> object is garbage collected, the associated <a data-link-type="dfn" href="#connection" id="ref-for-connection-38">connection</a> must be <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-2">closed</a>.</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbdatabase">IDBDatabase</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>          <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-idbdatabase-name" id="ref-for-dom-idbdatabase-name-1">name</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long" href="#dom-idbdatabase-version" id="ref-for-dom-idbdatabase-version-1">version</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-1">objectStoreNames</a>;
 
-  <a class="n" data-link-type="idl-name" href="#idbtransaction" id="ref-for-idbtransaction-3">IDBTransaction</a> <a class="nv idl-code" data-link-type="method" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-1">transaction</a>((<span class="kt">DOMString</span> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<span class="kt">DOMString</span>>) <dfn class="nv idl-code" data-dfn-for="IDBDatabase/transaction(storeNames, mode), IDBDatabase/transaction(storeNames)" data-dfn-type="argument" data-export="" id="dom-idbdatabase-transaction-storenames-mode-storenames">storeNames<a class="self-link" href="#dom-idbdatabase-transaction-storenames-mode-storenames"></a></dfn>,
+  <a class="n" data-link-type="idl-name" href="#idbtransaction" id="ref-for-idbtransaction-3">IDBTransaction</a> <a class="nv idl-code" data-link-type="method" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-2">transaction</a>((<span class="kt">DOMString</span> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<span class="kt">DOMString</span>>) <dfn class="nv idl-code" data-dfn-for="IDBDatabase/transaction(storeNames, mode), IDBDatabase/transaction(storeNames)" data-dfn-type="argument" data-export="" id="dom-idbdatabase-transaction-storenames-mode-storenames">storeNames<a class="self-link" href="#dom-idbdatabase-transaction-storenames-mode-storenames"></a></dfn>,
                              <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#enumdef-idbtransactionmode" id="ref-for-enumdef-idbtransactionmode-1">IDBTransactionMode</a> <dfn class="nv idl-code" data-dfn-for="IDBDatabase/transaction(storeNames, mode), IDBDatabase/transaction(storeNames)" data-dfn-type="argument" data-export="" id="dom-idbdatabase-transaction-storenames-mode-mode">mode<a class="self-link" href="#dom-idbdatabase-transaction-storenames-mode-mode"></a></dfn> = "readonly");
   <span class="kt">void</span>           <a class="nv idl-code" data-link-type="method" href="#dom-idbdatabase-close" id="ref-for-dom-idbdatabase-close-2">close</a>();
 
@@ -3214,46 +3218,46 @@ If an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-name" id="ref-for-dom-idbdatabase-name-2">name</a></code>
      <dd> Returns the <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-2">name</a> of the database. 
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-version" id="ref-for-dom-idbdatabase-version-2">version</a></code>
-     <dd> Returns the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-8">version</a> of the database. 
+     <dd> Returns the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-6">version</a> of the database. 
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-name">name</dfn> attribute’s getter must
-return the <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-3">name</a> of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-37">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-39">database</a>. The attribute must return this name even if the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-3">close pending flag</a> is set on the <a data-link-type="dfn" href="#connection" id="ref-for-connection-38">connection</a>. In
+return the <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-3">name</a> of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-39">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-41">database</a>. The attribute must return this name even if the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-3">close pending flag</a> is set on the <a data-link-type="dfn" href="#connection" id="ref-for-connection-40">connection</a>. In
 other words, the value of this attribute stays constant for the
 lifetime of the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-6">IDBDatabase</a></code> instance.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-version">version</dfn> attribute’s getter
-must return this <a data-link-type="dfn" href="#connection" id="ref-for-connection-39">connection</a>'s <a data-link-type="dfn" href="#connection-version" id="ref-for-connection-version-2">version</a>.</p>
-   <aside class="note"> As long as the <a data-link-type="dfn" href="#connection" id="ref-for-connection-40">connection</a> is open, this is the same as the
-  connected <a data-link-type="dfn" href="#database" id="ref-for-database-40">database</a>'s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-9">version</a>. Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-41">connection</a> has <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-3">closed</a>, this attribute will not
-  reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-17">upgrade transaction</a>. </aside>
+must return this <a data-link-type="dfn" href="#connection" id="ref-for-connection-41">connection</a>'s <a data-link-type="dfn" href="#connection-version" id="ref-for-connection-version-2">version</a>.</p>
+   <aside class="note"> As long as the <a data-link-type="dfn" href="#connection" id="ref-for-connection-42">connection</a> is open, this is the same as the
+  connected <a data-link-type="dfn" href="#database" id="ref-for-database-42">database</a>'s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-7">version</a>. Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-43">connection</a> has <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-3">closed</a>, this attribute will not
+  reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-19">upgrade transaction</a>. </aside>
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-2">objectStoreNames</a></code>
-     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-51">object stores</a> in the database. 
+     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-52">object stores</a> in the database. 
      <dt><var>store</var> = <var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-2">createObjectStore</a></code>(<var>name</var> [, <var>options</var>])
      <dd>
-       Creates a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-52">object store</a> with the given <var>name</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-4">IDBObjectStore</a></code>. 
-      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-18">upgrade transaction</a>.</p>
+       Creates a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-53">object store</a> with the given <var>name</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-4">IDBObjectStore</a></code>. 
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-20">upgrade transaction</a>.</p>
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-deleteobjectstore" id="ref-for-dom-idbdatabase-deleteobjectstore-2">deleteObjectStore</a></code>(<var>name</var>)
      <dd>
-       Deletes the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-53">object store</a> with the given <var>name</var>. 
-      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-19">upgrade transaction</a>.</p>
+       Deletes the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-54">object store</a> with the given <var>name</var>. 
+      <p>Throws a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-21">upgrade transaction</a>.</p>
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-objectstorenames">objectStoreNames</dfn> attribute’s
 getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-1">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-2">names</a> of
-the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-54">object stores</a> in this <a data-link-type="dfn" href="#connection" id="ref-for-connection-42">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-1">object store set</a>.</p>
-   <aside class="note"> As long as the <a data-link-type="dfn" href="#connection" id="ref-for-connection-43">connection</a> is open, this is the same as the
-  connected <a data-link-type="dfn" href="#database" id="ref-for-database-41">database</a>'s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-55">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-3">names</a>.
-  Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-44">connection</a> has <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-4">closed</a>, this attribute
-  will not reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-20">upgrade transaction</a>. </aside>
+the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-55">object stores</a> in this <a data-link-type="dfn" href="#connection" id="ref-for-connection-44">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-1">object store set</a>.</p>
+   <aside class="note"> As long as the <a data-link-type="dfn" href="#connection" id="ref-for-connection-45">connection</a> is open, this is the same as the
+  connected <a data-link-type="dfn" href="#database" id="ref-for-database-43">database</a>'s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-56">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-3">names</a>.
+  Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-46">connection</a> has <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-4">closed</a>, this attribute
+  will not reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-22">upgrade transaction</a>. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="method" data-export="" data-lt="createObjectStore(name, options)|createObjectStore(name)" id="dom-idbdatabase-createobjectstore">createObjectStore(<var>name</var>, <var>options</var>)</dfn> method, when invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>database</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-42">database</a> associated with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-45">connection</a>.</p>
+      <p>Let <var>database</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-44">database</a> associated with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-47">connection</a>.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-21">upgrade transaction</a> associated with <var>database</var>. If one does not exist or it is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-5">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>Let <var>transaction</var> be the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-23">upgrade transaction</a> associated with <var>database</var>. If one does not exist or it is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-5">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-6">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -3263,7 +3267,7 @@ the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-54">ob
       <p>If <var>keyPath</var> is not null and is not a <a data-link-type="dfn" href="#valid-key-path" id="ref-for-valid-key-path-1">valid key
 path</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-56">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-4">named</a> <var>name</var> already
+      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-57">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-4">named</a> <var>name</var> already
 exists in <var>database</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>autoIncrement</var> be set if <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstoreparameters-autoincrement" id="ref-for-dom-idbobjectstoreparameters-autoincrement-1">autoIncrement</a></code> member is true, or
@@ -3273,42 +3277,42 @@ unset otherwise.</p>
 sequence (empty or otherwise), <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-57">object store</a> in <var>database</var>. Set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-58">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-5">name</a> to <var>name</var>. If <var>autoIncrement</var> is set, then the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-59">object
+      <p>Let <var>store</var> be a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-58">object store</a> in <var>database</var>. Set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-59">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-5">name</a> to <var>name</var>. If <var>autoIncrement</var> is set, then the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-60">object
 store</a> uses a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-12">key generator</a>. If <var>keyPath</var> is
-not null, set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-60">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-11">key path</a> to <var>keyPath</var>.</p>
+not null, set the created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-61">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-11">key path</a> to <var>keyPath</var>.</p>
      <li data-md="">
       <p>Return a new <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-8">object store handle</a> associated with <var>store</var> and <var>transaction</var>.</p>
     </ol>
    </div>
-   <p>This method creates and returns a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-61">object store</a> with the given
-name in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-46">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-43">database</a>. Note that this method must
-only be called from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-22">upgrade transaction</a>.</p>
+   <p>This method creates and returns a new <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-62">object store</a> with the given
+name in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-48">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-45">database</a>. Note that this method must
+only be called from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-24">upgrade transaction</a>.</p>
    <p>This method synchronously modifies the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-3">objectStoreNames</a></code> property on the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-7">IDBDatabase</a></code> instance on which it was called.</p>
    <p>In some implementations it is possible for the implementation to run
-into problems after queuing a task to create the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-62">object store</a> after the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-3">createObjectStore()</a></code> method has returned. For example in
-implementations where metadata about the newly created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-63">object
+into problems after queuing a task to create the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-63">object store</a> after the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-3">createObjectStore()</a></code> method has returned. For example in
+implementations where metadata about the newly created <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-64">object
 store</a> is inserted into the database asynchronously, or where the
 implementation might need to ask the user for permission for quota
 reasons. Such implementations must still create and return an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-5">IDBObjectStore</a></code> object, and once the implementation determines that
-creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-64">object store</a> has failed, it must abort the
+creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-65">object store</a> has failed, it must abort the
 transaction using the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-3">steps for aborting a transaction</a> using the
-appropriate error. For example if creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-65">object store</a> failed due to quota reasons, a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as
+appropriate error. For example if creating the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-66">object store</a> failed due to quota reasons, a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as
 error.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="method" data-export="" id="dom-idbdatabase-deleteobjectstore">deleteObjectStore(<var>name</var>)</dfn> method, when invoked, must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>database</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-44">database</a> associated with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-47">connection</a>.</p>
+      <p>Let <var>database</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-46">database</a> associated with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-49">connection</a>.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-23">upgrade transaction</a> associated with <var>database</var>. If one does not exist or it is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-6">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>Let <var>transaction</var> be the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-25">upgrade transaction</a> associated with <var>database</var>. If one does not exist or it is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-6">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-7">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-66">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-6">named</a> <var>name</var> in <var>database</var>,
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-67">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-6">named</a> <var>name</var> in <var>database</var>,
 or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
-      <p>Remove <var>store</var> from this <a data-link-type="dfn" href="#connection" id="ref-for-connection-48">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-2">object
+      <p>Remove <var>store</var> from this <a data-link-type="dfn" href="#connection" id="ref-for-connection-50">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-2">object
 store set</a>.</p>
      <li data-md="">
       <p>If there is an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-9">object store handle</a> associated with <var>store</var> and <var>transaction</var>, remove all entries from its <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-1">index set</a>.</p>
@@ -3316,16 +3320,16 @@ store set</a>.</p>
       <p>Destroy <var>store</var>.</p>
     </ol>
    </div>
-   <p>This method destroys the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-67">object store</a> with the given name in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-49">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-45">database</a>. Note that this method must only be called
-from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-24">upgrade transaction</a>.</p>
+   <p>This method destroys the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-68">object store</a> with the given name in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-51">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-47">database</a>. Note that this method must only be called
+from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-26">upgrade transaction</a>.</p>
    <p>This method synchronously modifies the <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-4">objectStoreNames</a></code> property on the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-8">IDBDatabase</a></code> instance on which it was called.</p>
    <div class="note" role="note">
     <dl class="domintro">
-     <dt><var>transaction</var> = <var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-2">transaction</a></code>(<var>scope</var> [, <var>mode</var> = "readonly"])
-     <dd> Returns a new <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-30">transaction</a> with the given <var>mode</var> (<code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-3">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-4">"readwrite"</a></code>)
-        and <var>scope</var> which can be a single <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-68">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-7">name</a> or an array of <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-8">names</a>. 
+     <dt><var>transaction</var> = <var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-3">transaction</a></code>(<var>scope</var> [, <var>mode</var> = "readonly"])
+     <dd> Returns a new <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-31">transaction</a> with the given <var>mode</var> (<code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-3">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-4">"readwrite"</a></code>)
+        and <var>scope</var> which can be a single <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-69">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-7">name</a> or an array of <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-8">names</a>. 
      <dt><var>connection</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-close" id="ref-for-dom-idbdatabase-close-3">close</a></code>()
-     <dd> Closes the <a data-link-type="dfn" href="#connection" id="ref-for-connection-50">connection</a> once all running <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-31">transactions</a> have finished. 
+     <dd> Closes the <a data-link-type="dfn" href="#connection" id="ref-for-connection-52">connection</a> once all running <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-32">transactions</a> have finished. 
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="method" data-export="" data-lt="transaction(storeNames, mode)|transaction(storeNames)" id="dom-idbdatabase-transaction">transaction(<var>storeNames</var>, <var>mode</var>)</dfn> method, when invoked, must run these steps:</p>
@@ -3334,7 +3338,7 @@ from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-u
      <li data-md="">
       <p>If <var>mode</var> parameter is not <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-4">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-5">"readwrite"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>.</p>
      <li data-md="">
-      <p>If this method is called on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-9">IDBDatabase</a></code> object for which an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-25">upgrade transaction</a> is still running, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+      <p>If this method is called on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-9">IDBDatabase</a></code> object for which an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-27">upgrade transaction</a> is still running, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If this method is called on an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-10">IDBDatabase</a></code> instance where the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-4">close pending flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
@@ -3343,13 +3347,13 @@ from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-u
       <p>Let <var>scope</var> be the set of unique strings in <var>storeNames</var> if it is a
 sequence, or a set containing one string equal to <var>storeNames</var> otherwise.</p>
      <li data-md="">
-      <p>If any string in <var>scope</var> is not the name of an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-69">object
-store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-51">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-46">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+      <p>If any string in <var>scope</var> is not the name of an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-70">object
+store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-53">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-48">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>scope</var> is empty, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be a newly <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-3">created</a> <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-32">transaction</a> with <var>connection</var>, <var>mode</var> and the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-70">object stores</a> named in <var>scope</var>.</p>
+      <p>Let <var>transaction</var> be a newly <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-3">created</a> <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-33">transaction</a> with <var>connection</var>, <var>mode</var> and the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-71">object stores</a> named in <var>scope</var>.</p>
      <li data-md="">
       <p>When control is returned to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>, the implementation must
 unset the <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-4">active flag</a>.</p>
@@ -3363,7 +3367,7 @@ must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Run the <a data-link-type="dfn" href="#steps-for-closing-a-database-connection" id="ref-for-steps-for-closing-a-database-connection-3">steps for closing a database connection</a> with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-52">connection</a>.</p>
+      <p>Run the <a data-link-type="dfn" href="#steps-for-closing-a-database-connection" id="ref-for-steps-for-closing-a-database-connection-3">steps for closing a database connection</a> with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-54">connection</a>.</p>
     </ol>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-onabort">onabort</dfn> attribute is the
@@ -3425,23 +3429,23 @@ the event handler for the <code>versionchange</code> event.</p>
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-3">name</a></code> = <var>newName</var>
      <dd>
        Updates the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-10">name</a> of the store to <var>newName</var>. 
-      <p>Throws "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-26">upgrade
+      <p>Throws "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-28">upgrade
         transaction</a>.</p>
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-keypath" id="ref-for-dom-idbobjectstore-keypath-2">keyPath</a></code>
      <dd> Returns the <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-12">key path</a> of the store, or null if none. 
      <dt><var>list</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-2">indexNames</a></code>
      <dd> Returns a list of the names of indexes in the store. 
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-transaction" id="ref-for-dom-idbobjectstore-transaction-2">transaction</a></code>
-     <dd> Returns the associated <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-33">transaction</a>. 
+     <dd> Returns the associated <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-34">transaction</a>. 
      <dt><var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-autoincrement" id="ref-for-dom-idbobjectstore-autoincrement-2">autoIncrement</a></code>
      <dd> Returns true if the store has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-13">key generator</a>, and false otherwise. 
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-name">name</dfn> attribute’s getter
 must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-11">object store handle</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-11">name</a>.</p>
-   <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-34">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-7">finished</a>,
-  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-71">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-12">name</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-35">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-8">finished</a>, this attribute will not reflect changes made with a
-  later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-27">upgrade transaction</a>. </aside>
+   <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-35">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-7">finished</a>,
+  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-72">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-12">name</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-36">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-8">finished</a>, this attribute will not reflect changes made with a
+  later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-29">upgrade transaction</a>. </aside>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-4">name</a></code> attribute’s setter must run these steps:</p>
    <div class="algorithm">
     <ol>
@@ -3454,14 +3458,14 @@ must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-28">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-30">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-8">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>store</var>’s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-13">name</a> is equal to <var>name</var>,
 terminate these steps.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-72">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-14">named</a> <var>name</var> already exists in <var>store</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-47">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+      <p>If an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-73">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-14">named</a> <var>name</var> already exists in <var>store</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-49">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Set <var>store</var>’s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-15">name</a> to <var>name</var>.</p>
@@ -3479,16 +3483,16 @@ path</a>, or null if none.</p>
    <p>The conversion is done following the normal <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> binding logic
 for <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> values, as
 appropriate.</p>
-   <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-73">object store</a> was created. However, if this attribute returns
+   <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-74">object store</a> was created. However, if this attribute returns
 an object (specifically an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>), it returns the same object
 instance every time it is inspected. Changing the properties of the
-object has no effect on the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-74">object store</a>.</p>
+object has no effect on the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-75">object store</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-indexnames">indexNames</dfn> attribute’s
-getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-2">sorted list</a> of the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-2">names</a> of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-19">indexes</a> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-16">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-2">index set</a>.</p>
-   <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-36">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-9">finished</a>,
-  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-75">object store</a>'s list
-  of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-20">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-3">names</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-37">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-10">finished</a>, this attribute will not
-  reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-29">upgrade transaction</a>. </aside>
+getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-2">sorted list</a> of the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-2">names</a> of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-20">indexes</a> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-16">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-2">index set</a>.</p>
+   <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-37">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-9">finished</a>,
+  this is the same as the associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-76">object store</a>'s list
+  of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-21">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-3">names</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-38">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-10">finished</a>, this attribute will not
+  reflect changes made with a later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-31">upgrade transaction</a>. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-transaction">transaction</dfn> attribute’s
 getter must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-17">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-transaction" id="ref-for-object-store-handle-transaction-3">transaction</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-autoincrement">autoIncrement</dfn> attribute’s
@@ -3496,7 +3500,7 @@ getter must return true if this <a data-link-type="dfn" href="#object-store-hand
 and false otherwise.</p>
    <div class="note" role="note">
      The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called within a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-9">read-only transaction</a>, and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if
-  called when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-38">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-9">active</a>. 
+  called when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-39">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-9">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-put" id="ref-for-dom-idbobjectstore-put-2">put</a></code>(<var>value</var> [, <var>key</var>]) 
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-add" id="ref-for-dom-idbobjectstore-add-2">add</a></code>(<var>value</var> [, <var>key</var>]) 
@@ -3689,7 +3693,7 @@ the <a data-link-type="dfn" href="#steps-for-clearing-an-object-store" id="ref-f
     </ol>
     <div class="note" role="note">
       The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
-  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-39">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-14">active</a>. 
+  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-40">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-14">active</a>. 
      <dl class="domintro">
       <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-get" id="ref-for-dom-idbobjectstore-get-2">get</a></code>(<var>query</var>) 
       <dd>
@@ -3866,7 +3870,7 @@ run with this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-ob
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-5">unbounded key range</a> is used.</p>
    <div class="note" role="note">
      The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
-  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-40">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-20">active</a>. 
+  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-41">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-20">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-opencursor" id="ref-for-dom-idbobjectstore-opencursor-3">openCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
      <dd>
@@ -3945,19 +3949,19 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
    <div class="note" role="note">
     <dl class="domintro">
      <dt> <var>index</var> = <var>store</var> . index(<var>name</var>) 
-     <dd> Returns an <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-5">IDBIndex</a></code> for the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-21">index</a> named <var>name</var> in <var>store</var>. 
+     <dd> Returns an <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-5">IDBIndex</a></code> for the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-22">index</a> named <var>name</var> in <var>store</var>. 
      <dt> <var>index</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-createindex" id="ref-for-dom-idbobjectstore-createindex-2">createIndex</a></code>(<var>name</var>, <var>keyPath</var> [, <var>options</var>]) 
      <dd>
-       Creates a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-22">index</a> in <var>store</var> with the given <var>name</var>, <var>keyPath</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-6">IDBIndex</a></code>. If the <var>keyPath</var> and <var>options</var> define constraints that cannot be
-      satisfied with the data already in <var>store</var> the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-30">upgrade
+       Creates a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-23">index</a> in <var>store</var> with the given <var>name</var>, <var>keyPath</var> and <var>options</var> and returns a new <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-6">IDBIndex</a></code>. If the <var>keyPath</var> and <var>options</var> define constraints that cannot be
+      satisfied with the data already in <var>store</var> the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-32">upgrade
       transaction</a> will <a data-link-type="dfn" href="#transaction-abort" id="ref-for-transaction-abort-6">abort</a> with
       a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. 
-      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-31">upgrade
+      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-33">upgrade
       transaction</a>.</p>
      <dt> <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-deleteindex" id="ref-for-dom-idbobjectstore-deleteindex-1">deleteIndex</a></code>(<var>name</var>) 
      <dd>
-       Deletes the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-23">index</a> in <var>store</var> with the given <var>name</var>. 
-      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-32">upgrade
+       Deletes the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-24">index</a> in <var>store</var> with the given <var>name</var>. 
+      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-34">upgrade
       transaction</a>.</p>
     </dl>
    </div>
@@ -3969,7 +3973,7 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-53">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-17">object store</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-33">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-35">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -3977,7 +3981,7 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-23">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-24">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-4">named</a> <var>name</var> already exists in <var>store</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-25">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-4">named</a> <var>name</var> already exists in <var>store</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>keyPath</var> is not a <a data-link-type="dfn" href="#valid-key-path" id="ref-for-valid-key-path-2">valid key path</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -3989,7 +3993,7 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
       <p>If <var>keyPath</var> is a sequence and <var>multiEntry</var> is
 set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>index</var> be a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-25">index</a> in <var>store</var>.
+      <p>Let <var>index</var> be a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-26">index</a> in <var>store</var>.
 Set <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-5">name</a> to <var>name</var> and <a data-link-type="dfn" href="#index-key-path" id="ref-for-index-key-path-4">key path</a> to <var>keyPath</var>. If <var>unique</var> is set, set <var>index</var>’s <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-3">unique flag</a>. If <var>multiEntry</var> is
 set, set <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-3">multiEntry flag</a>.</p>
      <li data-md="">
@@ -3999,9 +4003,9 @@ set, set <var>index</var>’s <a data-link-type="dfn" href="#index-multientry-fl
       <p>Return a new <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-6">index handle</a> associated with <var>index</var> and this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-55">object store handle</a>.</p>
     </ol>
    </div>
-   <p>This method creates and returns a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-26">index</a> with the
-given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-76">object store</a>. Note that this method
-must only be called from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-34">upgrade transaction</a>.</p>
+   <p>This method creates and returns a new <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-27">index</a> with the
+given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-77">object store</a>. Note that this method
+must only be called from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-36">upgrade transaction</a>.</p>
    <p>The index that is requested to be created can contain constraints on
 the data allowed in the index’s <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-7">referenced</a> object store, such
 as requiring uniqueness of the values referenced by the index’s
@@ -4009,12 +4013,12 @@ keyPath. If the <a data-link-type="dfn" href="#index-referenced" id="ref-for-ind
 which violates these constraints, this must not cause the
 implementation of <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-createindex" id="ref-for-dom-idbobjectstore-createindex-3">createIndex()</a></code> to throw an
 exception or affect what it returns. The implementation must still
-create and return an <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-7">IDBIndex</a></code> object, and the implementation must <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to abort the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-35">upgrade transaction</a> which was
+create and return an <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-7">IDBIndex</a></code> object, and the implementation must <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to abort the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-37">upgrade transaction</a> which was
 used for the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-createindex" id="ref-for-dom-idbobjectstore-createindex-4">createIndex()</a></code> call.</p>
    <p>This method synchronously modifies the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-3">indexNames</a></code> property on the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-9">IDBObjectStore</a></code> instance on which it was called.
 Although this method does not return an <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-29">IDBRequest</a></code> object, the
 index creation itself is processed as an asynchronous request within
-the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-36">upgrade transaction</a>.</p>
+the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-38">upgrade transaction</a>.</p>
    <p>In some implementations it is possible for the implementation to
 asynchronously run into problems creating the index after the
 createIndex method has returned. For example in implementations where
@@ -4025,7 +4029,7 @@ implementations must still create and return an <code class="idl"><a data-link-t
 and once the implementation determines that creating the index has
 failed, it must abort the transaction using the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-4">steps for aborting
 a transaction</a> using an appropriate error as <var>error</var>. For example
-if creating the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-27">index</a> failed due to quota reasons,
+if creating the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-28">index</a> failed due to quota reasons,
 a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as error and if the index can’t be
 created due to <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-4">unique flag</a> constraints, a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> must be used as error.</p>
    <aside class="example" id="example-6eb47322">
@@ -4037,7 +4041,7 @@ created due to <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-ind
 </pre>
     <p>At the point where <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-createindex" id="ref-for-dom-idbobjectstore-createindex-5">createIndex()</a></code> called, neither of the <a data-link-type="dfn" href="#request" id="ref-for-request-21">requests</a> have executed. When the second request executes, a
   duplicate name is created. Since the index creation is considered an
-  asynchronous <a data-link-type="dfn" href="#request" id="ref-for-request-22">request</a>, the index’s <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-5">uniqueness constraint</a> does not cause the second <a data-link-type="dfn" href="#request" id="ref-for-request-23">request</a> to fail. Instead, the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-41">transaction</a> will
+  asynchronous <a data-link-type="dfn" href="#request" id="ref-for-request-22">request</a>, the index’s <a data-link-type="dfn" href="#index-unique-flag" id="ref-for-index-unique-flag-5">uniqueness constraint</a> does not cause the second <a data-link-type="dfn" href="#request" id="ref-for-request-23">request</a> to fail. Instead, the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-42">transaction</a> will
   be <a data-link-type="dfn" href="#transaction-abort" id="ref-for-transaction-abort-7">aborted</a> when the index is created and the constraint
   fails.</p>
    </aside>
@@ -4056,7 +4060,7 @@ invoked, must run these steps:</p>
       <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-11">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-28">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-6">named</a> <var>name</var> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-58">object
+      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-29">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-6">named</a> <var>name</var> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-58">object
 store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-4">index set</a> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> otherwise.</p>
      <li data-md="">
       <p>Return an <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-7">index handle</a> associated with <var>index</var> and
@@ -4077,7 +4081,7 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>store</var> be this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-61">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-19">object store</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-37">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-39">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>store</var> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -4085,19 +4089,19 @@ when invoked, must run these steps:</p>
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-24">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-29">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-7">named</a> <var>name</var> in <var>store</var> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> otherwise.</p>
+      <p>Let <var>index</var> be the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-30">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-7">named</a> <var>name</var> in <var>store</var> if one exists, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> otherwise.</p>
      <li data-md="">
       <p>Remove <var>index</var> from this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-62">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-5">index set</a>.</p>
      <li data-md="">
       <p>Destroy <var>index</var>.</p>
     </ol>
    </div>
-   <p>This method destroys the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-30">index</a> with the given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-77">object store</a>. Note that this method must only be called from
-within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-38">upgrade transaction</a>.</p>
+   <p>This method destroys the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-31">index</a> with the given name in the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-78">object store</a>. Note that this method must only be called from
+within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-40">upgrade transaction</a>.</p>
    <p>This method synchronously modifies the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-4">indexNames</a></code> property on the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-13">IDBObjectStore</a></code> instance on which it was called.
 Although this method does not return an <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-30">IDBRequest</a></code> object, the
 index destruction itself is processed as an asynchronous request
-within the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-39">upgrade transaction</a>.</p>
+within the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-41">upgrade transaction</a>.</p>
    <h3 class="heading settled" data-level="4.6" id="index-interface"><span class="secno">4.6. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-12">IDBIndex</a></code> interface</span><a class="self-link" href="#index-interface"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-13">IDBIndex</a></code> interface represents an <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-8">index handle</a>.</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
@@ -4129,7 +4133,7 @@ within the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgra
      <dt><var>index</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-name" id="ref-for-dom-idbindex-name-3">name</a></code> = <var>newName</var>
      <dd>
        Updates the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-9">name</a> of the store to <var>newName</var>. 
-      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-40">upgrade
+      <p>Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if not called within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-42">upgrade
       transaction</a>.</p>
      <dt><var>index</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-objectstore" id="ref-for-dom-idbindex-objectstore-2">objectStore</a></code>
      <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-15">IDBObjectStore</a></code> the index belongs to. 
@@ -4143,9 +4147,9 @@ within the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgra
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBIndex" data-dfn-type="attribute" data-export="" id="dom-idbindex-name">name</dfn> attribute’s getter must
 return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-9">index handle</a>'s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-10">name</a>.</p>
-   <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-42">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-12">finished</a>,
-  this is the same as the associated <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-31">index</a>'s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-11">name</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-43">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-13">finished</a>, this attribute will not reflect changes made with a
-  later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-41">upgrade transaction</a>. </aside>
+   <aside class="note"> As long as the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-43">transaction</a> has not <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-12">finished</a>,
+  this is the same as the associated <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-32">index</a>'s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-11">name</a>. Once the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-44">transaction</a> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-13">finished</a>, this attribute will not reflect changes made with a
+  later <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-43">upgrade transaction</a>. </aside>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-idbindex-name" id="ref-for-dom-idbindex-name-4">name</a></code> attribute’s setter must run these steps:</p>
    <div class="algorithm">
     <ol>
@@ -4156,17 +4160,17 @@ return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handl
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-11">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-2">index</a>.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-42">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>transaction</var> is not an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-44">upgrade transaction</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-25">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-78">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-79">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-12">name</a> is equal to <var>name</var>, terminate these steps.</p>
      <li data-md="">
-      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-32">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-13">named</a> <var>name</var> already exists in <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-79">object
+      <p>If an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-33">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-13">named</a> <var>name</var> already exists in <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-80">object
 store</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Set <var>index</var>’s <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-14">name</a> to <var>name</var>.</p>
@@ -4186,10 +4190,10 @@ return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handl
    <p>The conversion is done following the normal <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> binding logic
 for <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> values, as
 appropriate.</p>
-   <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-33">index</a> was created. However, if this attribute returns an
+   <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-34">index</a> was created. However, if this attribute returns an
 object (specifically an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>), it returns the same object
 instance every time it is inspected. Changing the properties of the
-object has no effect on the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-34">index</a>.</p>
+object has no effect on the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-35">index</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBIndex" data-dfn-type="attribute" data-export="" id="dom-idbindex-multientry">multiEntry</dfn> attribute’s getter
 must return true if this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-15">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-4">index</a>'s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-5">multiEntry flag</a> is set, and false
 otherwise.</p>
@@ -4198,7 +4202,7 @@ return true if this <a data-link-type="dfn" href="#index-handle" id="ref-for-ind
 otherwise.</p>
    <div class="note" role="note">
      The following methods throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
-  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-44">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-26">active</a>. 
+  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-45">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-26">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-get" id="ref-for-dom-idbindex-get-2">get</a></code>(<var>query</var>) 
      <dd>
@@ -4234,7 +4238,7 @@ must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-18">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-6">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-80">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-81">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-27">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4265,7 +4269,7 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-21">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-7">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-81">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-82">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-28">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -4291,7 +4295,7 @@ when invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-24">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-8">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-82">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-83">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-29">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4321,7 +4325,7 @@ there are more than <var>count</var> records in range, only the first <var>count
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-27">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-9">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-83">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-84">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-30">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4352,7 +4356,7 @@ invoked, must run these steps:</p>
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-30">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-10">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-84">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-85">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-31">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4364,14 +4368,14 @@ Rethrow any exceptions.</p>
       <p>Run the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-17">steps for asynchronously executing a request</a> and
 return the <code class="idl"><a data-link-type="idl" href="#idbrequest" id="ref-for-idbrequest-42">IDBRequest</a></code> created by these steps. The steps are
 run with this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-31">index handle</a> as <var>source</var> and the <a data-link-type="dfn" href="#steps-to-count-the-records-in-a-range" id="ref-for-steps-to-count-the-records-in-a-range-2">steps to
-count the records in a range</a> as <var>operation</var>, with <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-35">index</a> as <var>source</var> and <var>range</var>.</p>
+count the records in a range</a> as <var>operation</var>, with <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-36">index</a> as <var>source</var> and <var>range</var>.</p>
     </ol>
    </div>
    <p>The <var>query</var> parameter may be a <a data-link-type="dfn" href="#key" id="ref-for-key-82">key</a> or an <code class="idl"><a data-link-type="idl" href="#idbkeyrange" id="ref-for-idbkeyrange-13">IDBKeyRange</a></code> identifying the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-62">records</a> keys to be counted. If null or not
 given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unbounded-key-range-10">unbounded key range</a> is used.</p>
    <div class="note" role="note">
      The following methods throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
-  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-45">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-32">active</a>. 
+  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-46">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-32">active</a>. 
     <dl class="domintro">
      <dt> <var>request</var> = <var>store</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-opencursor" id="ref-for-dom-idbindex-opencursor-3">openCursor</a></code>([<var>query</var> [, <var>direction</var> = "next"]]) 
      <dd>
@@ -4392,7 +4396,7 @@ given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for-unboun
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-33">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-11">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-85">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-86">object store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-33">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -4419,7 +4423,7 @@ or not given, an <a data-link-type="dfn" href="#unbounded-key-range" id="ref-for
      <li data-md="">
       <p>Let <var>index</var> be this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-36">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-12">index</a>.</p>
      <li data-md="">
-      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-86">object store</a> has
+      <p>If <var>index</var> or <var>index</var>’s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-87">object store</a> has
 been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-34">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
@@ -4628,7 +4632,7 @@ the same time.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="attribute" data-export="" id="dom-idbcursor-source">source</dfn> attribute’s getter must
 return the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-14">source</a> of this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-30">cursor</a>. This
 attribute never returns null or throws an exception, even if the
-cursor is currently being iterated, has iterated past its end, or its <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-46">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-35">active</a>.</p>
+cursor is currently being iterated, has iterated past its end, or its <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-47">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-35">active</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="attribute" data-export="" id="dom-idbcursor-direction">direction</dfn> attribute’s getter
 must return the <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-7">direction</a> of the <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-31">cursor</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="attribute" data-export="" id="dom-idbcursor-key">key</dfn> attribute’s getter must
@@ -4655,7 +4659,7 @@ does not modify the contents of the database.</p>
   in range, or <code>undefined</code> otherwise. 
     <p>If called while the cursor is already advancing, an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> will be thrown.</p>
     <p>The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called
-  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-47">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-36">active</a>.</p>
+  when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-48">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-36">active</a>.</p>
     <dl class="domintro">
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-advance" id="ref-for-dom-idbcursor-advance-2">advance</a></code>(<var>count</var>)
      <dd> Advances the cursor through the next <var>count</var> <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-70">records</a> in
@@ -4667,7 +4671,7 @@ does not modify the contents of the database.</p>
       after <var>key</var>. 
      <dt><var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-continueprimarykey" id="ref-for-dom-idbcursor-continueprimarykey-2">continuePrimaryKey</a></code>(<var>key</var>, <var>primaryKey</var>)
      <dd> Advances the cursor to the next <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-73">record</a> in range matching
-      or after <var>key</var> and <var>primaryKey</var>. Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-15">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-36">index</a>. 
+      or after <var>key</var> and <var>primaryKey</var>. Throws an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-15">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-37">index</a>. 
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBCursor" data-dfn-type="method" data-export="" id="dom-idbcursor-advance">advance(<var>count</var>)</dfn> method, when
@@ -4763,7 +4767,7 @@ this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-38">cursor</a> an
       <p>If the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-20">source</a> or <a data-link-type="dfn" href="#cursor-effective-object-store" id="ref-for-cursor-effective-object-store-4">effective object
 store</a> has been deleted, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-21">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-37">index</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If this cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-21">source</a> is not an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-38">index</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If this cursor’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-10">direction</a> is not <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-5">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-5">"prev"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
@@ -4817,7 +4821,7 @@ this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-41">cursor</a>, <
   flag</a> has been unset. </aside>
    <div class="note" role="note">
      The following methods throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#readonlyerror">ReadOnlyError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if called within a <a data-link-type="dfn" href="#transaction-read-only-transaction" id="ref-for-transaction-read-only-transaction-14">read-only transaction</a>, and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if
-  called when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-48">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-40">active</a>. 
+  called when the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-49">transaction</a> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-40">active</a>. 
     <dl class="domintro">
      <dt><var>request</var> = <var>cursor</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbcursor-update" id="ref-for-dom-idbcursor-update-2">update</a></code>(<var>value</var>)
      <dd>
@@ -4929,7 +4933,7 @@ modified, those modifications will be seen by anyone inspecting the
 value of the cursor. However modifying such an object does not modify
 the contents of the database.</p>
    <h3 class="heading settled" data-level="4.9" id="transaction"><span class="secno">4.9. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-6">IDBTransaction</a></code> interface</span><a class="self-link" href="#transaction"></a></h3>
-   <p><a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-49">transaction</a> objects implement the following interface:</p>
+   <p><a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-50">transaction</a> objects implement the following interface:</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbtransaction">IDBTransaction</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbtransaction-objectstorenames" id="ref-for-dom-idbtransaction-objectstorenames-1">objectStoreNames</a>;
@@ -4955,12 +4959,12 @@ the contents of the database.</p>
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstorenames" id="ref-for-dom-idbtransaction-objectstorenames-2">objectStoreNames</a></code>
-     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-87">object stores</a> in the
-      transaction’s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-12">scope</a>. For an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-43">upgrade transaction</a> this is all object stores in the <a data-link-type="dfn" href="#database" id="ref-for-database-48">database</a>. 
+     <dd> Returns a list of the names of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-88">object stores</a> in the
+      transaction’s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-12">scope</a>. For an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-45">upgrade transaction</a> this is all object stores in the <a data-link-type="dfn" href="#database" id="ref-for-database-50">database</a>. 
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-mode" id="ref-for-dom-idbtransaction-mode-2">mode</a></code>
      <dd> Returns the <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-9">mode</a> the transaction was created with
       (<code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-5">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-6">"readwrite"</a></code>), or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-versionchange" id="ref-for-dom-idbtransactionmode-versionchange-3">"versionchange"</a></code> for
-      an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-44">upgrade transaction</a>. 
+      an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-46">upgrade transaction</a>. 
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-db" id="ref-for-dom-idbtransaction-db-2">db</a></code>
      <dd> Returns the transaction’s <a data-link-type="dfn" href="#transaction-connection" id="ref-for-transaction-connection-2">connection</a>. 
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-error" id="ref-for-dom-idbtransaction-error-2">error</a></code>
@@ -4972,12 +4976,12 @@ the contents of the database.</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-50">transaction</a> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-45">upgrade transaction</a>,
-return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-3">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-16">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-88">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-51">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-53">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
+      <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-51">transaction</a> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-47">upgrade transaction</a>,
+return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-3">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-16">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-89">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-52">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
 set</a>.</p>
      <li data-md="">
-      <p>Otherwise, return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-4">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-17">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-89">object stores</a> in
-this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-52">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-13">scope</a>.</p>
+      <p>Otherwise, return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-4">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-17">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-90">object stores</a> in
+this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-53">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-13">scope</a>.</p>
     </ol>
    </div>
    <aside class="advisement"> 🚧
@@ -4985,25 +4989,25 @@ this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction
   It is supported in Chrome 48 and Firefox 44.
   🚧 </aside>
    <aside class="note"> The contents of each list returned by this attribute does not
-  change, but subsequent calls to this attribute during an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-46">upgrade
-  transaction</a> may return lists with different contents as <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-90">object stores</a> are created and deleted. </aside>
+  change, but subsequent calls to this attribute during an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-48">upgrade
+  transaction</a> may return lists with different contents as <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-91">object stores</a> are created and deleted. </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-mode">mode</dfn> attribute’s getter
-must return the <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-10">mode</a> of the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-53">transaction</a>.</p>
+must return the <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-10">mode</a> of the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-54">transaction</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-db">db</dfn> attribute’s getter must
-return the <a data-link-type="dfn" href="#database" id="ref-for-database-49">database</a> <a data-link-type="dfn" href="#connection" id="ref-for-connection-54">connection</a> of which this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-54">transaction</a> is a part.</p>
+return the <a data-link-type="dfn" href="#database" id="ref-for-database-51">database</a> <a data-link-type="dfn" href="#connection" id="ref-for-connection-56">connection</a> of which this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-55">transaction</a> is a part.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-error">error</dfn> attribute’s getter
-must return this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-55">transaction</a>'s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-1">error</a>, or null if
+must return this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-56">transaction</a>'s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-1">error</a>, or null if
 none.</p>
-   <aside class="note"> If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-56">transaction</a> was aborted due to a failed <a data-link-type="dfn" href="#request" id="ref-for-request-27">request</a>, this will be the same as the <a data-link-type="dfn" href="#request" id="ref-for-request-28">request</a>'s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-6">error</a>. If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-57">transaction</a> was aborted
+   <aside class="note"> If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-57">transaction</a> was aborted due to a failed <a data-link-type="dfn" href="#request" id="ref-for-request-27">request</a>, this will be the same as the <a data-link-type="dfn" href="#request" id="ref-for-request-28">request</a>'s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-6">error</a>. If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a> was aborted
   due to an uncaught exception in an event handler, the error will be
-  a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. If the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a> was aborted due to
+  a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>. If the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-59">transaction</a> was aborted due to
   an error while committing, it will reflect the reason for the
   failure (e.g. "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>", "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#constrainterror">ConstraintError</a></code>", or
   "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>). </aside>
    <div class="note" role="note">
     <dl class="domintro">
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstore" id="ref-for-dom-idbtransaction-objectstore-2">objectStore</a></code>(<var>name</var>)
-     <dd> Returns an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-19">IDBObjectStore</a></code> in the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-59">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-14">scope</a>. 
+     <dd> Returns an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-19">IDBObjectStore</a></code> in the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-60">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-14">scope</a>. 
      <dt><var>transaction</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-abort" id="ref-for-dom-idbtransaction-abort-2">abort()</a></code>
      <dd> Aborts the transaction. All pending <a data-link-type="dfn" href="#request" id="ref-for-request-29">requests</a> will fail with
       a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and all changes made to the database will be
@@ -5018,10 +5022,10 @@ when invoked, must run these steps:</p>
       <p>If <var>transaction</var> has <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-14">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-91">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">named</a> <var>name</var> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-60">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-15">scope</a>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+      <p>Let <var>store</var> be the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-92">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">named</a> <var>name</var> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-61">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-15">scope</a>, or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> if none.</p>
      <li data-md="">
-      <p>Return an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-63">object store handle</a> associated with <var>store</var> and this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-61">transaction</a>.</p>
+      <p>Return an <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-63">object store handle</a> associated with <var>store</var> and this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-62">transaction</a>.</p>
     </ol>
    </div>
    <aside class="note"> Each call to this method on the same <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-7">IDBTransaction</a></code> instance
@@ -5033,9 +5037,9 @@ must run these steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-62">transaction</a> is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-15">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
+      <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-63">transaction</a> is <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-15">finished</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Unset the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-63">transaction</a>'s <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-5">active flag</a> and run the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-5">steps for aborting a transaction</a> with null as <var>error</var>.</p>
+      <p>Unset the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-64">transaction</a>'s <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-5">active flag</a> and run the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-5">steps for aborting a transaction</a> with null as <var>error</var>.</p>
     </ol>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-onabort">onabort</dfn> attribute is the
@@ -5044,15 +5048,15 @@ event handler for the <code>abort</code> event.</p>
 the event handler for the <code>complete</code> event.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-onerror">onerror</dfn> attribute is the
 event handler for the <code>error</code> event.</p>
-   <aside class="note"> To determine if a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-64">transaction</a> has completed successfully,
-  listen to the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-65">transaction</a>'s <code>complete</code> event
-  rather than the <code>success</code> event of a particular <a data-link-type="dfn" href="#request" id="ref-for-request-30">request</a>, because the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-66">transaction</a> may still fail after
+   <aside class="note"> To determine if a <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-65">transaction</a> has completed successfully,
+  listen to the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-66">transaction</a>'s <code>complete</code> event
+  rather than the <code>success</code> event of a particular <a data-link-type="dfn" href="#request" id="ref-for-request-30">request</a>, because the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-67">transaction</a> may still fail after
   the <code>success</code> event fires. </aside>
    <h2 class="heading settled" data-level="5" id="algorithms"><span class="secno">5. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="opening"><span class="secno">5.1. </span><span class="content">Opening a database</span><a class="self-link" href="#opening"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="steps-for-opening-a-database">steps for opening a database</dfn> are defined in the
 following steps. The algorithm in these steps takes four arguments:
-the <var>origin</var> which requested the <a data-link-type="dfn" href="#database" id="ref-for-database-50">database</a> to be opened, a
+the <var>origin</var> which requested the <a data-link-type="dfn" href="#database" id="ref-for-database-52">database</a> to be opened, a
 database <var>name</var>, a database <var>version</var>, and a <var>request</var>.</p>
    <div class="algorithm">
     <ol>
@@ -5063,49 +5067,49 @@ database <var>name</var>, a database <var>version</var>, and a <var>request</var
      <li data-md="">
       <p>Wait until all previous requests in <var>queue</var> have been processed.</p>
      <li data-md="">
-      <p>Let <var>db</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-51">database</a> <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-4">named</a> <var>name</var> in <var>origin</var>, or null otherwise.</p>
+      <p>Let <var>db</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-53">database</a> <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-4">named</a> <var>name</var> in <var>origin</var>, or null otherwise.</p>
      <li data-md="">
-      <p>If <var>version</var> is undefined, let <var>version</var> be 1 if <var>db</var> is null, or <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-10">version</a> otherwise.</p>
+      <p>If <var>version</var> is undefined, let <var>version</var> be 1 if <var>db</var> is null, or <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-8">version</a> otherwise.</p>
      <li data-md="">
-      <p>If <var>db</var> is null, let <var>db</var> be a new <a data-link-type="dfn" href="#database" id="ref-for-database-52">database</a> with <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-5">name</a> <var>name</var>, <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-11">version</a> 0 (zero), and with
-no <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-92">object stores</a>. If this fails for any reason, return an
+      <p>If <var>db</var> is null, let <var>db</var> be a new <a data-link-type="dfn" href="#database" id="ref-for-database-54">database</a> with <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-5">name</a> <var>name</var>, <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-9">version</a> 0 (zero), and with
+no <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a>. If this fails for any reason, return an
 appropriate error (e.g. a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" or
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>).</p>
      <li data-md="">
-      <p>If <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-12">version</a> is greater than <var>version</var>,
+      <p>If <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-10">version</a> is greater than <var>version</var>,
 abort these steps and return a new "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#versionerror">VersionError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>connection</var> be a new <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connection</a> to <var>db</var>.</p>
+      <p>Let <var>connection</var> be a new <a data-link-type="dfn" href="#connection" id="ref-for-connection-57">connection</a> to <var>db</var>.</p>
      <li data-md="">
       <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-version" id="ref-for-connection-version-3">version</a> to <var>version</var>.</p>
      <li data-md="">
-      <p>If <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-13">version</a> is less than <var>version</var>, run
+      <p>If <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-11">version</a> is less than <var>version</var>, run
 these substeps:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-56">connections</a>,
+        <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-58">connections</a>,
 except <var>connection</var>, associated with <var>db</var>.</p>
        <li data-md="">
         <p>For each <var>entry</var> in <var>openConnections</var> that does not have its <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-5">close pending flag</a> set, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-2">fire a
-version change event</a> named <code>versionchange</code> at <var>entry</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-14">version</a> and <var>version</var>.</p>
+version change event</a> named <code>versionchange</code> at <var>entry</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-12">version</a> and <var>version</var>.</p>
         <aside class="note"> Firing this event might cause one or more of the other
   objects in <var>openConnections</var> to be closed, in which case the <code>versionchange</code> event must not be fired at those
   objects if that hasn’t yet been done. </aside>
        <li data-md="">
         <p>Wait for all of the events to be fired.</p>
        <li data-md="">
-        <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-57">connections</a> in <var>openConnections</var> are still
+        <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-59">connections</a> in <var>openConnections</var> are still
 not closed, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-3">fire a version change
-event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-5">blocked</a></code> at <var>request</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-15">version</a> and <var>version</var>.</p>
+event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-5">blocked</a></code> at <var>request</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-13">version</a> and <var>version</var>.</p>
        <li data-md="">
-        <p><span id="version-change-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-58">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-5">closed</a>.</p>
+        <p><span id="version-change-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-60">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-5">closed</a>.</p>
        <li data-md="">
         <p>Run the <a data-link-type="dfn" href="#steps-for-running-an-upgrade-transaction" id="ref-for-steps-for-running-an-upgrade-transaction-3">steps for running an upgrade transaction</a> using <var>connection</var>, <var>version</var> and <var>request</var>.</p>
        <li data-md="">
         <p>If <var>connection</var> was <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-6">closed</a>, create and
 return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-47">upgrade transaction</a> was aborted, run the <a data-link-type="dfn" href="#steps-for-closing-a-database-connection" id="ref-for-steps-for-closing-a-database-connection-4">steps
+        <p>If the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-49">upgrade transaction</a> was aborted, run the <a data-link-type="dfn" href="#steps-for-closing-a-database-connection" id="ref-for-steps-for-closing-a-database-connection-4">steps
 for closing a database connection</a> with <var>connection</var>,
 create and return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
       </ol>
@@ -5144,14 +5148,14 @@ bubble or be cancelable.</p>
    </div>
    <aside class="note"> Once the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-7">close pending flag</a> has been set no new transactions
   can be <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-6">created</a> using <var>connection</var>. All methods that <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-7">create</a> transactions first check the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-8">close pending flag</a> first and throw an exception if it is set. </aside>
-   <aside class="note"> Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-59">connection</a> is closed, this can unblock the <a data-link-type="dfn" href="#steps-for-running-an-upgrade-transaction" id="ref-for-steps-for-running-an-upgrade-transaction-4">steps for
+   <aside class="note"> Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-61">connection</a> is closed, this can unblock the <a data-link-type="dfn" href="#steps-for-running-an-upgrade-transaction" id="ref-for-steps-for-running-an-upgrade-transaction-4">steps for
   running an upgrade transaction</a>, and the <a data-link-type="dfn" href="#steps-for-deleting-a-database" id="ref-for-steps-for-deleting-a-database-2">steps for deleting a
-  database</a>, which <a href="#delete-close-block">both</a> <a href="#version-change-close-block">wait</a> for <a data-link-type="dfn" href="#connection" id="ref-for-connection-60">connections</a> to
-  a given <a data-link-type="dfn" href="#database" id="ref-for-database-53">database</a> to be closed before continuing. </aside>
+  database</a>, which <a href="#delete-close-block">both</a> <a href="#version-change-close-block">wait</a> for <a data-link-type="dfn" href="#connection" id="ref-for-connection-62">connections</a> to
+  a given <a data-link-type="dfn" href="#database" id="ref-for-database-55">database</a> to be closed before continuing. </aside>
    <h3 class="heading settled" data-level="5.3" id="deleting-a-database"><span class="secno">5.3. </span><span class="content">Deleting a database</span><a class="self-link" href="#deleting-a-database"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="steps-for-deleting-a-database">steps for deleting a database</dfn> are as follows. The
 algorithm in these steps takes three arguments: the <var>origin</var> that
-requested the <a data-link-type="dfn" href="#database" id="ref-for-database-54">database</a> to be deleted, a database <var>name</var>, and a <var>request</var>.</p>
+requested the <a data-link-type="dfn" href="#database" id="ref-for-database-56">database</a> to be deleted, a database <var>name</var>, and a <var>request</var>.</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
@@ -5161,24 +5165,24 @@ requested the <a data-link-type="dfn" href="#database" id="ref-for-database-54">
      <li data-md="">
       <p>Wait until all previous requests in <var>queue</var> have been processed.</p>
      <li data-md="">
-      <p>Let <var>db</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-55">database</a> <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-6">named</a> <var>name</var> in <var>origin</var>, if one exists. Otherwise, return 0 (zero).</p>
+      <p>Let <var>db</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-57">database</a> <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-6">named</a> <var>name</var> in <var>origin</var>, if one exists. Otherwise, return 0 (zero).</p>
      <li data-md="">
-      <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-61">connections</a> associated with <var>db</var>.</p>
+      <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-63">connections</a> associated with <var>db</var>.</p>
      <li data-md="">
       <p>For each <var>entry</var> in <var>openConnections</var> that does not have its <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-9">close pending flag</a> set, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-4">fire a version
-change event</a> named <code>versionchange</code> at <var>entry</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-16">version</a> and null.</p>
+change event</a> named <code>versionchange</code> at <var>entry</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-14">version</a> and null.</p>
       <aside class="note"> Firing this event might cause one or more of the other objects
   in <var>openConnections</var> to be closed, in which case the <code>versionchange</code> event must not be fired at those
   objects if that hasn’t yet been done. </aside>
      <li data-md="">
       <p>Wait for all of the events to be fired.</p>
      <li data-md="">
-      <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-62">connections</a> in <var>openConnections</var> are
-still not closed, <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-5">fire a version change event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-6">blocked</a></code> at <var>request</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-17">version</a> and null.</p>
+      <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-64">connections</a> in <var>openConnections</var> are
+still not closed, <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-5">fire a version change event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-6">blocked</a></code> at <var>request</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-15">version</a> and null.</p>
      <li data-md="">
-      <p><span id="delete-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-63">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-8">closed</a>.</p>
+      <p><span id="delete-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-65">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-8">closed</a>.</p>
      <li data-md="">
-      <p>Let <var>version</var> be <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-18">version</a>.</p>
+      <p>Let <var>version</var> be <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-16">version</a>.</p>
      <li data-md="">
       <p>Delete <var>db</var>. If this fails for any reason, return an appropriate
 error (e.g. "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" or "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>).</p>
@@ -5193,10 +5197,10 @@ takes one argument, the <var>transaction</var> to commit.</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>All the changes made to the <a data-link-type="dfn" href="#database" id="ref-for-database-56">database</a> by <var>transaction</var> are
-written to the <a data-link-type="dfn" href="#database" id="ref-for-database-57">database</a>.</p>
+      <p>All the changes made to the <a data-link-type="dfn" href="#database" id="ref-for-database-58">database</a> by <var>transaction</var> are
+written to the <a data-link-type="dfn" href="#database" id="ref-for-database-59">database</a>.</p>
      <li data-md="">
-      <p>If an error occurs while writing the changes to the <a data-link-type="dfn" href="#database" id="ref-for-database-58">database</a>, abort the transaction by following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-7">steps
+      <p>If an error occurs while writing the changes to the <a data-link-type="dfn" href="#database" id="ref-for-database-60">database</a>, abort the transaction by following the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-7">steps
 for aborting a transaction</a> with <var>transaction</var> and an
 appropriate for the error, for example "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a></code>" or
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -5213,7 +5217,7 @@ cancelable.</p>
   after the transaction has been successfully written is the
   "<code>complete</code>" event fired. </aside>
        <li data-md="">
-        <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-48">upgrade transaction</a>, then
+        <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-50">upgrade transaction</a>, then
 let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-for-request-31">request</a> associated with <var>transaction</var> and set <var>request</var>’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-4">transaction</a> to null.</p>
       </ol>
     </ol>
@@ -5225,14 +5229,14 @@ takes two arguments: the <var>transaction</var> to abort, and <var>error</var>.<
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>All the changes made to the <a data-link-type="dfn" href="#database" id="ref-for-database-59">database</a> by the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-67">transaction</a> are reverted. For <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-49">upgrade transactions</a> this includes changes
-to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-38">indexes</a>, as well as the
-change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-19">version</a>. Any <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-94">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-39">indexes</a> which were created during the transaction are now
+      <p>All the changes made to the <a data-link-type="dfn" href="#database" id="ref-for-database-61">database</a> by the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-68">transaction</a> are reverted. For <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-51">upgrade transactions</a> this includes changes
+to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-94">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-39">indexes</a>, as well as the
+change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-17">version</a>. Any <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-95">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-40">indexes</a> which were created during the transaction are now
 considered deleted for the purposes of other algorithms.</p>
      <li data-md="">
-      <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-50">upgrade transaction</a>, run the <a data-link-type="dfn" href="#steps-for-aborting-an-upgrade-transaction" id="ref-for-steps-for-aborting-an-upgrade-transaction-2">steps
+      <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-52">upgrade transaction</a>, run the <a data-link-type="dfn" href="#steps-for-aborting-an-upgrade-transaction" id="ref-for-steps-for-aborting-an-upgrade-transaction-2">steps
 for aborting an upgrade transaction</a> with <var>transaction</var>. This
-reverts changes to all <a data-link-type="dfn" href="#connection" id="ref-for-connection-64">connection</a>, <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-64">object store handle</a>,
+reverts changes to all <a data-link-type="dfn" href="#connection" id="ref-for-connection-66">connection</a>, <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-64">object store handle</a>,
 and <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-38">index handle</a> instances associated with <var>transaction</var>.</p>
      <li data-md="">
       <p>If <var>error</var> is not null, set <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-2">error</a> to <var>error</var>.</p>
@@ -5262,7 +5266,7 @@ run these substeps:</p>
         <p>Dispatch an event at <var>transaction</var>. The event must use the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">Event</a> interface and have its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> set to
 "<code>abort</code>". The event does bubble but is not cancelable.</p>
        <li data-md="">
-        <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-51">upgrade transaction</a>, then
+        <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-53">upgrade transaction</a>, then
 let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-for-request-32">request</a> associated with <var>transaction</var> and set <var>request</var>’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-5">transaction</a> to null.</p>
       </ol>
     </ol>
@@ -5272,13 +5276,13 @@ let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-fo
 request</dfn> the implementation must run the following algorithm. The
 algorithm takes a <var>source</var> object and an <var>operation</var> to perform on a
 database, and an optional <var>request</var>.</p>
-   <p>These steps can be aborted at any point if the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-68">transaction</a> the
+   <p>These steps can be aborted at any point if the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-69">transaction</a> the
 created <a data-link-type="dfn" href="#request" id="ref-for-request-34">request</a> belongs to is <a data-link-type="dfn" href="#transaction-abort" id="ref-for-transaction-abort-9">aborted</a> using the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-8">steps for
 aborting a transaction</a>.</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>transaction</var> be the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-69">transaction</a> associated with <var>source</var>.</p>
+      <p>Let <var>transaction</var> be the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-70">transaction</a> associated with <var>source</var>.</p>
      <li data-md="">
       <p>If <var>transaction</var> is not <a data-link-type="dfn" href="#transaction-active" id="ref-for-transaction-active-43">active</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#transactioninactiveerror">TransactionInactiveError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>.</p>
@@ -5328,25 +5332,25 @@ in this algorithm.</p>
    <h3 class="heading settled" data-level="5.7" id="upgrade-transaction-steps"><span class="secno">5.7. </span><span class="content">Running an upgrade transaction</span><a class="self-link" href="#upgrade-transaction-steps"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="steps-for-running-an-upgrade-transaction">steps for running an upgrade transaction</dfn> are as
 follows. This algorithm takes three arguments: a <var>connection</var> object
-which is used to update the <a data-link-type="dfn" href="#database" id="ref-for-database-60">database</a>, a new <var>version</var> to be set
-for the <a data-link-type="dfn" href="#database" id="ref-for-database-61">database</a>, and a <var>request</var>.</p>
+which is used to update the <a data-link-type="dfn" href="#database" id="ref-for-database-62">database</a>, a new <var>version</var> to be set
+for the <a data-link-type="dfn" href="#database" id="ref-for-database-63">database</a>, and a <var>request</var>.</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>db</var> be <var>connection</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-62">database</a>.</p>
+      <p>Let <var>db</var> be <var>connection</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-64">database</a>.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be a new <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-52">upgrade transaction</a> with <var>connection</var> used as <a data-link-type="dfn" href="#connection" id="ref-for-connection-65">connection</a>. The <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-16">scope</a> of <var>transaction</var> includes every <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-95">object store</a> in <var>connection</var>.</p>
+      <p>Let <var>transaction</var> be a new <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a> with <var>connection</var> used as <a data-link-type="dfn" href="#connection" id="ref-for-connection-67">connection</a>. The <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-16">scope</a> of <var>transaction</var> includes every <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-96">object store</a> in <var>connection</var>.</p>
      <li data-md="">
       <p>Unset <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-6">active flag</a>.</p>
      <li data-md="">
       <p>Start <var>transaction</var>.</p>
-      <aside class="note"> Note that until this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-70">transaction</a> is finished, no
-  other <a data-link-type="dfn" href="#connection" id="ref-for-connection-66">connections</a> can be opened to the same <a data-link-type="dfn" href="#database" id="ref-for-database-63">database</a>. </aside>
+      <aside class="note"> Note that until this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-71">transaction</a> is finished, no
+  other <a data-link-type="dfn" href="#connection" id="ref-for-connection-68">connections</a> can be opened to the same <a data-link-type="dfn" href="#database" id="ref-for-database-65">database</a>. </aside>
      <li data-md="">
-      <p>Let <var>old version</var> be <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-20">version</a>.</p>
+      <p>Let <var>old version</var> be <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-18">version</a>.</p>
      <li data-md="">
       <p>Set the version of <var>db</var> to <var>version</var>. This change is
-considered part of the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-71">transaction</a>, and so if the
+considered part of the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-72">transaction</a>, and so if the
 transaction is <a data-link-type="dfn" href="#transaction-abort" id="ref-for-transaction-abort-10">aborted</a>, this change is reverted.</p>
      <li data-md="">
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run the following steps:</p>
@@ -5358,7 +5362,7 @@ transaction is <a data-link-type="dfn" href="#transaction-abort" id="ref-for-tra
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-16">done flag</a> on the <a data-link-type="dfn" href="#request" id="ref-for-request-36">request</a>.</p>
        <li data-md="">
-        <p><a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-6">Fire a version change event</a> named <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-11">upgradeneeded</a></code> at <var>request</var> with <var>old
+        <p><a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-6">Fire a version change event</a> named <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-10">upgradeneeded</a></code> at <var>request</var> with <var>old
 version</var> and <var>version</var>.</p>
        <li data-md="">
         <p>If an exception was propagated out from any event handler while
@@ -5368,52 +5372,52 @@ transaction</a> with the <var>error</var> property set to a newly <a data-link-t
       </ol>
      <li data-md="">
       <p>Wait for <var>transaction</var> to <a data-link-type="dfn" href="#transaction-finish" id="ref-for-transaction-finish-16">finish</a>.</p>
-      <aside class="note"> Some of the algorithms invoked during the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-72">transaction</a>'s <a data-link-type="dfn" href="#transaction-lifetime" id="ref-for-transaction-lifetime-2">lifetime</a>, such as the <a data-link-type="dfn" href="#steps-for-committing-a-transaction" id="ref-for-steps-for-committing-a-transaction-2">steps for committing a
+      <aside class="note"> Some of the algorithms invoked during the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-73">transaction</a>'s <a data-link-type="dfn" href="#transaction-lifetime" id="ref-for-transaction-lifetime-2">lifetime</a>, such as the <a data-link-type="dfn" href="#steps-for-committing-a-transaction" id="ref-for-steps-for-committing-a-transaction-2">steps for committing a
   transaction</a> and the <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-10">steps for aborting a transaction</a>,
-  include steps specific to <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-53">upgrade transactions</a>. </aside>
+  include steps specific to <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-55">upgrade transactions</a>. </aside>
     </ol>
    </div>
    <h3 class="heading settled" data-level="5.8" id="abort-upgrade-transaction"><span class="secno">5.8. </span><span class="content">Aborting an upgrade transaction</span><a class="self-link" href="#abort-upgrade-transaction"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="steps-for-aborting-an-upgrade-transaction">steps for aborting an upgrade transaction</dfn> <var>transaction</var> are as follows.</p>
    <aside class="note"> The steps are run after the normal <a data-link-type="dfn" href="#steps-for-aborting-a-transaction" id="ref-for-steps-for-aborting-a-transaction-11">steps for aborting a
-  transaction</a>, which revert changes to the <a data-link-type="dfn" href="#database" id="ref-for-database-64">database</a> including
-  the set of associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-96">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-40">indexes</a>, as well
-  as the change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-21">version</a>. </aside>
+  transaction</a>, which revert changes to the <a data-link-type="dfn" href="#database" id="ref-for-database-66">database</a> including
+  the set of associated <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-97">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-41">indexes</a>, as well
+  as the change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-19">version</a>. </aside>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Let <var>connection</var> be <var>transaction</var>’s <a data-link-type="dfn" href="#connection" id="ref-for-connection-67">connection</a>.</p>
+      <p>Let <var>connection</var> be <var>transaction</var>’s <a data-link-type="dfn" href="#connection" id="ref-for-connection-69">connection</a>.</p>
      <li data-md="">
-      <p>Let <var>database</var> be <var>connection</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-65">database</a>.</p>
+      <p>Let <var>database</var> be <var>connection</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-67">database</a>.</p>
      <li data-md="">
-      <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-version" id="ref-for-connection-version-4">version</a> to <var>database</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-22">version</a> if <var>database</var> previously existed, or 0 (zero)
+      <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-version" id="ref-for-connection-version-4">version</a> to <var>database</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-20">version</a> if <var>database</var> previously existed, or 0 (zero)
 if <var>database</var> was newly created.</p>
       <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-version" id="ref-for-dom-idbdatabase-version-3">version</a></code> returned by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-12">IDBDatabase</a></code> object. </aside>
      <li data-md="">
-      <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-4">object store set</a> to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-97">object stores</a> in <var>database</var> if <var>database</var> previously
+      <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-4">object store set</a> to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-98">object stores</a> in <var>database</var> if <var>database</var> previously
 existed, or the empty set if <var>database</var> was newly created.</p>
       <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-5">objectStoreNames</a></code> returned
   by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-13">IDBDatabase</a></code> object. </aside>
      <li data-md="">
-      <p>For each <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-65">object store handle</a> <var>handle</var> associated with <var>transaction</var>, including those for <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-98">object stores</a> that
+      <p>For each <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-65">object store handle</a> <var>handle</var> associated with <var>transaction</var>, including those for <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-99">object stores</a> that
 were created or deleted during <var>transaction</var>, run these substeps:</p>
       <ol>
        <li data-md="">
         <p>If <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-20">object store</a> was not
 newly created during <var>transaction</var>, set <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-name" id="ref-for-object-store-handle-name-2">name</a> to its <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-21">object store</a>'s <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-19">name</a>.</p>
        <li data-md="">
-        <p>Set <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-6">index set</a> to the set of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-41">indexes</a> that
+        <p>Set <var>handle</var>’s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-6">index set</a> to the set of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-42">indexes</a> that
 reference its <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-22">object store</a>.</p>
       </ol>
       <aside class="note"> This reverts the values of <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-6">name</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-5">indexNames</a></code> returned by related <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-23">IDBObjectStore</a></code> objects. </aside>
       <details class="note">
        <summary>How is this observable?</summary>
-        Although script cannot access an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-99">object store</a> by using the <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstore" id="ref-for-dom-idbtransaction-objectstore-3">objectStore()</a></code> method on an <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-10">IDBTransaction</a></code> instance after
-  the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-73">transaction</a> is aborted, it may still have references to <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-24">IDBObjectStore</a></code> instances where the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-7">name</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-6">indexNames</a></code> properties can be queried. 
+        Although script cannot access an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-100">object store</a> by using the <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-objectstore" id="ref-for-dom-idbtransaction-objectstore-3">objectStore()</a></code> method on an <code class="idl"><a data-link-type="idl" href="#idbtransaction" id="ref-for-idbtransaction-10">IDBTransaction</a></code> instance after
+  the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-74">transaction</a> is aborted, it may still have references to <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-24">IDBObjectStore</a></code> instances where the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-name" id="ref-for-dom-idbobjectstore-name-7">name</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-indexnames" id="ref-for-dom-idbobjectstore-indexnames-6">indexNames</a></code> properties can be queried. 
       </details>
      <li data-md="">
       <p>For each <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-39">index handle</a> <var>handle</var> associated with <var>transaction</var>,
-including those for <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-42">indexes</a> that were created or deleted
+including those for <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-43">indexes</a> that were created or deleted
 during <var>transaction</var>, run these substeps:</p>
       <ol>
        <li data-md="">
@@ -5424,21 +5428,21 @@ its <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-
       <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbindex-name" id="ref-for-dom-idbindex-name-6">name</a></code> returned by related <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-16">IDBIndex</a></code> objects. </aside>
       <details class="note">
        <summary>How is this observable?</summary>
-        Although script cannot access an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-43">index</a> by using the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-index" id="ref-for-dom-idbobjectstore-index-2">index()</a></code> method on an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-25">IDBObjectStore</a></code> instance after the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-74">transaction</a> is aborted, it may still have references to <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-17">IDBIndex</a></code> instances where the <code class="idl"><a data-link-type="idl" href="#dom-idbindex-name" id="ref-for-dom-idbindex-name-7">name</a></code> property can
+        Although script cannot access an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-44">index</a> by using the <code class="idl"><a data-link-type="idl" href="#dom-idbobjectstore-index" id="ref-for-dom-idbobjectstore-index-2">index()</a></code> method on an <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-25">IDBObjectStore</a></code> instance after the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-75">transaction</a> is aborted, it may still have references to <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-17">IDBIndex</a></code> instances where the <code class="idl"><a data-link-type="idl" href="#dom-idbindex-name" id="ref-for-dom-idbindex-name-7">name</a></code> property can
   be queried. 
       </details>
     </ol>
    </div>
    <aside class="note"> The <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-name" id="ref-for-dom-idbdatabase-name-3">name</a></code> property of the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-14">IDBDatabase</a></code> instance is
-  not modified, even if the aborted <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a> was
-  creating a new <a data-link-type="dfn" href="#database" id="ref-for-database-66">database</a>. </aside>
+  not modified, even if the aborted <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-56">upgrade transaction</a> was
+  creating a new <a data-link-type="dfn" href="#database" id="ref-for-database-68">database</a>. </aside>
    <h3 class="heading settled" data-level="5.9" id="fire-success-event"><span class="secno">5.9. </span><span class="content">Firing a success event</span><a class="self-link" href="#fire-success-event"></a></h3>
    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire-a-success-event">fire a success event</dfn> at a <a data-link-type="dfn" href="#request" id="ref-for-request-37">request</a>,
 the implementation must run the following steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Set <var>transaction</var> to the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-75">transaction</a> associated with
+      <p>Set <var>transaction</var> to the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-76">transaction</a> associated with
 the <a data-link-type="dfn" href="#request-source" id="ref-for-request-source-5">source</a>.</p>
      <li data-md="">
       <p>Set the <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-7">active flag</a> of <var>transaction</var>.</p>
@@ -5460,7 +5464,7 @@ the implementation must run the following steps:</p>
    <div class="algorithm">
     <ol>
      <li data-md="">
-      <p>Set <var>transaction</var> to the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-76">transaction</a> associated with
+      <p>Set <var>transaction</var> to the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-77">transaction</a> associated with
 the <a data-link-type="dfn" href="#request-source" id="ref-for-request-source-6">source</a>.</p>
      <li data-md="">
       <p>Set the <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-9">active flag</a> of <var>transaction</var>.</p>
@@ -5482,7 +5486,7 @@ for aborting a transaction</a> using <var>transaction</var> and <a data-link-typ
     </ol>
    </div>
    <h2 class="heading settled" data-level="6" id="database-operations"><span class="secno">6. </span><span class="content">Database operations</span><a class="self-link" href="#database-operations"></a></h2>
-   <p>This section describes various operations done on the data in <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-100">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-44">indexes</a> in a <a data-link-type="dfn" href="#database" id="ref-for-database-67">database</a>.
+   <p>This section describes various operations done on the data in <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-101">object stores</a> and <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-45">indexes</a> in a <a data-link-type="dfn" href="#database" id="ref-for-database-69">database</a>.
 These operations are run by the <a data-link-type="dfn" href="#steps-for-asynchronously-executing-a-request" id="ref-for-steps-for-asynchronously-executing-a-request-26">steps for asynchronously executing
 a request</a>.</p>
    <aside class="note"> Invocations of <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclone">StructuredClone</a>() in the operation steps below
@@ -5760,7 +5764,7 @@ records with key <a data-link-type="dfn" href="#in" id="ref-for-in-13">in</a> <v
      <li data-md="">
       <p>Remove all records from <var>store</var>.</p>
      <li data-md="">
-      <p>In all <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-45">indexes</a> which <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-12">reference</a> <var>store</var>, remove all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-90">records</a>.</p>
+      <p>In all <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-46">indexes</a> which <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-12">reference</a> <var>store</var>, remove all <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-90">records</a>.</p>
      <li data-md="">
       <p>Return undefined.</p>
     </ol>
@@ -5775,12 +5779,12 @@ follows.</p>
      <li data-md="">
       <p>Let <var>direction</var> be <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-direction" id="ref-for-cursor-direction-15">direction</a>.</p>
      <li data-md="">
-      <p class="assertion">Assert: if <var>primaryKey</var> is given, <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-46">index</a> and <var>direction</var> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-8">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-8">"prev"</a></code>.</p>
+      <p class="assertion">Assert: if <var>primaryKey</var> is given, <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-47">index</a> and <var>direction</var> is <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-next" id="ref-for-dom-idbcursordirection-next-8">"next"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbcursordirection-prev" id="ref-for-dom-idbcursordirection-prev-8">"prev"</a></code>.</p>
      <li data-md="">
       <p>Let <var>records</var> be the list of <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-91">records</a> in <var>source</var>.</p>
       <aside class="note"> <var>records</var> is always sorted in ascending <a data-link-type="dfn" href="#key" id="ref-for-key-89">key</a> order.
-  In the case of <var>source</var> being an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-47">index</a>, <var>records</var> is secondarily sorted in ascending <a data-link-type="dfn" href="#value" id="ref-for-value-21">value</a> order
-  (where the value in an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-48">index</a> is the <a data-link-type="dfn" href="#key" id="ref-for-key-90">key</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-92">record</a> in the referenced <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-101">object store</a>). </aside>
+  In the case of <var>source</var> being an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-48">index</a>, <var>records</var> is secondarily sorted in ascending <a data-link-type="dfn" href="#value" id="ref-for-value-21">value</a> order
+  (where the value in an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-49">index</a> is the <a data-link-type="dfn" href="#key" id="ref-for-key-90">key</a> of the <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-92">record</a> in the referenced <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-102">object store</a>). </aside>
      <li data-md="">
       <p>Let <var>range</var> be <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-range" id="ref-for-cursor-range-11">range</a>.</p>
      <li data-md="">
@@ -5809,9 +5813,9 @@ to</a> <var>key</var> and the record’s value is <a data-link-type="dfn" href="
 than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-17">equal to</a> <var>primaryKey</var>, or the
 record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-11">greater than</a> <var>key</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-102">object store</a>, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-12">greater than</a> <var>position</var>.</p>
+            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-103">object store</a>, the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-12">greater than</a> <var>position</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-49">index</a>, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-18">equal to</a> <var>position</var> and the record’s value is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-13">greater
+            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-50">index</a>, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-18">equal to</a> <var>position</var> and the record’s value is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-13">greater
 than</a> <var>object store position</var> or the record’s key is <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-14">greater than</a> <var>position</var>.</p>
            <li data-md="">
             <p>The record’s key is <a data-link-type="dfn" href="#in" id="ref-for-in-14">in</a> <var>range</var>.</p>
@@ -5842,10 +5846,10 @@ than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-20">eq
             <p>If <var>primaryKey</var> is defined, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-21">equal
 to</a> <var>key</var> and the record’s value is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-7">less than</a> or <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-22">equal to</a> <var>primaryKey</var>, or the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-8">less than</a> <var>key</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-103">object store</a>, the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-9">less
+            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-104">object store</a>, the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-9">less
 than</a> <var>position</var>.</p>
            <li data-md="">
-            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-50">index</a>, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-23">equal to</a> <var>position</var> and the record’s value is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-10">less than</a> <var>object store position</var> or the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-11">less than</a> <var>position</var>.</p>
+            <p>If <var>position</var> is defined, and <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-51">index</a>, the record’s key is <a data-link-type="dfn" href="#equal-to" id="ref-for-equal-to-23">equal to</a> <var>position</var> and the record’s value is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-10">less than</a> <var>object store position</var> or the record’s key is <a data-link-type="dfn" href="#less-than" id="ref-for-less-than-11">less than</a> <var>position</var>.</p>
            <li data-md="">
             <p>The record’s key is <a data-link-type="dfn" href="#in" id="ref-for-in-16">in</a> <var>range</var>.</p>
           </ul>
@@ -5872,7 +5876,7 @@ than</a> <var>position</var>.</p>
          <li data-md="">
           <p>Set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-key" id="ref-for-cursor-key-8">key</a> to undefined.</p>
          <li data-md="">
-          <p>If <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-51">index</a>, set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-6">object store position</a> to undefined.</p>
+          <p>If <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-52">index</a>, set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-6">object store position</a> to undefined.</p>
          <li data-md="">
           <p>If <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-key-only-flag" id="ref-for-cursor-key-only-flag-8">key only flag</a> is unset, set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-value" id="ref-for-cursor-value-9">value</a> to undefined.</p>
          <li data-md="">
@@ -5881,7 +5885,7 @@ than</a> <var>position</var>.</p>
        <li data-md="">
         <p>Let <var>position</var> be <var>found record</var>’s key.</p>
        <li data-md="">
-        <p>If <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-52">index</a>, let <var>object store
+        <p>If <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-53">index</a>, let <var>object store
 position</var> be <var>found record</var>’s value.</p>
        <li data-md="">
         <p>Decrease <var>count</var> by 1.</p>
@@ -5889,7 +5893,7 @@ position</var> be <var>found record</var>’s value.</p>
      <li data-md="">
       <p>Set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-position-15">position</a> to <var>position</var>.</p>
      <li data-md="">
-      <p>If <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-53">index</a>, set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-7">object
+      <p>If <var>source</var> is an <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-54">index</a>, set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-for-cursor-object-store-position-7">object
 store position</a> to <var>object store position</var>.</p>
      <li data-md="">
       <p>Set <var>cursor</var>’s <a data-link-type="dfn" href="#cursor-key" id="ref-for-cursor-key-9">key</a> to <var>found record</var>’s key.</p>
@@ -6064,7 +6068,7 @@ key to a value</a>.</p>
     </ol>
    </div>
    <aside class="note"> The <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-5">key path</a> used here is always a string and never a sequence,
-  since it is not possible to create a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-104">object store</a> which has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-24">key generator</a> and also has a <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-20">key path</a> that is a
+  since it is not possible to create a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-105">object store</a> which has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-24">key generator</a> and also has a <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-20">key path</a> that is a
   sequence. </aside>
    <aside class="note"> Assertions can be made in the above steps because this algorithm is
   only applied to values that are the output of <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclone">StructuredClone</a>. </aside>
@@ -6458,7 +6462,7 @@ and define abstract types such as <a data-link-type="dfn" href="#key" id="ref-fo
      <p>Clarified when a transaction can attempt to commit.
 (<a href="https://github.com/w3c/IndexedDB/issues/77">bug #77</a>)</p>
     <li data-md="">
-     <p>Clarified <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-15">open request</a> / <a data-link-type="dfn" href="#request-connection-queue" id="ref-for-request-connection-queue-5">connection queue</a> processing.
+     <p>Clarified <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-14">open request</a> / <a data-link-type="dfn" href="#request-connection-queue" id="ref-for-request-connection-queue-5">connection queue</a> processing.
 (<a href="https://github.com/w3c/IndexedDB/issues/9">bug #9</a>, <a href="https://github.com/w3c/IndexedDB/issues/77">bug #78</a>, <a href="https://github.com/w3c/IndexedDB/issues/77">bug #79</a>, <a href="https://github.com/w3c/IndexedDB/issues/77">bug #81</a>)</p>
    </ul>
    <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
@@ -7374,22 +7378,22 @@ specification.</p>
     <li><a href="#ref-for-database-15">2.2. Object Store</a> <a href="#ref-for-database-16">(2)</a>
     <li><a href="#ref-for-database-17">2.7. Transactions</a>
     <li><a href="#ref-for-database-18">2.7.1. Transaction Lifetime</a> <a href="#ref-for-database-19">(2)</a> <a href="#ref-for-database-20">(3)</a>
-    <li><a href="#ref-for-database-21">2.7.2. Upgrade Transactions</a> <a href="#ref-for-database-22">(2)</a> <a href="#ref-for-database-23">(3)</a> <a href="#ref-for-database-24">(4)</a>
-    <li><a href="#ref-for-database-25">2.8. Requests</a>
-    <li><a href="#ref-for-database-26">2.8.1. Open Requests</a>
-    <li><a href="#ref-for-database-27">4.1. The IDBRequest interface</a> <a href="#ref-for-database-28">(2)</a> <a href="#ref-for-database-29">(3)</a> <a href="#ref-for-database-30">(4)</a>
-    <li><a href="#ref-for-database-31">4.3. The IDBFactory interface</a> <a href="#ref-for-database-32">(2)</a> <a href="#ref-for-database-33">(3)</a> <a href="#ref-for-database-34">(4)</a> <a href="#ref-for-database-35">(5)</a> <a href="#ref-for-database-36">(6)</a> <a href="#ref-for-database-37">(7)</a>
-    <li><a href="#ref-for-database-38">4.4. The IDBDatabase interface</a> <a href="#ref-for-database-39">(2)</a> <a href="#ref-for-database-40">(3)</a> <a href="#ref-for-database-41">(4)</a> <a href="#ref-for-database-42">(5)</a> <a href="#ref-for-database-43">(6)</a> <a href="#ref-for-database-44">(7)</a> <a href="#ref-for-database-45">(8)</a> <a href="#ref-for-database-46">(9)</a>
-    <li><a href="#ref-for-database-47">4.5. The IDBObjectStore interface</a>
-    <li><a href="#ref-for-database-48">4.9. The IDBTransaction interface</a> <a href="#ref-for-database-49">(2)</a>
-    <li><a href="#ref-for-database-50">5.1. Opening a database</a> <a href="#ref-for-database-51">(2)</a> <a href="#ref-for-database-52">(3)</a>
-    <li><a href="#ref-for-database-53">5.2. Closing a database</a>
-    <li><a href="#ref-for-database-54">5.3. Deleting a database</a> <a href="#ref-for-database-55">(2)</a>
-    <li><a href="#ref-for-database-56">5.4. Committing a transaction</a> <a href="#ref-for-database-57">(2)</a> <a href="#ref-for-database-58">(3)</a>
-    <li><a href="#ref-for-database-59">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-database-60">5.7. Running an upgrade transaction</a> <a href="#ref-for-database-61">(2)</a> <a href="#ref-for-database-62">(3)</a> <a href="#ref-for-database-63">(4)</a>
-    <li><a href="#ref-for-database-64">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-database-65">(2)</a> <a href="#ref-for-database-66">(3)</a>
-    <li><a href="#ref-for-database-67">6. Database operations</a>
+    <li><a href="#ref-for-database-21">2.7.2. Upgrade Transactions</a> <a href="#ref-for-database-22">(2)</a> <a href="#ref-for-database-23">(3)</a> <a href="#ref-for-database-24">(4)</a> <a href="#ref-for-database-25">(5)</a> <a href="#ref-for-database-26">(6)</a>
+    <li><a href="#ref-for-database-27">2.8. Requests</a>
+    <li><a href="#ref-for-database-28">2.8.1. Open Requests</a>
+    <li><a href="#ref-for-database-29">4.1. The IDBRequest interface</a> <a href="#ref-for-database-30">(2)</a> <a href="#ref-for-database-31">(3)</a> <a href="#ref-for-database-32">(4)</a>
+    <li><a href="#ref-for-database-33">4.3. The IDBFactory interface</a> <a href="#ref-for-database-34">(2)</a> <a href="#ref-for-database-35">(3)</a> <a href="#ref-for-database-36">(4)</a> <a href="#ref-for-database-37">(5)</a> <a href="#ref-for-database-38">(6)</a> <a href="#ref-for-database-39">(7)</a>
+    <li><a href="#ref-for-database-40">4.4. The IDBDatabase interface</a> <a href="#ref-for-database-41">(2)</a> <a href="#ref-for-database-42">(3)</a> <a href="#ref-for-database-43">(4)</a> <a href="#ref-for-database-44">(5)</a> <a href="#ref-for-database-45">(6)</a> <a href="#ref-for-database-46">(7)</a> <a href="#ref-for-database-47">(8)</a> <a href="#ref-for-database-48">(9)</a>
+    <li><a href="#ref-for-database-49">4.5. The IDBObjectStore interface</a>
+    <li><a href="#ref-for-database-50">4.9. The IDBTransaction interface</a> <a href="#ref-for-database-51">(2)</a>
+    <li><a href="#ref-for-database-52">5.1. Opening a database</a> <a href="#ref-for-database-53">(2)</a> <a href="#ref-for-database-54">(3)</a>
+    <li><a href="#ref-for-database-55">5.2. Closing a database</a>
+    <li><a href="#ref-for-database-56">5.3. Deleting a database</a> <a href="#ref-for-database-57">(2)</a>
+    <li><a href="#ref-for-database-58">5.4. Committing a transaction</a> <a href="#ref-for-database-59">(2)</a> <a href="#ref-for-database-60">(3)</a>
+    <li><a href="#ref-for-database-61">5.5. Aborting a transaction</a>
+    <li><a href="#ref-for-database-62">5.7. Running an upgrade transaction</a> <a href="#ref-for-database-63">(2)</a> <a href="#ref-for-database-64">(3)</a> <a href="#ref-for-database-65">(4)</a>
+    <li><a href="#ref-for-database-66">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-database-67">(2)</a> <a href="#ref-for-database-68">(3)</a>
+    <li><a href="#ref-for-database-69">6. Database operations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="database-name">
@@ -7405,14 +7409,14 @@ specification.</p>
    <b><a href="#database-version">#database-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-database-version-1">2.1. Database</a>
-    <li><a href="#ref-for-database-version-2">2.7.2. Upgrade Transactions</a> <a href="#ref-for-database-version-3">(2)</a> <a href="#ref-for-database-version-4">(3)</a> <a href="#ref-for-database-version-5">(4)</a>
-    <li><a href="#ref-for-database-version-6">4.3. The IDBFactory interface</a> <a href="#ref-for-database-version-7">(2)</a>
-    <li><a href="#ref-for-database-version-8">4.4. The IDBDatabase interface</a> <a href="#ref-for-database-version-9">(2)</a>
-    <li><a href="#ref-for-database-version-10">5.1. Opening a database</a> <a href="#ref-for-database-version-11">(2)</a> <a href="#ref-for-database-version-12">(3)</a> <a href="#ref-for-database-version-13">(4)</a> <a href="#ref-for-database-version-14">(5)</a> <a href="#ref-for-database-version-15">(6)</a>
-    <li><a href="#ref-for-database-version-16">5.3. Deleting a database</a> <a href="#ref-for-database-version-17">(2)</a> <a href="#ref-for-database-version-18">(3)</a>
-    <li><a href="#ref-for-database-version-19">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-database-version-20">5.7. Running an upgrade transaction</a>
-    <li><a href="#ref-for-database-version-21">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-database-version-22">(2)</a>
+    <li><a href="#ref-for-database-version-2">2.7.2. Upgrade Transactions</a> <a href="#ref-for-database-version-3">(2)</a>
+    <li><a href="#ref-for-database-version-4">4.3. The IDBFactory interface</a> <a href="#ref-for-database-version-5">(2)</a>
+    <li><a href="#ref-for-database-version-6">4.4. The IDBDatabase interface</a> <a href="#ref-for-database-version-7">(2)</a>
+    <li><a href="#ref-for-database-version-8">5.1. Opening a database</a> <a href="#ref-for-database-version-9">(2)</a> <a href="#ref-for-database-version-10">(3)</a> <a href="#ref-for-database-version-11">(4)</a> <a href="#ref-for-database-version-12">(5)</a> <a href="#ref-for-database-version-13">(6)</a>
+    <li><a href="#ref-for-database-version-14">5.3. Deleting a database</a> <a href="#ref-for-database-version-15">(2)</a> <a href="#ref-for-database-version-16">(3)</a>
+    <li><a href="#ref-for-database-version-17">5.5. Aborting a transaction</a>
+    <li><a href="#ref-for-database-version-18">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-database-version-19">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-database-version-20">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="connection">
@@ -7421,17 +7425,17 @@ specification.</p>
     <li><a href="#ref-for-connection-1">1. Introduction</a> <a href="#ref-for-connection-2">(2)</a>
     <li><a href="#ref-for-connection-3">2.1.1. Database Connection</a> <a href="#ref-for-connection-4">(2)</a> <a href="#ref-for-connection-5">(3)</a> <a href="#ref-for-connection-6">(4)</a> <a href="#ref-for-connection-7">(5)</a> <a href="#ref-for-connection-8">(6)</a> <a href="#ref-for-connection-9">(7)</a> <a href="#ref-for-connection-10">(8)</a> <a href="#ref-for-connection-11">(9)</a> <a href="#ref-for-connection-12">(10)</a> <a href="#ref-for-connection-13">(11)</a> <a href="#ref-for-connection-14">(12)</a> <a href="#ref-for-connection-15">(13)</a> <a href="#ref-for-connection-16">(14)</a> <a href="#ref-for-connection-17">(15)</a> <a href="#ref-for-connection-18">(16)</a> <a href="#ref-for-connection-19">(17)</a> <a href="#ref-for-connection-20">(18)</a>
     <li><a href="#ref-for-connection-21">2.7. Transactions</a>
-    <li><a href="#ref-for-connection-22">2.7.2. Upgrade Transactions</a> <a href="#ref-for-connection-23">(2)</a> <a href="#ref-for-connection-24">(3)</a> <a href="#ref-for-connection-25">(4)</a>
-    <li><a href="#ref-for-connection-26">2.8.1. Open Requests</a> <a href="#ref-for-connection-27">(2)</a>
-    <li><a href="#ref-for-connection-28">4.3. The IDBFactory interface</a> <a href="#ref-for-connection-29">(2)</a> <a href="#ref-for-connection-30">(3)</a> <a href="#ref-for-connection-31">(4)</a> <a href="#ref-for-connection-32">(5)</a> <a href="#ref-for-connection-33">(6)</a>
-    <li><a href="#ref-for-connection-34">4.4. The IDBDatabase interface</a> <a href="#ref-for-connection-35">(2)</a> <a href="#ref-for-connection-36">(3)</a> <a href="#ref-for-connection-37">(4)</a> <a href="#ref-for-connection-38">(5)</a> <a href="#ref-for-connection-39">(6)</a> <a href="#ref-for-connection-40">(7)</a> <a href="#ref-for-connection-41">(8)</a> <a href="#ref-for-connection-42">(9)</a> <a href="#ref-for-connection-43">(10)</a> <a href="#ref-for-connection-44">(11)</a> <a href="#ref-for-connection-45">(12)</a> <a href="#ref-for-connection-46">(13)</a> <a href="#ref-for-connection-47">(14)</a> <a href="#ref-for-connection-48">(15)</a> <a href="#ref-for-connection-49">(16)</a> <a href="#ref-for-connection-50">(17)</a> <a href="#ref-for-connection-51">(18)</a> <a href="#ref-for-connection-52">(19)</a>
-    <li><a href="#ref-for-connection-53">4.9. The IDBTransaction interface</a> <a href="#ref-for-connection-54">(2)</a>
-    <li><a href="#ref-for-connection-55">5.1. Opening a database</a> <a href="#ref-for-connection-56">(2)</a> <a href="#ref-for-connection-57">(3)</a> <a href="#ref-for-connection-58">(4)</a>
-    <li><a href="#ref-for-connection-59">5.2. Closing a database</a> <a href="#ref-for-connection-60">(2)</a>
-    <li><a href="#ref-for-connection-61">5.3. Deleting a database</a> <a href="#ref-for-connection-62">(2)</a> <a href="#ref-for-connection-63">(3)</a>
-    <li><a href="#ref-for-connection-64">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-connection-65">5.7. Running an upgrade transaction</a> <a href="#ref-for-connection-66">(2)</a>
-    <li><a href="#ref-for-connection-67">5.8. Aborting an upgrade transaction</a>
+    <li><a href="#ref-for-connection-22">2.7.2. Upgrade Transactions</a> <a href="#ref-for-connection-23">(2)</a> <a href="#ref-for-connection-24">(3)</a> <a href="#ref-for-connection-25">(4)</a> <a href="#ref-for-connection-26">(5)</a> <a href="#ref-for-connection-27">(6)</a>
+    <li><a href="#ref-for-connection-28">2.8.1. Open Requests</a> <a href="#ref-for-connection-29">(2)</a>
+    <li><a href="#ref-for-connection-30">4.3. The IDBFactory interface</a> <a href="#ref-for-connection-31">(2)</a> <a href="#ref-for-connection-32">(3)</a> <a href="#ref-for-connection-33">(4)</a> <a href="#ref-for-connection-34">(5)</a> <a href="#ref-for-connection-35">(6)</a>
+    <li><a href="#ref-for-connection-36">4.4. The IDBDatabase interface</a> <a href="#ref-for-connection-37">(2)</a> <a href="#ref-for-connection-38">(3)</a> <a href="#ref-for-connection-39">(4)</a> <a href="#ref-for-connection-40">(5)</a> <a href="#ref-for-connection-41">(6)</a> <a href="#ref-for-connection-42">(7)</a> <a href="#ref-for-connection-43">(8)</a> <a href="#ref-for-connection-44">(9)</a> <a href="#ref-for-connection-45">(10)</a> <a href="#ref-for-connection-46">(11)</a> <a href="#ref-for-connection-47">(12)</a> <a href="#ref-for-connection-48">(13)</a> <a href="#ref-for-connection-49">(14)</a> <a href="#ref-for-connection-50">(15)</a> <a href="#ref-for-connection-51">(16)</a> <a href="#ref-for-connection-52">(17)</a> <a href="#ref-for-connection-53">(18)</a> <a href="#ref-for-connection-54">(19)</a>
+    <li><a href="#ref-for-connection-55">4.9. The IDBTransaction interface</a> <a href="#ref-for-connection-56">(2)</a>
+    <li><a href="#ref-for-connection-57">5.1. Opening a database</a> <a href="#ref-for-connection-58">(2)</a> <a href="#ref-for-connection-59">(3)</a> <a href="#ref-for-connection-60">(4)</a>
+    <li><a href="#ref-for-connection-61">5.2. Closing a database</a> <a href="#ref-for-connection-62">(2)</a>
+    <li><a href="#ref-for-connection-63">5.3. Deleting a database</a> <a href="#ref-for-connection-64">(2)</a> <a href="#ref-for-connection-65">(3)</a>
+    <li><a href="#ref-for-connection-66">5.5. Aborting a transaction</a>
+    <li><a href="#ref-for-connection-67">5.7. Running an upgrade transaction</a> <a href="#ref-for-connection-68">(2)</a>
+    <li><a href="#ref-for-connection-69">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="connection-version">
@@ -7487,21 +7491,21 @@ specification.</p>
     <li><a href="#ref-for-object-store-13">2.6. Index</a> <a href="#ref-for-object-store-14">(2)</a> <a href="#ref-for-object-store-15">(3)</a> <a href="#ref-for-object-store-16">(4)</a> <a href="#ref-for-object-store-17">(5)</a> <a href="#ref-for-object-store-18">(6)</a> <a href="#ref-for-object-store-19">(7)</a>
     <li><a href="#ref-for-object-store-20">2.7. Transactions</a>
     <li><a href="#ref-for-object-store-21">2.7.1. Transaction Lifetime</a> <a href="#ref-for-object-store-22">(2)</a> <a href="#ref-for-object-store-23">(3)</a> <a href="#ref-for-object-store-24">(4)</a> <a href="#ref-for-object-store-25">(5)</a> <a href="#ref-for-object-store-26">(6)</a> <a href="#ref-for-object-store-27">(7)</a> <a href="#ref-for-object-store-28">(8)</a> <a href="#ref-for-object-store-29">(9)</a>
-    <li><a href="#ref-for-object-store-30">2.7.2. Upgrade Transactions</a>
-    <li><a href="#ref-for-object-store-31">2.9. Key Range</a>
-    <li><a href="#ref-for-object-store-32">2.10. Cursor</a> <a href="#ref-for-object-store-33">(2)</a> <a href="#ref-for-object-store-34">(3)</a> <a href="#ref-for-object-store-35">(4)</a> <a href="#ref-for-object-store-36">(5)</a> <a href="#ref-for-object-store-37">(6)</a>
-    <li><a href="#ref-for-object-store-38">2.11. Key Generators</a> <a href="#ref-for-object-store-39">(2)</a> <a href="#ref-for-object-store-40">(3)</a> <a href="#ref-for-object-store-41">(4)</a> <a href="#ref-for-object-store-42">(5)</a> <a href="#ref-for-object-store-43">(6)</a> <a href="#ref-for-object-store-44">(7)</a> <a href="#ref-for-object-store-45">(8)</a> <a href="#ref-for-object-store-46">(9)</a> <a href="#ref-for-object-store-47">(10)</a> <a href="#ref-for-object-store-48">(11)</a> <a href="#ref-for-object-store-49">(12)</a> <a href="#ref-for-object-store-50">(13)</a>
-    <li><a href="#ref-for-object-store-51">4.4. The IDBDatabase interface</a> <a href="#ref-for-object-store-52">(2)</a> <a href="#ref-for-object-store-53">(3)</a> <a href="#ref-for-object-store-54">(4)</a> <a href="#ref-for-object-store-55">(5)</a> <a href="#ref-for-object-store-56">(6)</a> <a href="#ref-for-object-store-57">(7)</a> <a href="#ref-for-object-store-58">(8)</a> <a href="#ref-for-object-store-59">(9)</a> <a href="#ref-for-object-store-60">(10)</a> <a href="#ref-for-object-store-61">(11)</a> <a href="#ref-for-object-store-62">(12)</a> <a href="#ref-for-object-store-63">(13)</a> <a href="#ref-for-object-store-64">(14)</a> <a href="#ref-for-object-store-65">(15)</a> <a href="#ref-for-object-store-66">(16)</a> <a href="#ref-for-object-store-67">(17)</a> <a href="#ref-for-object-store-68">(18)</a> <a href="#ref-for-object-store-69">(19)</a> <a href="#ref-for-object-store-70">(20)</a>
-    <li><a href="#ref-for-object-store-71">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-72">(2)</a> <a href="#ref-for-object-store-73">(3)</a> <a href="#ref-for-object-store-74">(4)</a> <a href="#ref-for-object-store-75">(5)</a> <a href="#ref-for-object-store-76">(6)</a> <a href="#ref-for-object-store-77">(7)</a>
-    <li><a href="#ref-for-object-store-78">4.6. The IDBIndex interface</a> <a href="#ref-for-object-store-79">(2)</a> <a href="#ref-for-object-store-80">(3)</a> <a href="#ref-for-object-store-81">(4)</a> <a href="#ref-for-object-store-82">(5)</a> <a href="#ref-for-object-store-83">(6)</a> <a href="#ref-for-object-store-84">(7)</a> <a href="#ref-for-object-store-85">(8)</a> <a href="#ref-for-object-store-86">(9)</a>
-    <li><a href="#ref-for-object-store-87">4.9. The IDBTransaction interface</a> <a href="#ref-for-object-store-88">(2)</a> <a href="#ref-for-object-store-89">(3)</a> <a href="#ref-for-object-store-90">(4)</a> <a href="#ref-for-object-store-91">(5)</a>
-    <li><a href="#ref-for-object-store-92">5.1. Opening a database</a>
-    <li><a href="#ref-for-object-store-93">5.5. Aborting a transaction</a> <a href="#ref-for-object-store-94">(2)</a>
-    <li><a href="#ref-for-object-store-95">5.7. Running an upgrade transaction</a>
-    <li><a href="#ref-for-object-store-96">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-object-store-97">(2)</a> <a href="#ref-for-object-store-98">(3)</a> <a href="#ref-for-object-store-99">(4)</a>
-    <li><a href="#ref-for-object-store-100">6. Database operations</a>
-    <li><a href="#ref-for-object-store-101">6.7. Cursor Iteration Operation</a> <a href="#ref-for-object-store-102">(2)</a> <a href="#ref-for-object-store-103">(3)</a>
-    <li><a href="#ref-for-object-store-104">7.2. Inject a key into a value</a>
+    <li><a href="#ref-for-object-store-30">2.7.2. Upgrade Transactions</a> <a href="#ref-for-object-store-31">(2)</a>
+    <li><a href="#ref-for-object-store-32">2.9. Key Range</a>
+    <li><a href="#ref-for-object-store-33">2.10. Cursor</a> <a href="#ref-for-object-store-34">(2)</a> <a href="#ref-for-object-store-35">(3)</a> <a href="#ref-for-object-store-36">(4)</a> <a href="#ref-for-object-store-37">(5)</a> <a href="#ref-for-object-store-38">(6)</a>
+    <li><a href="#ref-for-object-store-39">2.11. Key Generators</a> <a href="#ref-for-object-store-40">(2)</a> <a href="#ref-for-object-store-41">(3)</a> <a href="#ref-for-object-store-42">(4)</a> <a href="#ref-for-object-store-43">(5)</a> <a href="#ref-for-object-store-44">(6)</a> <a href="#ref-for-object-store-45">(7)</a> <a href="#ref-for-object-store-46">(8)</a> <a href="#ref-for-object-store-47">(9)</a> <a href="#ref-for-object-store-48">(10)</a> <a href="#ref-for-object-store-49">(11)</a> <a href="#ref-for-object-store-50">(12)</a> <a href="#ref-for-object-store-51">(13)</a>
+    <li><a href="#ref-for-object-store-52">4.4. The IDBDatabase interface</a> <a href="#ref-for-object-store-53">(2)</a> <a href="#ref-for-object-store-54">(3)</a> <a href="#ref-for-object-store-55">(4)</a> <a href="#ref-for-object-store-56">(5)</a> <a href="#ref-for-object-store-57">(6)</a> <a href="#ref-for-object-store-58">(7)</a> <a href="#ref-for-object-store-59">(8)</a> <a href="#ref-for-object-store-60">(9)</a> <a href="#ref-for-object-store-61">(10)</a> <a href="#ref-for-object-store-62">(11)</a> <a href="#ref-for-object-store-63">(12)</a> <a href="#ref-for-object-store-64">(13)</a> <a href="#ref-for-object-store-65">(14)</a> <a href="#ref-for-object-store-66">(15)</a> <a href="#ref-for-object-store-67">(16)</a> <a href="#ref-for-object-store-68">(17)</a> <a href="#ref-for-object-store-69">(18)</a> <a href="#ref-for-object-store-70">(19)</a> <a href="#ref-for-object-store-71">(20)</a>
+    <li><a href="#ref-for-object-store-72">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-73">(2)</a> <a href="#ref-for-object-store-74">(3)</a> <a href="#ref-for-object-store-75">(4)</a> <a href="#ref-for-object-store-76">(5)</a> <a href="#ref-for-object-store-77">(6)</a> <a href="#ref-for-object-store-78">(7)</a>
+    <li><a href="#ref-for-object-store-79">4.6. The IDBIndex interface</a> <a href="#ref-for-object-store-80">(2)</a> <a href="#ref-for-object-store-81">(3)</a> <a href="#ref-for-object-store-82">(4)</a> <a href="#ref-for-object-store-83">(5)</a> <a href="#ref-for-object-store-84">(6)</a> <a href="#ref-for-object-store-85">(7)</a> <a href="#ref-for-object-store-86">(8)</a> <a href="#ref-for-object-store-87">(9)</a>
+    <li><a href="#ref-for-object-store-88">4.9. The IDBTransaction interface</a> <a href="#ref-for-object-store-89">(2)</a> <a href="#ref-for-object-store-90">(3)</a> <a href="#ref-for-object-store-91">(4)</a> <a href="#ref-for-object-store-92">(5)</a>
+    <li><a href="#ref-for-object-store-93">5.1. Opening a database</a>
+    <li><a href="#ref-for-object-store-94">5.5. Aborting a transaction</a> <a href="#ref-for-object-store-95">(2)</a>
+    <li><a href="#ref-for-object-store-96">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-object-store-97">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-object-store-98">(2)</a> <a href="#ref-for-object-store-99">(3)</a> <a href="#ref-for-object-store-100">(4)</a>
+    <li><a href="#ref-for-object-store-101">6. Database operations</a>
+    <li><a href="#ref-for-object-store-102">6.7. Cursor Iteration Operation</a> <a href="#ref-for-object-store-103">(2)</a> <a href="#ref-for-object-store-104">(3)</a>
+    <li><a href="#ref-for-object-store-105">7.2. Inject a key into a value</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="object-store-list-of-records">
@@ -7753,17 +7757,17 @@ specification.</p>
     <li><a href="#ref-for-index-concept-2">2.6. Index</a> <a href="#ref-for-index-concept-3">(2)</a> <a href="#ref-for-index-concept-4">(3)</a> <a href="#ref-for-index-concept-5">(4)</a> <a href="#ref-for-index-concept-6">(5)</a>
     <li><a href="#ref-for-index-concept-7">2.6.1. Index Handle</a> <a href="#ref-for-index-concept-8">(2)</a> <a href="#ref-for-index-concept-9">(3)</a>
     <li><a href="#ref-for-index-concept-10">2.7.1. Transaction Lifetime</a>
-    <li><a href="#ref-for-index-concept-11">2.7.2. Upgrade Transactions</a>
-    <li><a href="#ref-for-index-concept-12">2.9. Key Range</a>
-    <li><a href="#ref-for-index-concept-13">2.10. Cursor</a> <a href="#ref-for-index-concept-14">(2)</a> <a href="#ref-for-index-concept-15">(3)</a> <a href="#ref-for-index-concept-16">(4)</a> <a href="#ref-for-index-concept-17">(5)</a> <a href="#ref-for-index-concept-18">(6)</a>
-    <li><a href="#ref-for-index-concept-19">4.5. The IDBObjectStore interface</a> <a href="#ref-for-index-concept-20">(2)</a> <a href="#ref-for-index-concept-21">(3)</a> <a href="#ref-for-index-concept-22">(4)</a> <a href="#ref-for-index-concept-23">(5)</a> <a href="#ref-for-index-concept-24">(6)</a> <a href="#ref-for-index-concept-25">(7)</a> <a href="#ref-for-index-concept-26">(8)</a> <a href="#ref-for-index-concept-27">(9)</a> <a href="#ref-for-index-concept-28">(10)</a> <a href="#ref-for-index-concept-29">(11)</a> <a href="#ref-for-index-concept-30">(12)</a>
-    <li><a href="#ref-for-index-concept-31">4.6. The IDBIndex interface</a> <a href="#ref-for-index-concept-32">(2)</a> <a href="#ref-for-index-concept-33">(3)</a> <a href="#ref-for-index-concept-34">(4)</a> <a href="#ref-for-index-concept-35">(5)</a>
-    <li><a href="#ref-for-index-concept-36">4.8. The IDBCursor interface</a> <a href="#ref-for-index-concept-37">(2)</a>
-    <li><a href="#ref-for-index-concept-38">5.5. Aborting a transaction</a> <a href="#ref-for-index-concept-39">(2)</a>
-    <li><a href="#ref-for-index-concept-40">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-index-concept-41">(2)</a> <a href="#ref-for-index-concept-42">(3)</a> <a href="#ref-for-index-concept-43">(4)</a>
-    <li><a href="#ref-for-index-concept-44">6. Database operations</a>
-    <li><a href="#ref-for-index-concept-45">6.6. Object Store Clear Operation</a>
-    <li><a href="#ref-for-index-concept-46">6.7. Cursor Iteration Operation</a> <a href="#ref-for-index-concept-47">(2)</a> <a href="#ref-for-index-concept-48">(3)</a> <a href="#ref-for-index-concept-49">(4)</a> <a href="#ref-for-index-concept-50">(5)</a> <a href="#ref-for-index-concept-51">(6)</a> <a href="#ref-for-index-concept-52">(7)</a> <a href="#ref-for-index-concept-53">(8)</a>
+    <li><a href="#ref-for-index-concept-11">2.7.2. Upgrade Transactions</a> <a href="#ref-for-index-concept-12">(2)</a>
+    <li><a href="#ref-for-index-concept-13">2.9. Key Range</a>
+    <li><a href="#ref-for-index-concept-14">2.10. Cursor</a> <a href="#ref-for-index-concept-15">(2)</a> <a href="#ref-for-index-concept-16">(3)</a> <a href="#ref-for-index-concept-17">(4)</a> <a href="#ref-for-index-concept-18">(5)</a> <a href="#ref-for-index-concept-19">(6)</a>
+    <li><a href="#ref-for-index-concept-20">4.5. The IDBObjectStore interface</a> <a href="#ref-for-index-concept-21">(2)</a> <a href="#ref-for-index-concept-22">(3)</a> <a href="#ref-for-index-concept-23">(4)</a> <a href="#ref-for-index-concept-24">(5)</a> <a href="#ref-for-index-concept-25">(6)</a> <a href="#ref-for-index-concept-26">(7)</a> <a href="#ref-for-index-concept-27">(8)</a> <a href="#ref-for-index-concept-28">(9)</a> <a href="#ref-for-index-concept-29">(10)</a> <a href="#ref-for-index-concept-30">(11)</a> <a href="#ref-for-index-concept-31">(12)</a>
+    <li><a href="#ref-for-index-concept-32">4.6. The IDBIndex interface</a> <a href="#ref-for-index-concept-33">(2)</a> <a href="#ref-for-index-concept-34">(3)</a> <a href="#ref-for-index-concept-35">(4)</a> <a href="#ref-for-index-concept-36">(5)</a>
+    <li><a href="#ref-for-index-concept-37">4.8. The IDBCursor interface</a> <a href="#ref-for-index-concept-38">(2)</a>
+    <li><a href="#ref-for-index-concept-39">5.5. Aborting a transaction</a> <a href="#ref-for-index-concept-40">(2)</a>
+    <li><a href="#ref-for-index-concept-41">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-index-concept-42">(2)</a> <a href="#ref-for-index-concept-43">(3)</a> <a href="#ref-for-index-concept-44">(4)</a>
+    <li><a href="#ref-for-index-concept-45">6. Database operations</a>
+    <li><a href="#ref-for-index-concept-46">6.6. Object Store Clear Operation</a>
+    <li><a href="#ref-for-index-concept-47">6.7. Cursor Iteration Operation</a> <a href="#ref-for-index-concept-48">(2)</a> <a href="#ref-for-index-concept-49">(3)</a> <a href="#ref-for-index-concept-50">(4)</a> <a href="#ref-for-index-concept-51">(5)</a> <a href="#ref-for-index-concept-52">(6)</a> <a href="#ref-for-index-concept-53">(7)</a> <a href="#ref-for-index-concept-54">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="index-referenced">
@@ -7887,21 +7891,21 @@ specification.</p>
     <li><a href="#ref-for-transaction-concept-5">2.6.1. Index Handle</a> <a href="#ref-for-transaction-concept-6">(2)</a> <a href="#ref-for-transaction-concept-7">(3)</a>
     <li><a href="#ref-for-transaction-concept-8">2.7. Transactions</a> <a href="#ref-for-transaction-concept-9">(2)</a> <a href="#ref-for-transaction-concept-10">(3)</a> <a href="#ref-for-transaction-concept-11">(4)</a> <a href="#ref-for-transaction-concept-12">(5)</a> <a href="#ref-for-transaction-concept-13">(6)</a> <a href="#ref-for-transaction-concept-14">(7)</a> <a href="#ref-for-transaction-concept-15">(8)</a> <a href="#ref-for-transaction-concept-16">(9)</a> <a href="#ref-for-transaction-concept-17">(10)</a> <a href="#ref-for-transaction-concept-18">(11)</a> <a href="#ref-for-transaction-concept-19">(12)</a> <a href="#ref-for-transaction-concept-20">(13)</a> <a href="#ref-for-transaction-concept-21">(14)</a>
     <li><a href="#ref-for-transaction-concept-22">2.7.1. Transaction Lifetime</a> <a href="#ref-for-transaction-concept-23">(2)</a>
-    <li><a href="#ref-for-transaction-concept-24">2.7.2. Upgrade Transactions</a> <a href="#ref-for-transaction-concept-25">(2)</a>
-    <li><a href="#ref-for-transaction-concept-26">2.8. Requests</a>
-    <li><a href="#ref-for-transaction-concept-27">2.10. Cursor</a>
-    <li><a href="#ref-for-transaction-concept-28">2.11. Key Generators</a> <a href="#ref-for-transaction-concept-29">(2)</a>
-    <li><a href="#ref-for-transaction-concept-30">4.4. The IDBDatabase interface</a> <a href="#ref-for-transaction-concept-31">(2)</a> <a href="#ref-for-transaction-concept-32">(3)</a>
-    <li><a href="#ref-for-transaction-concept-33">4.5. The IDBObjectStore interface</a> <a href="#ref-for-transaction-concept-34">(2)</a> <a href="#ref-for-transaction-concept-35">(3)</a> <a href="#ref-for-transaction-concept-36">(4)</a> <a href="#ref-for-transaction-concept-37">(5)</a> <a href="#ref-for-transaction-concept-38">(6)</a> <a href="#ref-for-transaction-concept-39">(7)</a> <a href="#ref-for-transaction-concept-40">(8)</a> <a href="#ref-for-transaction-concept-41">(9)</a>
-    <li><a href="#ref-for-transaction-concept-42">4.6. The IDBIndex interface</a> <a href="#ref-for-transaction-concept-43">(2)</a> <a href="#ref-for-transaction-concept-44">(3)</a> <a href="#ref-for-transaction-concept-45">(4)</a>
-    <li><a href="#ref-for-transaction-concept-46">4.8. The IDBCursor interface</a> <a href="#ref-for-transaction-concept-47">(2)</a> <a href="#ref-for-transaction-concept-48">(3)</a>
-    <li><a href="#ref-for-transaction-concept-49">4.9. The IDBTransaction interface</a> <a href="#ref-for-transaction-concept-50">(2)</a> <a href="#ref-for-transaction-concept-51">(3)</a> <a href="#ref-for-transaction-concept-52">(4)</a> <a href="#ref-for-transaction-concept-53">(5)</a> <a href="#ref-for-transaction-concept-54">(6)</a> <a href="#ref-for-transaction-concept-55">(7)</a> <a href="#ref-for-transaction-concept-56">(8)</a> <a href="#ref-for-transaction-concept-57">(9)</a> <a href="#ref-for-transaction-concept-58">(10)</a> <a href="#ref-for-transaction-concept-59">(11)</a> <a href="#ref-for-transaction-concept-60">(12)</a> <a href="#ref-for-transaction-concept-61">(13)</a> <a href="#ref-for-transaction-concept-62">(14)</a> <a href="#ref-for-transaction-concept-63">(15)</a> <a href="#ref-for-transaction-concept-64">(16)</a> <a href="#ref-for-transaction-concept-65">(17)</a> <a href="#ref-for-transaction-concept-66">(18)</a>
-    <li><a href="#ref-for-transaction-concept-67">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-transaction-concept-68">5.6. Asynchronously executing a request</a> <a href="#ref-for-transaction-concept-69">(2)</a>
-    <li><a href="#ref-for-transaction-concept-70">5.7. Running an upgrade transaction</a> <a href="#ref-for-transaction-concept-71">(2)</a> <a href="#ref-for-transaction-concept-72">(3)</a>
-    <li><a href="#ref-for-transaction-concept-73">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-transaction-concept-74">(2)</a>
-    <li><a href="#ref-for-transaction-concept-75">5.9. Firing a success event</a>
-    <li><a href="#ref-for-transaction-concept-76">5.10. Firing an error event</a>
+    <li><a href="#ref-for-transaction-concept-24">2.7.2. Upgrade Transactions</a> <a href="#ref-for-transaction-concept-25">(2)</a> <a href="#ref-for-transaction-concept-26">(3)</a>
+    <li><a href="#ref-for-transaction-concept-27">2.8. Requests</a>
+    <li><a href="#ref-for-transaction-concept-28">2.10. Cursor</a>
+    <li><a href="#ref-for-transaction-concept-29">2.11. Key Generators</a> <a href="#ref-for-transaction-concept-30">(2)</a>
+    <li><a href="#ref-for-transaction-concept-31">4.4. The IDBDatabase interface</a> <a href="#ref-for-transaction-concept-32">(2)</a> <a href="#ref-for-transaction-concept-33">(3)</a>
+    <li><a href="#ref-for-transaction-concept-34">4.5. The IDBObjectStore interface</a> <a href="#ref-for-transaction-concept-35">(2)</a> <a href="#ref-for-transaction-concept-36">(3)</a> <a href="#ref-for-transaction-concept-37">(4)</a> <a href="#ref-for-transaction-concept-38">(5)</a> <a href="#ref-for-transaction-concept-39">(6)</a> <a href="#ref-for-transaction-concept-40">(7)</a> <a href="#ref-for-transaction-concept-41">(8)</a> <a href="#ref-for-transaction-concept-42">(9)</a>
+    <li><a href="#ref-for-transaction-concept-43">4.6. The IDBIndex interface</a> <a href="#ref-for-transaction-concept-44">(2)</a> <a href="#ref-for-transaction-concept-45">(3)</a> <a href="#ref-for-transaction-concept-46">(4)</a>
+    <li><a href="#ref-for-transaction-concept-47">4.8. The IDBCursor interface</a> <a href="#ref-for-transaction-concept-48">(2)</a> <a href="#ref-for-transaction-concept-49">(3)</a>
+    <li><a href="#ref-for-transaction-concept-50">4.9. The IDBTransaction interface</a> <a href="#ref-for-transaction-concept-51">(2)</a> <a href="#ref-for-transaction-concept-52">(3)</a> <a href="#ref-for-transaction-concept-53">(4)</a> <a href="#ref-for-transaction-concept-54">(5)</a> <a href="#ref-for-transaction-concept-55">(6)</a> <a href="#ref-for-transaction-concept-56">(7)</a> <a href="#ref-for-transaction-concept-57">(8)</a> <a href="#ref-for-transaction-concept-58">(9)</a> <a href="#ref-for-transaction-concept-59">(10)</a> <a href="#ref-for-transaction-concept-60">(11)</a> <a href="#ref-for-transaction-concept-61">(12)</a> <a href="#ref-for-transaction-concept-62">(13)</a> <a href="#ref-for-transaction-concept-63">(14)</a> <a href="#ref-for-transaction-concept-64">(15)</a> <a href="#ref-for-transaction-concept-65">(16)</a> <a href="#ref-for-transaction-concept-66">(17)</a> <a href="#ref-for-transaction-concept-67">(18)</a>
+    <li><a href="#ref-for-transaction-concept-68">5.5. Aborting a transaction</a>
+    <li><a href="#ref-for-transaction-concept-69">5.6. Asynchronously executing a request</a> <a href="#ref-for-transaction-concept-70">(2)</a>
+    <li><a href="#ref-for-transaction-concept-71">5.7. Running an upgrade transaction</a> <a href="#ref-for-transaction-concept-72">(2)</a> <a href="#ref-for-transaction-concept-73">(3)</a>
+    <li><a href="#ref-for-transaction-concept-74">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-transaction-concept-75">(2)</a>
+    <li><a href="#ref-for-transaction-concept-76">5.9. Firing a success event</a>
+    <li><a href="#ref-for-transaction-concept-77">5.10. Firing an error event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="transaction-connection">
@@ -8042,19 +8046,19 @@ specification.</p>
     <li><a href="#ref-for-upgrade-transaction-3">2.2. Object Store</a>
     <li><a href="#ref-for-upgrade-transaction-4">2.2.1. Object Store Handle</a> <a href="#ref-for-upgrade-transaction-5">(2)</a>
     <li><a href="#ref-for-upgrade-transaction-6">2.6.1. Index Handle</a>
-    <li><a href="#ref-for-upgrade-transaction-7">2.7.2. Upgrade Transactions</a> <a href="#ref-for-upgrade-transaction-8">(2)</a> <a href="#ref-for-upgrade-transaction-9">(3)</a> <a href="#ref-for-upgrade-transaction-10">(4)</a> <a href="#ref-for-upgrade-transaction-11">(5)</a> <a href="#ref-for-upgrade-transaction-12">(6)</a>
-    <li><a href="#ref-for-upgrade-transaction-13">2.8. Requests</a>
-    <li><a href="#ref-for-upgrade-transaction-14">4.1. The IDBRequest interface</a>
-    <li><a href="#ref-for-upgrade-transaction-15">4.3. The IDBFactory interface</a> <a href="#ref-for-upgrade-transaction-16">(2)</a>
-    <li><a href="#ref-for-upgrade-transaction-17">4.4. The IDBDatabase interface</a> <a href="#ref-for-upgrade-transaction-18">(2)</a> <a href="#ref-for-upgrade-transaction-19">(3)</a> <a href="#ref-for-upgrade-transaction-20">(4)</a> <a href="#ref-for-upgrade-transaction-21">(5)</a> <a href="#ref-for-upgrade-transaction-22">(6)</a> <a href="#ref-for-upgrade-transaction-23">(7)</a> <a href="#ref-for-upgrade-transaction-24">(8)</a> <a href="#ref-for-upgrade-transaction-25">(9)</a>
-    <li><a href="#ref-for-upgrade-transaction-26">4.5. The IDBObjectStore interface</a> <a href="#ref-for-upgrade-transaction-27">(2)</a> <a href="#ref-for-upgrade-transaction-28">(3)</a> <a href="#ref-for-upgrade-transaction-29">(4)</a> <a href="#ref-for-upgrade-transaction-30">(5)</a> <a href="#ref-for-upgrade-transaction-31">(6)</a> <a href="#ref-for-upgrade-transaction-32">(7)</a> <a href="#ref-for-upgrade-transaction-33">(8)</a> <a href="#ref-for-upgrade-transaction-34">(9)</a> <a href="#ref-for-upgrade-transaction-35">(10)</a> <a href="#ref-for-upgrade-transaction-36">(11)</a> <a href="#ref-for-upgrade-transaction-37">(12)</a> <a href="#ref-for-upgrade-transaction-38">(13)</a> <a href="#ref-for-upgrade-transaction-39">(14)</a>
-    <li><a href="#ref-for-upgrade-transaction-40">4.6. The IDBIndex interface</a> <a href="#ref-for-upgrade-transaction-41">(2)</a> <a href="#ref-for-upgrade-transaction-42">(3)</a>
-    <li><a href="#ref-for-upgrade-transaction-43">4.9. The IDBTransaction interface</a> <a href="#ref-for-upgrade-transaction-44">(2)</a> <a href="#ref-for-upgrade-transaction-45">(3)</a> <a href="#ref-for-upgrade-transaction-46">(4)</a>
-    <li><a href="#ref-for-upgrade-transaction-47">5.1. Opening a database</a>
-    <li><a href="#ref-for-upgrade-transaction-48">5.4. Committing a transaction</a>
-    <li><a href="#ref-for-upgrade-transaction-49">5.5. Aborting a transaction</a> <a href="#ref-for-upgrade-transaction-50">(2)</a> <a href="#ref-for-upgrade-transaction-51">(3)</a>
-    <li><a href="#ref-for-upgrade-transaction-52">5.7. Running an upgrade transaction</a> <a href="#ref-for-upgrade-transaction-53">(2)</a>
-    <li><a href="#ref-for-upgrade-transaction-54">5.8. Aborting an upgrade transaction</a>
+    <li><a href="#ref-for-upgrade-transaction-7">2.7.2. Upgrade Transactions</a> <a href="#ref-for-upgrade-transaction-8">(2)</a> <a href="#ref-for-upgrade-transaction-9">(3)</a> <a href="#ref-for-upgrade-transaction-10">(4)</a> <a href="#ref-for-upgrade-transaction-11">(5)</a> <a href="#ref-for-upgrade-transaction-12">(6)</a> <a href="#ref-for-upgrade-transaction-13">(7)</a> <a href="#ref-for-upgrade-transaction-14">(8)</a>
+    <li><a href="#ref-for-upgrade-transaction-15">2.8. Requests</a>
+    <li><a href="#ref-for-upgrade-transaction-16">4.1. The IDBRequest interface</a>
+    <li><a href="#ref-for-upgrade-transaction-17">4.3. The IDBFactory interface</a> <a href="#ref-for-upgrade-transaction-18">(2)</a>
+    <li><a href="#ref-for-upgrade-transaction-19">4.4. The IDBDatabase interface</a> <a href="#ref-for-upgrade-transaction-20">(2)</a> <a href="#ref-for-upgrade-transaction-21">(3)</a> <a href="#ref-for-upgrade-transaction-22">(4)</a> <a href="#ref-for-upgrade-transaction-23">(5)</a> <a href="#ref-for-upgrade-transaction-24">(6)</a> <a href="#ref-for-upgrade-transaction-25">(7)</a> <a href="#ref-for-upgrade-transaction-26">(8)</a> <a href="#ref-for-upgrade-transaction-27">(9)</a>
+    <li><a href="#ref-for-upgrade-transaction-28">4.5. The IDBObjectStore interface</a> <a href="#ref-for-upgrade-transaction-29">(2)</a> <a href="#ref-for-upgrade-transaction-30">(3)</a> <a href="#ref-for-upgrade-transaction-31">(4)</a> <a href="#ref-for-upgrade-transaction-32">(5)</a> <a href="#ref-for-upgrade-transaction-33">(6)</a> <a href="#ref-for-upgrade-transaction-34">(7)</a> <a href="#ref-for-upgrade-transaction-35">(8)</a> <a href="#ref-for-upgrade-transaction-36">(9)</a> <a href="#ref-for-upgrade-transaction-37">(10)</a> <a href="#ref-for-upgrade-transaction-38">(11)</a> <a href="#ref-for-upgrade-transaction-39">(12)</a> <a href="#ref-for-upgrade-transaction-40">(13)</a> <a href="#ref-for-upgrade-transaction-41">(14)</a>
+    <li><a href="#ref-for-upgrade-transaction-42">4.6. The IDBIndex interface</a> <a href="#ref-for-upgrade-transaction-43">(2)</a> <a href="#ref-for-upgrade-transaction-44">(3)</a>
+    <li><a href="#ref-for-upgrade-transaction-45">4.9. The IDBTransaction interface</a> <a href="#ref-for-upgrade-transaction-46">(2)</a> <a href="#ref-for-upgrade-transaction-47">(3)</a> <a href="#ref-for-upgrade-transaction-48">(4)</a>
+    <li><a href="#ref-for-upgrade-transaction-49">5.1. Opening a database</a>
+    <li><a href="#ref-for-upgrade-transaction-50">5.4. Committing a transaction</a>
+    <li><a href="#ref-for-upgrade-transaction-51">5.5. Aborting a transaction</a> <a href="#ref-for-upgrade-transaction-52">(2)</a> <a href="#ref-for-upgrade-transaction-53">(3)</a>
+    <li><a href="#ref-for-upgrade-transaction-54">5.7. Running an upgrade transaction</a> <a href="#ref-for-upgrade-transaction-55">(2)</a>
+    <li><a href="#ref-for-upgrade-transaction-56">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request">
@@ -8141,12 +8145,11 @@ specification.</p>
   <aside class="dfn-panel" data-for="request-open-request">
    <b><a href="#request-open-request">#request-open-request</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-open-request-1">2.7.2. Upgrade Transactions</a>
-    <li><a href="#ref-for-request-open-request-2">2.8. Requests</a>
-    <li><a href="#ref-for-request-open-request-3">2.8.1. Open Requests</a> <a href="#ref-for-request-open-request-4">(2)</a> <a href="#ref-for-request-open-request-5">(3)</a> <a href="#ref-for-request-open-request-6">(4)</a> <a href="#ref-for-request-open-request-7">(5)</a> <a href="#ref-for-request-open-request-8">(6)</a> <a href="#ref-for-request-open-request-9">(7)</a>
-    <li><a href="#ref-for-request-open-request-10">4.1. The IDBRequest interface</a> <a href="#ref-for-request-open-request-11">(2)</a> <a href="#ref-for-request-open-request-12">(3)</a>
-    <li><a href="#ref-for-request-open-request-13">4.3. The IDBFactory interface</a> <a href="#ref-for-request-open-request-14">(2)</a>
-    <li><a href="#ref-for-request-open-request-15">10. Revision History</a>
+    <li><a href="#ref-for-request-open-request-1">2.8. Requests</a>
+    <li><a href="#ref-for-request-open-request-2">2.8.1. Open Requests</a> <a href="#ref-for-request-open-request-3">(2)</a> <a href="#ref-for-request-open-request-4">(3)</a> <a href="#ref-for-request-open-request-5">(4)</a> <a href="#ref-for-request-open-request-6">(5)</a> <a href="#ref-for-request-open-request-7">(6)</a> <a href="#ref-for-request-open-request-8">(7)</a>
+    <li><a href="#ref-for-request-open-request-9">4.1. The IDBRequest interface</a> <a href="#ref-for-request-open-request-10">(2)</a> <a href="#ref-for-request-open-request-11">(3)</a>
+    <li><a href="#ref-for-request-open-request-12">4.3. The IDBFactory interface</a> <a href="#ref-for-request-open-request-13">(2)</a>
+    <li><a href="#ref-for-request-open-request-14">10. Revision History</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-blocked">
@@ -8164,11 +8167,11 @@ specification.</p>
     <li><a href="#ref-for-request-upgradeneeded-1">1. Introduction</a>
     <li><a href="#ref-for-request-upgradeneeded-2">2.2. Object Store</a>
     <li><a href="#ref-for-request-upgradeneeded-3">2.7. Transactions</a>
-    <li><a href="#ref-for-request-upgradeneeded-4">2.7.2. Upgrade Transactions</a> <a href="#ref-for-request-upgradeneeded-5">(2)</a> <a href="#ref-for-request-upgradeneeded-6">(3)</a>
-    <li><a href="#ref-for-request-upgradeneeded-7">2.8. Requests</a>
-    <li><a href="#ref-for-request-upgradeneeded-8">2.8.1. Open Requests</a>
-    <li><a href="#ref-for-request-upgradeneeded-9">4.1. The IDBRequest interface</a> <a href="#ref-for-request-upgradeneeded-10">(2)</a>
-    <li><a href="#ref-for-request-upgradeneeded-11">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-request-upgradeneeded-4">2.7.2. Upgrade Transactions</a> <a href="#ref-for-request-upgradeneeded-5">(2)</a>
+    <li><a href="#ref-for-request-upgradeneeded-6">2.8. Requests</a>
+    <li><a href="#ref-for-request-upgradeneeded-7">2.8.1. Open Requests</a>
+    <li><a href="#ref-for-request-upgradeneeded-8">4.1. The IDBRequest interface</a> <a href="#ref-for-request-upgradeneeded-9">(2)</a>
+    <li><a href="#ref-for-request-upgradeneeded-10">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-connection-queue">
@@ -8606,7 +8609,8 @@ specification.</p>
   <aside class="dfn-panel" data-for="dom-idbdatabase-transaction">
    <b><a href="#dom-idbdatabase-transaction">#dom-idbdatabase-transaction</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-idbdatabase-transaction-1">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-transaction-2">(2)</a>
+    <li><a href="#ref-for-dom-idbdatabase-transaction-1">2.7.2. Upgrade Transactions</a>
+    <li><a href="#ref-for-dom-idbdatabase-transaction-2">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-transaction-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-idbdatabase-close">
@@ -9171,7 +9175,8 @@ specification.</p>
   <aside class="dfn-panel" data-for="steps-for-opening-a-database">
    <b><a href="#steps-for-opening-a-database">#steps-for-opening-a-database</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-steps-for-opening-a-database-1">4.3. The IDBFactory interface</a>
+    <li><a href="#ref-for-steps-for-opening-a-database-1">2.7.2. Upgrade Transactions</a>
+    <li><a href="#ref-for-steps-for-opening-a-database-2">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="steps-for-closing-a-database-connection">


### PR DESCRIPTION
Per request by @cynthia over on https://github.com/w3c/IndexedDB/issues/154 - an attempt to clarify the role of upgrade transactions.

The previous "upgrade transactions" section was full of redundant non-normative text but not called out as such. Rework, remove some of the redundancy, and frame it with succinct snippets.

Hopefully this improved things: @cynthia - can you review?