### PR TITLE
Define a 'name' construct, reference Charmod-Norm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -369,6 +369,23 @@ from the database. Ideally the user will never see this.
 A <dfn>sorted list</dfn> is a list containing strings
 sorted in ascending order by code unit.
 
+A <dfn>name</dfn> is a string equivalent to a {{DOMString}};
+that is, an arbitrary sequence of 16-bit code units of any length,
+including the empty string. [=/Names=] are always compared as
+opaque sequences of 16-bit code units.
+
+<aside class=note>
+  As a result, [=/name=] comparison is sensitive to variations in case
+  as well as other minor variations such as normalization form, the
+  inclusion or omission of controls, and other variations in Unicode
+  text. [[Charmod-Norm]]
+
+  If an implementation uses a storage mechanism which does not support
+  arbitrary strings, the implementation must use an escaping mechanism
+  or something similar to map the provided name to a string that it
+  can store.
+</aside>
+
 
 <!-- ============================================================ -->
 <h3 id=database-construct>Database</h3>
@@ -381,18 +398,8 @@ hold the data stored in the database.
 <div dfn-for=database>
 
 A [=database=] has a <dfn>name</dfn> which identifies it within a
-specific [=/origin=]. The name can be any string value, including
-the empty string, and stays constant for the lifetime of the database.
-Database names are always compared in a case-sensitive manner, as
-opaque sequences of 16-bit code units. Implementations must support
-all names.
-
-<aside class=note>
-  If an implementation uses a storage mechanism which can't handle
-  arbitrary database names, the implementation must use an escaping
-  mechanism or something similar to map the provided name to a name
-  that it can handle.
-</aside>
+specific [=/origin=]. The name is a [=/name=],
+and stays constant for the lifetime of the database.
 
 A [=database=] has a <dfn>version</dfn>. When a database is first
 created, its [=database/version=] is 0 (zero).
@@ -500,11 +507,9 @@ data stored in the object store. Each <dfn>record</dfn> consists of a
 [=ascending=] order. There can never be multiple records in a given object
 store with the same key.
 
-An [=/object store=] has a <dfn>name</dfn>. The name can be any string
-value, including the empty string. At any one time, the name is unique
-within the [=database=] to which it belongs. Object store names are
-always compared in a case-sensitive manner, as opaque sequences of
-16-bit code units.
+An [=/object store=] has a <dfn>name</dfn>, which is a [=/name=].
+At any one time, the name is unique
+within the [=database=] to which it belongs.
 
 An [=/object store=] optionally has a <dfn>key path</dfn>. If the
 object store has a key path it is said to use <dfn>in-line keys</dfn>.
@@ -855,11 +860,9 @@ contain multiple records with the same key. Such records are
 additionally sorted according to the [=/index=]'s [=object-store/record=]'s value
 (meaning the key of the record in the referenced [=/object store=]).
 
-An [=/index=] has a <dfn>name</dfn>. The name can be any
-string value, including the empty string. At any one time, the name is
+An [=/index=] has a <dfn>name</dfn>, which is a [=/name=].
+At any one time, the name is
 unique within index's [=referenced=] [=/object store=].
-Index names are always compared in a case-sensitive manner, as opaque
-sequences of 16-bit code units.
 
 An [=/index=] has a <dfn>unique flag</dfn>. When this flag is
 set, the index enforces that no two [=object-store/records=] in the index has

--- a/index.html
+++ b/index.html
@@ -1852,20 +1852,27 @@ from the database. Ideally the user will never see this.</p>
    <h2 class="heading settled" data-level="2" id="constructs"><span class="secno">2. </span><span class="content">Constructs</span><a class="self-link" href="#constructs"></a></h2>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="sorted-list">sorted list</dfn> is a list containing strings
 sorted in ascending order by code unit.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="name">name</dfn> is a string equivalent to a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>;
