### PR TITLE
Don't bleed IDL types into constructs/algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -361,7 +361,7 @@ from the database. Ideally the user will never see this.
 <h2 id=constructs>Constructs</h2>
 <!-- ============================================================ -->
 
-A <dfn>sorted list</dfn> is a {{DOMStringList}} containing strings
+A <dfn>sorted list</dfn> is a list containing strings
 sorted in ascending order by code unit.
 
 
@@ -755,17 +755,17 @@ of running the steps to [=compare two keys=] with |a| and |b| is 0.
 <h3 id=key-path-construct>Key Path</h3>
 <!-- ============================================================ -->
 
-A <dfn>key path</dfn> is a {{DOMString}} or
-[=sequence&lt;DOMString&gt;=] that defines how to extract a [=/key=]
+A <dfn>key path</dfn> is a string or list of strings
+that defines how to extract a [=/key=]
 from a [=/value=]. A <dfn>valid key path</dfn> is one of:
 
-* An empty {{DOMString}}.
-* An <dfn>identifier</dfn>, which is a {{DOMString}} matching the
+* An empty string.
+* An <dfn>identifier</dfn>, which is a string matching the
     [=IdentifierName=] production from the ECMAScript Language
     Specification [[!ECMA-262]].
-* A {{DOMString}} consisting of two or more [=identifiers=] separated
+* A string consisting of two or more [=identifiers=] separated
     by periods (ASCII character code 46, U+002E FULL STOP).
-* A non-empty [=sequence&lt;DOMString&gt;=] containing only strings
+* A non-empty list containing only strings
     conforming to the above requirements.
 
 <aside class=note>
@@ -2460,7 +2460,7 @@ must return this [=/connection=]'s
 </div>
 
 The <dfn attribute for=IDBDatabase>objectStoreNames</dfn> attribute's
-getter must return a [=sorted list=] of the [=object-store/names=] of
+getter must return a {{DOMStringList}} associated with a [=sorted list=] of the [=object-store/names=] of
 the [=/object stores=] in this [=/connection=]'s [=object store set=].
 
 <details class=note>
@@ -2820,12 +2820,10 @@ The {{IDBObjectStore/name}} attribute's setter must run these steps:
 
 The <dfn attribute for=IDBObjectStore>keyPath</dfn> attribute's getter
 must return this [=/object store handle=]'s
-[=object-store-handle/object store=]'s [=object-store/key
-path=], or null if none.
-
-The conversion is done following the normal [[!WEBIDL]] binding logic
-for {{DOMString}} and [=sequence&lt;DOMString&gt;=] values, as
-appropriate.
+[=object-store-handle/object store=]'s [=object-store/key path=], or
+null if none. The [=/key path=] is converted as a {{DOMString}} (if a
+string) or a [=sequence&lt;DOMString&gt;=] (if a list of strings), per
+[[!WEBIDL]].
 
 The returned value is not the same instance that was used when the
 [=/object store=] was created. However, if this attribute returns
@@ -2835,7 +2833,7 @@ object has no effect on the [=/object store=].
 
 
 The <dfn attribute for=IDBObjectStore>indexNames</dfn> attribute's
-getter must return a [=sorted list=] of the [=index/names=]
+getter must return a {{DOMStringList}} associated with a [=sorted list=] of the [=index/names=]
 of [=/indexes=] in this [=/object store handle=]'s
 [=index set=].
 
@@ -3892,11 +3890,9 @@ store handle=].
 
 The <dfn attribute for=IDBIndex>keyPath</dfn> attribute's getter must
 return this [=index handle=]'s [=index-handle/index=]'s
-[=object-store/key path=].
-
-The conversion is done following the normal [[!WEBIDL]] binding logic
-for {{DOMString}} and [=sequence&lt;DOMString&gt;=] values, as
-appropriate.
+[=object-store/key path=]. The [=/key path=] is converted as a
+{{DOMString}} (if a string) or a [=sequence&lt;DOMString&gt;=] (if a
+list of strings), per [[!WEBIDL]].
 
 The returned value is not the same instance that was used when the
 [=/index=] was created. However, if this attribute returns an
@@ -5051,12 +5047,12 @@ The <dfn attribute for=IDBTransaction>objectStoreNames</dfn>
 attribute's getter must run the following steps:
 
 1. If this [=/transaction=] is an [=upgrade transaction=],
-    return a [=sorted list=] of the [=object-store/names=]
+    return a {{DOMStringList}} associated with a [=sorted list=] of the [=object-store/names=]
     of the [=/object stores=] in this
     [=/transaction=]'s [=/connection=]'s [=object store
     set=].
 