+that is, an arbitrary sequence of 16-bit code units of any length,
+including the empty string. <a data-link-type="dfn" href="#name" id="ref-for-name-1">Names</a> are always compared as
+opaque sequences of 16-bit code units.</p>
+   <aside class="note">
+     As a result, <a data-link-type="dfn" href="#name" id="ref-for-name-2">name</a> comparison is sensitive to variations in case
+  as well as other minor variations such as normalization form, the
+  inclusion or omission of controls, and other variations in Unicode
+  text. <a data-link-type="biblio" href="#biblio-charmod-norm">[Charmod-Norm]</a> 
+    <p>If an implementation uses a storage mechanism which does not support
+  arbitrary strings, the implementation must use an escaping mechanism
+  or something similar to map the provided name to a string that it
+  can store.</p>
+   </aside>
    <h3 class="heading settled" data-level="2.1" id="database-construct"><span class="secno">2.1. </span><span class="content">Database</span><a class="self-link" href="#database-construct"></a></h3>
    <p>Each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> has an associated set of <a data-link-type="dfn" href="#database" id="ref-for-database-1">databases</a>. A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="database">database</dfn> has zero or more <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-1">object stores</a> which
 hold the data stored in the database.</p>
    <div>
     <p>A <a data-link-type="dfn" href="#database" id="ref-for-database-2">database</a> has a <dfn class="dfn-paneled" data-dfn-for="database" data-dfn-type="dfn" data-noexport="" id="database-name">name</dfn> which identifies it within a
-specific <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a>. The name can be any string value, including
-the empty string, and stays constant for the lifetime of the database.
-Database names are always compared in a case-sensitive manner, as
-opaque sequences of 16-bit code units. Implementations must support
-all names.</p>
-    <aside class="note"> If an implementation uses a storage mechanism which can’t handle
-  arbitrary database names, the implementation must use an escaping
-  mechanism or something similar to map the provided name to a name
-  that it can handle. </aside>
+specific <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a>. The name is a <a data-link-type="dfn" href="#name" id="ref-for-name-3">name</a>,
+and stays constant for the lifetime of the database.</p>
     <p>A <a data-link-type="dfn" href="#database" id="ref-for-database-3">database</a> has a <dfn class="dfn-paneled" data-dfn-for="database" data-dfn-type="dfn" data-noexport="" id="database-version">version</dfn>. When a database is first
 created, its <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-1">version</a> is 0 (zero).</p>
     <aside class="note"> Each <a data-link-type="dfn" href="#database" id="ref-for-database-4">database</a> has one version at a time; a <a data-link-type="dfn" href="#database" id="ref-for-database-5">database</a> can’t
@@ -1927,11 +1934,9 @@ new database is created it doesn’t contain any <a data-link-type="dfn" href="#
     <p>An <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-6">object store</a> has a <dfn class="dfn-paneled" data-dfn-for="object-store" data-dfn-type="dfn" data-noexport="" id="object-store-list-of-records">list of records</dfn> which hold the
 data stored in the object store. Each <dfn class="dfn-paneled" data-dfn-for="object-store" data-dfn-type="dfn" data-noexport="" id="object-store-record">record</dfn> consists of a <a data-link-type="dfn" href="#key" id="ref-for-key-1">key</a> and a <a data-link-type="dfn" href="#value" id="ref-for-value-1">value</a>. The list is sorted according to key in <a data-link-type="dfn" href="#greater-than" id="ref-for-greater-than-1">ascending</a> order. There can never be multiple records in a given object
 store with the same key.</p>
-    <p>An <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-7">object store</a> has a <dfn class="dfn-paneled" data-dfn-for="object-store" data-dfn-type="dfn" data-noexport="" id="object-store-name">name</dfn>. The name can be any string
-value, including the empty string. At any one time, the name is unique
-within the <a data-link-type="dfn" href="#database" id="ref-for-database-16">database</a> to which it belongs. Object store names are
-always compared in a case-sensitive manner, as opaque sequences of
-16-bit code units.</p>
+    <p>An <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-7">object store</a> has a <dfn class="dfn-paneled" data-dfn-for="object-store" data-dfn-type="dfn" data-noexport="" id="object-store-name">name</dfn>, which is a <a data-link-type="dfn" href="#name" id="ref-for-name-4">name</a>.
+At any one time, the name is unique
+within the <a data-link-type="dfn" href="#database" id="ref-for-database-16">database</a> to which it belongs.</p>
     <p>An <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-8">object store</a> optionally has a <dfn class="dfn-paneled" data-dfn-for="object-store" data-dfn-type="dfn" data-noexport="" id="object-store-key-path">key path</dfn>. If the
 object store has a key path it is said to use <dfn class="dfn-paneled" data-dfn-for="object-store" data-dfn-type="dfn" data-noexport="" id="object-store-in-line-keys">in-line keys</dfn>.
 Otherwise it is said to use <dfn class="dfn-paneled" data-dfn-for="object-store" data-dfn-type="dfn" data-noexport="" id="object-store-out-of-line-keys">out-of-line keys</dfn>.</p>