-2. Otherwise, return a [=sorted list=] of the
+2. Otherwise, return a {{DOMStringList}} associated with a [=sorted list=] of the
     [=object-store/names=] of the [=/object stores=] in
     this [=/transaction=]'s [=transaction/scope=].
 
@@ -6339,14 +6335,14 @@ The steps to <dfn>evaluate a key path on a value</dfn> with |value|
 and |keyPath| are as follows. The result of these steps is an
 ECMAScript value or failure, or the steps may throw an exception.
 
-1. If |keyPath| is a [=sequence&lt;DOMString&gt;=], run these substeps:
+1. If |keyPath| is a list of strings, run these substeps:
 
     1. Let |result| be a new [=Array=] object created as if by the
         expression <code>[]</code>.
 
     2. Let |i| be 0.
 
-    3. For each |item| in the |keyPath| sequence, run these substeps:
+    3. For each |item| in |keyPath|, run these substeps:
 
         1. Let |key| be the result of recursively running the steps to
             [=evaluate a key path on a value=] using

--- a/index.html
+++ b/index.html
@@ -1850,7 +1850,7 @@ request<span class="p">.</span>onupgradeneeded <span class="o">=</span> <span cl
 from the database. Ideally the user will never see this.</p>
    </aside>
    <h2 class="heading settled" data-level="2" id="constructs"><span class="secno">2. </span><span class="content">Constructs</span><a class="self-link" href="#constructs"></a></h2>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sorted-list">sorted list</dfn> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> containing strings
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sorted-list">sorted list</dfn> is a list containing strings
 sorted in ascending order by code unit.</p>
    <h3 class="heading settled" data-level="2.1" id="database-construct"><span class="secno">2.1. </span><span class="content">Database</span><a class="self-link" href="#database-construct"></a></h3>
    <p>Each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> has an associated set of <a data-link-type="dfn" href="#database" id="ref-for-database-1">databases</a>. A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="database">database</dfn> has zero or more <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-1">object stores</a> which
@@ -2155,18 +2155,19 @@ of running the steps to <a data-link-type="dfn" href="#compare-two-keys" id="ref
   (in the range [0, 255]) rather than signed <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-byte">byte</a></code> values (in the range
   [-128, 127]). </aside>
    <h3 class="heading settled" data-level="2.5" id="key-path-construct"><span class="secno">2.5. </span><span class="content">Key Path</span><a class="self-link" href="#key-path-construct"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-path">key path</dfn> is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> that defines how to extract a <a data-link-type="dfn" href="#key" id="ref-for-key-21">key</a> from a <a data-link-type="dfn" href="#value" id="ref-for-value-4">value</a>. A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="valid-key-path">valid key path</dfn> is one of:</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-path">key path</dfn> is a string or list of strings
+that defines how to extract a <a data-link-type="dfn" href="#key" id="ref-for-key-21">key</a> from a <a data-link-type="dfn" href="#value" id="ref-for-value-4">value</a>. A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="valid-key-path">valid key path</dfn> is one of:</p>
    <ul>
     <li data-md="">
-     <p>An empty <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>.</p>
+     <p>An empty string.</p>
     <li data-md="">
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="identifier">identifier</dfn>, which is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> matching the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#prod-IdentifierName">IdentifierName</a> production from the ECMAScript Language
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="identifier">identifier</dfn>, which is a string matching the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#prod-IdentifierName">IdentifierName</a> production from the ECMAScript Language
 Specification <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a>.</p>
     <li data-md="">
-     <p>A <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> consisting of two or more <a data-link-type="dfn" href="#identifier" id="ref-for-identifier-1">identifiers</a> separated
+     <p>A string consisting of two or more <a data-link-type="dfn" href="#identifier" id="ref-for-identifier-1">identifiers</a> separated
 by periods (ASCII character code 46, U+002E FULL STOP).</p>
     <li data-md="">
-     <p>A non-empty <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> containing only strings
+     <p>A non-empty list containing only strings
 conforming to the above requirements.</p>
    </ul>
    <aside class="note"> Spaces are not allowed within a key path. </aside>
@@ -3311,7 +3312,7 @@ must return this <a data-link-type="dfn" href="#connection" id="ref-for-connecti
     </dl>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-objectstorenames">objectStoreNames</dfn> attribute’s
-getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-1">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-2">names</a> of
+getter must return a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> associated with a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-1">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-2">names</a> of
 the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-56">object stores</a> in this <a data-link-type="dfn" href="#connection" id="ref-for-connection-44">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-1">object store set</a>.</p>
    <details class="note">
     <summary> Is this the same as the <a data-link-type="dfn" href="#database" id="ref-for-database-44">database</a>'s <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-57">object store</a> <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-3">names</a>? </summary>
@@ -3550,17 +3551,15 @@ terminate these steps.</p>
   It is supported in Chrome 58, Firefox 51, and Safari 10.1.
   🚧 </aside>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-keypath">keyPath</dfn> attribute’s getter
-must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-15">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-4">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-13">key
-path</a>, or null if none.</p>
-   <p>The conversion is done following the normal <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> binding logic
-for <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> values, as
-appropriate.</p>
+must return this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-15">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-object-store" id="ref-for-object-store-handle-object-store-4">object store</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-13">key path</a>, or
+null if none. The <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-2">key path</a> is converted as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> (if a
+string) or a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> (if a list of strings), per <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a>.</p>
    <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-77">object store</a> was created. However, if this attribute returns
 an object (specifically an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>), it returns the same object
 instance every time it is inspected. Changing the properties of the
 object has no effect on the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-78">object store</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBObjectStore" data-dfn-type="attribute" data-export="" id="dom-idbobjectstore-indexnames">indexNames</dfn> attribute’s
-getter must return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-2">sorted list</a> of the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-2">names</a> of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-20">indexes</a> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-16">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-2">index set</a>.</p>
+getter must return a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> associated with a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-2">sorted list</a> of the <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-2">names</a> of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-20">indexes</a> in this <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-16">object store handle</a>'s <a data-link-type="dfn" href="#object-store-handle-index-set" id="ref-for-object-store-handle-index-set-2">index set</a>.</p>
    <details class="note">
     <summary> Is this the same as <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-79">object store</a>'s list
     of <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-21">index</a> <a data-link-type="dfn" href="#index-name" id="ref-for-index-name-3">names</a>? </summary>
@@ -4232,7 +4231,7 @@ within the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgra
      <dt><var>index</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbindex-objectstore" id="ref-for-dom-idbindex-objectstore-2">objectStore</a></code>
      <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-15">IDBObjectStore</a></code> the index belongs to. 
      <dt><var>index</var> . keyPath
-     <dd> Returns the <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-2">key path</a> of the index. 
+     <dd> Returns the <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-3">key path</a> of the index. 
      <dt><var>index</var> . multiEntry
      <dd> Returns true if the index’s <a data-link-type="dfn" href="#index-multientry-flag" id="ref-for-index-multientry-flag-4">multiEntry flag</a> is set. 
      <dt><var>index</var> . unique
@@ -4283,10 +4282,8 @@ store</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-th
 must return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-13">index handle</a>'s <a data-link-type="dfn" href="#index-handle-object-store-handle" id="ref-for-index-handle-object-store-handle-1">object
 store handle</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBIndex" data-dfn-type="attribute" data-export="" id="dom-idbindex-keypath">keyPath</dfn> attribute’s getter must
-return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-14">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-3">index</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-18">key path</a>.</p>
-   <p>The conversion is done following the normal <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> binding logic
-for <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> values, as
-appropriate.</p>
+return this <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-14">index handle</a>'s <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-index-3">index</a>'s <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-18">key path</a>. The <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-4">key path</a> is converted as a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code> (if a string) or a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a> (if a
+list of strings), per <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a>.</p>
    <p>The returned value is not the same instance that was used when the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-36">index</a> was created. However, if this attribute returns an
 object (specifically an <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a>), it returns the same object
 instance every time it is inspected. Changing the properties of the
@@ -5069,10 +5066,10 @@ the contents of the database.</p>
     <ol>
      <li data-md="">
       <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-57">transaction</a> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-47">upgrade transaction</a>,
-return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-3">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
+return a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> associated with a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-3">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
 set</a>.</p>
      <li data-md="">
-      <p>Otherwise, return a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-4">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-19">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-94">object stores</a> in
+      <p>Otherwise, return a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> associated with a <a data-link-type="dfn" href="#sorted-list" id="ref-for-sorted-list-4">sorted list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-19">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-94">object stores</a> in
 this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-59">transaction</a>'s <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-13">scope</a>.</p>
     </ol>
    </div>
@@ -5995,7 +5992,7 @@ store position</a> to <var>object store position</var>.</p>
    <h2 class="heading settled" data-level="7" id="binding"><span class="secno">7. </span><span class="content">ECMAScript binding</span><a class="self-link" href="#binding"></a></h2>
    <p>This section defines how <a data-link-type="dfn" href="#key" id="ref-for-key-89">key</a> values defined in this specification
 are converted to and from ECMAScript values, and how they may be