@@ -2226,11 +2231,9 @@ above, the record in the index whose key is <var>Y</var> and value is <var>X</va
 contain multiple records with the same key. Such records are
 additionally sorted according to the <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-3">index</a>'s <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-10">record</a>'s value
 (meaning the key of the record in the referenced <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-18">object store</a>).</p>
-    <p>An <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-4">index</a> has a <dfn class="dfn-paneled" data-dfn-for="index" data-dfn-type="dfn" data-noexport="" id="index-name">name</dfn>. The name can be any
-string value, including the empty string. At any one time, the name is
-unique within index’s <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-5">referenced</a> <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-19">object store</a>.
-Index names are always compared in a case-sensitive manner, as opaque
-sequences of 16-bit code units.</p>
+    <p>An <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-4">index</a> has a <dfn class="dfn-paneled" data-dfn-for="index" data-dfn-type="dfn" data-noexport="" id="index-name">name</dfn>, which is a <a data-link-type="dfn" href="#name" id="ref-for-name-5">name</a>.
+At any one time, the name is
+unique within index’s <a data-link-type="dfn" href="#index-referenced" id="ref-for-index-referenced-5">referenced</a> <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-19">object store</a>.</p>
     <p>An <a data-link-type="dfn" href="#index-concept" id="ref-for-index-concept-5">index</a> has a <dfn class="dfn-paneled" data-dfn-for="index" data-dfn-type="dfn" data-noexport="" id="index-unique-flag">unique flag</dfn>. When this flag is
 set, the index enforces that no two <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-11">records</a> in the index has
 the same key. If a <a data-link-type="dfn" href="#object-store-record" id="ref-for-object-store-record-12">record</a> in the index’s referenced object
@@ -6979,6 +6982,7 @@ specification.</p>
    <li>
     name
     <ul>
+     <li><a href="#name">definition of</a><span>, in §2</span>
      <li><a href="#database-name">dfn for database</a><span>, in §2.1</span>
      <li><a href="#object-store-name">dfn for object-store</a><span>, in §2.2</span>
      <li><a href="#object-store-handle-name">dfn for object-store-handle</a><span>, in §2.2.1</span>
@@ -7335,6 +7339,8 @@ specification.</p>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
+   <dt id="biblio-charmod-norm">[Charmod-Norm]
+   <dd>Addison Phillips; et al. <a href="https://www.w3.org/TR/charmod-norm/">Character Model for the World Wide Web: String Matching and Searching</a>. URL: <a href="https://www.w3.org/TR/charmod-norm/">https://www.w3.org/TR/charmod-norm/</a>
    <dt id="biblio-cookies">[COOKIES]
    <dd>A. Barth. <a href="https://tools.ietf.org/html/rfc6265">HTTP State Management Mechanism</a>. April 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6265">https://tools.ietf.org/html/rfc6265</a>
    <dt id="biblio-webstorage">[WEBSTORAGE]
@@ -7552,6 +7558,15 @@ specification.</p>
     <li><a href="#ref-for-sorted-list-1">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-sorted-list-2">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-sorted-list-3">4.9. The IDBTransaction interface</a> <a href="#ref-for-sorted-list-4">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="name">
+   <b><a href="#name">#name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-name-1">2. Constructs</a> <a href="#ref-for-name-2">(2)</a>
+    <li><a href="#ref-for-name-3">2.1. Database</a>
+    <li><a href="#ref-for-name-4">2.2. Object Store</a>
+    <li><a href="#ref-for-name-5">2.6. Index</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="database">


### PR DESCRIPTION
Replace repeated "opaque sequences of 16-bit code units" blather with a type with associated details.