-extracted from and injected into ECMAScript values using <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-3">key
+extracted from and injected into ECMAScript values using <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-5">key
 paths</a>. This section references types and algorithms and uses some
 algorithm conventions from the ECMAScript Language Specification. <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a> Conversions not detailed here are defined in <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a>.</p>
    <h3 class="heading settled" data-level="7.1" id="extract-key-from-value"><span class="secno">7.1. </span><span class="content">Extract a key from a value</span><a class="self-link" href="#extract-key-from-value"></a></h3>
@@ -6026,7 +6023,7 @@ key</a> with <var>r</var> otherwise. Rethrow any exceptions.</p>
 ECMAScript value or failure, or the steps may throw an exception.</p>
     <ol>
      <li data-md="">
-      <p>If <var>keyPath</var> is a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence">sequence&lt;DOMString></a>, run these substeps:</p>
+      <p>If <var>keyPath</var> is a list of strings, run these substeps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>result</var> be a new <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-array-objects">Array</a> object created as if by the
@@ -6034,7 +6031,7 @@ expression <code>[]</code>.</p>
        <li data-md="">
         <p>Let <var>i</var> be 0.</p>
        <li data-md="">
-        <p>For each <var>item</var> in the <var>keyPath</var> sequence, run these substeps:</p>
+        <p>For each <var>item</var> in <var>keyPath</var>, run these substeps:</p>
         <ol>
          <li data-md="">
           <p>Let <var>key</var> be the result of recursively running the steps to <a data-link-type="dfn" href="#evaluate-a-key-path-on-a-value" id="ref-for-evaluate-a-key-path-on-a-value-2">evaluate a key path on a value</a> using <var>item</var> as <var>keyPath</var> and <var>value</var> as <var>value</var>.</p>
@@ -6054,7 +6051,7 @@ failure.</p>
         </ol>
        <li data-md="">
         <p>Return <var>result</var>.</p>
-        <aside class="note"> This will only ever "recurse" one level since <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-4">key
+        <aside class="note"> This will only ever "recurse" one level since <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-6">key
   path</a> sequences can’t ever be nested. </aside>
       </ol>
      <li data-md="">
@@ -6104,7 +6101,7 @@ remaining steps.</p>
    <aside class="note"> Assertions can be made in the above steps because this algorithm is
   only applied to values that are the output of <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclone">StructuredClone</a> and only access "own" properties. </aside>
    <h3 class="heading settled" data-level="7.2" id="inject-key-into-value"><span class="secno">7.2. </span><span class="content">Inject a key into a value</span><a class="self-link" href="#inject-key-into-value"></a></h3>
-   <aside class="note"> The <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-5">key paths</a> used in this section are always strings and never
+   <aside class="note"> The <a data-link-type="dfn" href="#key-path" id="ref-for-key-path-7">key paths</a> used in this section are always strings and never
   sequences, since it is not possible to create a <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-109">object store</a> which has a <a data-link-type="dfn" href="#key-generator" id="ref-for-key-generator-22">key generator</a> and also has a <a data-link-type="dfn" href="#object-store-key-path" id="ref-for-object-store-key-path-21">key path</a> that is a
   sequence. </aside>
    <div class="algorithm">
@@ -7915,10 +7912,11 @@ specification.</p>
    <b><a href="#key-path">#key-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-path-1">2.5. Key Path</a>
-    <li><a href="#ref-for-key-path-2">4.6. The IDBIndex interface</a>
-    <li><a href="#ref-for-key-path-3">7. ECMAScript binding</a>
-    <li><a href="#ref-for-key-path-4">7.1. Extract a key from a value</a>
-    <li><a href="#ref-for-key-path-5">7.2. Inject a key into a value</a>
+    <li><a href="#ref-for-key-path-2">4.5. The IDBObjectStore interface</a>
+    <li><a href="#ref-for-key-path-3">4.6. The IDBIndex interface</a> <a href="#ref-for-key-path-4">(2)</a>
+    <li><a href="#ref-for-key-path-5">7. ECMAScript binding</a>
+    <li><a href="#ref-for-key-path-6">7.1. Extract a key from a value</a>
+    <li><a href="#ref-for-key-path-7">7.2. Inject a key into a value</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valid-key-path">


### PR DESCRIPTION
Avoid defining constructs like 'key path' in terms of IDL types like 'DOMString' and 'sequence<>'. Instead use abstract spec types like 'string' and 'list'.

* "sorted list" is now just a list - getters mention the conversion to DOMStringList
* key path is a "string or list of strings" - getters mention the conversion to IDL types

https://github.com/w3c/IndexedDB/issues/167