### PR TITLE
Align IDBDatabase.transaction() exception precedence with tests/implementations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1179,7 +1179,7 @@ with [=transaction/cleanup event loop=] matching the current
 <aside class=note>
   This behavior is invoked by [[HTML]]. It ensures that
   [=/transactions=] created by a script call
-  to{{IDBDatabase/transaction()}} are deactivated once the task that
+  to {{IDBDatabase/transaction()}} are deactivated once the task that
   invoked the script has completed. The steps are run at most once for
   each [=/transaction=].
 </aside>
@@ -2628,11 +2628,10 @@ instance on which it was called.
 The <dfn method for=IDBDatabase>transaction(|storeNames|,
 |mode|)</dfn> method, when invoked, must run these steps:
 
-1. If this method is called on {{IDBDatabase}} object for which an
-    [=upgrade transaction=] is still running, [=throw=] an
-    "{{InvalidStateError}}" {{DOMException}}.
+1. If a running [=upgrade transaction=] is associated with the [=/connection=],
+    [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-2. If this method is called on an {{IDBDatabase}} instance where the
+2. If the [=/connection=]'s
     [=close pending flag=] is set, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
@@ -2646,7 +2645,7 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|,
 
 5. If |scope| is empty, [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 
-6. If |mode| parameter is not {{"readonly"}} or {{"readwrite"}},
+6. If |mode| is not {{"readonly"}} or {{"readwrite"}},
     [=throw=] a [=TypeError=].
 
 7. Let |transaction| be a newly [=transaction/created=] [=/transaction=] with

--- a/index.bs
+++ b/index.bs
@@ -2628,26 +2628,26 @@ instance on which it was called.
 The <dfn method for=IDBDatabase>transaction(|storeNames|,
 |mode|)</dfn> method, when invoked, must run these steps:
 
-1. If |mode| parameter is not {{"readonly"}} or {{"readwrite"}},
-    [=throw=] a [=TypeError=].
-
-2. If this method is called on {{IDBDatabase}} object for which an
+1. If this method is called on {{IDBDatabase}} object for which an
     [=upgrade transaction=] is still running, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
-3. If this method is called on an {{IDBDatabase}} instance where the
+2. If this method is called on an {{IDBDatabase}} instance where the
     [=close pending flag=] is set, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
-4. Let |scope| be the set of unique strings in |storeNames| if it is a
+3. Let |scope| be the set of unique strings in |storeNames| if it is a
     sequence, or a set containing one string equal to |storeNames|
     otherwise.
 
-5. If any string in |scope| is not the name of an [=/object
+4. If any string in |scope| is not the name of an [=/object
     store=] in the [=connected=] [=database=], [=throw=] a
     "{{NotFoundError}}" {{DOMException}}.
 
-6. If |scope| is empty, [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
+5. If |scope| is empty, [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
+
+6. If |mode| parameter is not {{"readonly"}} or {{"readwrite"}},
+    [=throw=] a [=TypeError=].
 
 7. Let |transaction| be a newly [=transaction/created=] [=/transaction=] with
     |connection|, |mode| and the set of [=/object stores=] named in

--- a/index.html
+++ b/index.html
@@ -2450,7 +2450,7 @@ run the following steps for each <a data-link-type="dfn" href="#transaction-conc
     </ol>
    </div>
    <aside class="note"> This behavior is invoked by <a data-link-type="biblio" href="#biblio-html">[HTML]</a>. It ensures that <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-26">transactions</a> created by a script call
-  to<code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-1">transaction()</a></code> are deactivated once the task that
+  to <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-transaction" id="ref-for-dom-idbdatabase-transaction-1">transaction()</a></code> are deactivated once the task that
   invoked the script has completed. The steps are run at most once for
   each <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-27">transaction</a>. </aside>
    <h4 class="heading settled" data-level="2.7.2" id="upgrade-transaction-construct"><span class="secno">2.7.2. </span><span class="content">Upgrade Transactions</span><a class="self-link" href="#upgrade-transaction-construct"></a></h4>
@@ -3412,22 +3412,21 @@ from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-u
     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="method" data-export="" data-lt="transaction(storeNames, mode)|transaction(storeNames)" id="dom-idbdatabase-transaction">transaction(<var>storeNames</var>, <var>mode</var>)</dfn> method, when invoked, must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>If this method is called on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-9">IDBDatabase</a></code> object for which an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-27">upgrade transaction</a> is still running, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
-"<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
+      <p>If a running <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-27">upgrade transaction</a> is associated with the <a data-link-type="dfn" href="#connection" id="ref-for-connection-53">connection</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If this method is called on an <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-10">IDBDatabase</a></code> instance where the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-4">close pending flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
+      <p>If the <a data-link-type="dfn" href="#connection" id="ref-for-connection-54">connection</a>'s <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-4">close pending flag</a> is set, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>scope</var> be the set of unique strings in <var>storeNames</var> if it is a
 sequence, or a set containing one string equal to <var>storeNames</var> otherwise.</p>
      <li data-md="">
       <p>If any string in <var>scope</var> is not the name of an <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-72">object
-store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-53">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-50">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
+store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connected</a> <a data-link-type="dfn" href="#database" id="ref-for-database-50">database</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>scope</var> is empty, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>If <var>mode</var> parameter is not <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-4">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-5">"readwrite"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>.</p>
+      <p>If <var>mode</var> is not <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-4">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-5">"readwrite"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>.</p>
      <li data-md="">
       <p>Let <var>transaction</var> be a newly <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-3">created</a> <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-39">transaction</a> with <var>connection</var>, <var>mode</var> and the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-73">object stores</a> named in <var>scope</var>.</p>
      <li data-md="">
@@ -3443,7 +3442,7 @@ current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/web
 must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>Run the steps to <a data-link-type="dfn" href="#close-a-database-connection" id="ref-for-close-a-database-connection-3">close a database connection</a> with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-54">connection</a>.</p>
+      <p>Run the steps to <a data-link-type="dfn" href="#close-a-database-connection" id="ref-for-close-a-database-connection-3">close a database connection</a> with this <a data-link-type="dfn" href="#connection" id="ref-for-connection-56">connection</a>.</p>
     </ol>
    </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="attribute" data-export="" id="dom-idbdatabase-onabort">onabort</dfn> attribute is the
@@ -5033,7 +5032,7 @@ the contents of the database.</p>
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="idbtransaction">IDBTransaction</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMStringList" href="#dom-idbtransaction-objectstorenames" id="ref-for-dom-idbtransaction-objectstorenames-1">objectStoreNames</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-idbtransactionmode" id="ref-for-enumdef-idbtransactionmode-2">IDBTransactionMode</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBTransactionMode" href="#dom-idbtransaction-mode" id="ref-for-dom-idbtransaction-mode-1">mode</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#idbdatabase" id="ref-for-idbdatabase-11">IDBDatabase</a>        <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBDatabase" href="#dom-idbtransaction-db" id="ref-for-dom-idbtransaction-db-1">db</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#idbdatabase" id="ref-for-idbdatabase-9">IDBDatabase</a>        <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="IDBDatabase" href="#dom-idbtransaction-db" id="ref-for-dom-idbtransaction-db-1">db</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>       <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMException" href="#dom-idbtransaction-error" id="ref-for-dom-idbtransaction-error-1">error</a>;
 
   <a class="n" data-link-type="idl-name" href="#idbobjectstore" id="ref-for-idbobjectstore-18">IDBObjectStore</a> <a class="nv idl-code" data-link-type="method" href="#dom-idbtransaction-objectstore" id="ref-for-dom-idbtransaction-objectstore-1">objectStore</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="IDBTransaction/objectStore(name)" data-dfn-type="argument" data-export="" id="dom-idbtransaction-objectstore-name-name">name<a class="self-link" href="#dom-idbtransaction-objectstore-name-name"></a></dfn>);
@@ -5072,7 +5071,7 @@ the contents of the database.</p>
     <ol>
      <li data-md="">
       <p>If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-57">transaction</a> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-47">upgrade transaction</a>,
-return a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> associated with a <a data-link-type="dfn" href="#sorted-name-list" id="ref-for-sorted-name-list-3">sorted name list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-55">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
+return a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> associated with a <a data-link-type="dfn" href="#sorted-name-list" id="ref-for-sorted-name-list-3">sorted name list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-18">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-93">object stores</a> in this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-58">transaction</a>'s <a data-link-type="dfn" href="#connection" id="ref-for-connection-57">connection</a>'s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-3">object store
 set</a>.</p>
      <li data-md="">
       <p>Otherwise, return a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#domstringlist">DOMStringList</a></code> associated with a <a data-link-type="dfn" href="#sorted-name-list" id="ref-for-sorted-name-list-4">sorted name list</a> of the <a data-link-type="dfn" href="#object-store-name" id="ref-for-object-store-name-19">names</a> of the <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-94">object stores</a> in
@@ -5089,7 +5088,7 @@ this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-mode">mode</dfn> attribute’s getter
 must return the <a data-link-type="dfn" href="#transaction-mode" id="ref-for-transaction-mode-10">mode</a> of the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-60">transaction</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-db">db</dfn> attribute’s getter must
-return the <a data-link-type="dfn" href="#database" id="ref-for-database-53">database</a> <a data-link-type="dfn" href="#connection" id="ref-for-connection-56">connection</a> of which this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-61">transaction</a> is a part.</p>
+return the <a data-link-type="dfn" href="#database" id="ref-for-database-53">database</a> <a data-link-type="dfn" href="#connection" id="ref-for-connection-58">connection</a> of which this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-61">transaction</a> is a part.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-error">error</dfn> attribute’s getter
 must return this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-62">transaction</a>'s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-1">error</a>, or null if
 none.</p>
@@ -5175,7 +5174,7 @@ appropriate error (e.g. a "<code class="idl"><a data-link-type="idl" href="https
       <p>If <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-11">version</a> is greater than <var>version</var>,
 abort these steps and return a new "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#versionerror">VersionError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
      <li data-md="">
-      <p>Let <var>connection</var> be a new <a data-link-type="dfn" href="#connection" id="ref-for-connection-57">connection</a> to <var>db</var>.</p>
+      <p>Let <var>connection</var> be a new <a data-link-type="dfn" href="#connection" id="ref-for-connection-59">connection</a> to <var>db</var>.</p>
      <li data-md="">
       <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-version" id="ref-for-connection-version-3">version</a> to <var>version</var>.</p>
      <li data-md="">
@@ -5183,7 +5182,7 @@ abort these steps and return a new "<code class="idl"><a data-link-type="idl" hr
 these substeps:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-58">connections</a>,
+        <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-60">connections</a>,
 except <var>connection</var>, associated with <var>db</var>.</p>
        <li data-md="">
         <p>For each <var>entry</var> in <var>openConnections</var> that does not have its <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-5">close pending flag</a> set, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-2">fire a
@@ -5194,11 +5193,11 @@ version change event</a> named <code>versionchange</code> at <var>entry</var> wi
        <li data-md="">
         <p>Wait for all of the events to be fired.</p>
        <li data-md="">
-        <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-59">connections</a> in <var>openConnections</var> are still
+        <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-61">connections</a> in <var>openConnections</var> are still
 not closed, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-3">fire a version change
 event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-5">blocked</a></code> at <var>request</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-14">version</a> and <var>version</var>.</p>
        <li data-md="">
-        <p><span id="version-change-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-60">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-5">closed</a>.</p>
+        <p><span id="version-change-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-62">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-5">closed</a>.</p>
        <li data-md="">
         <p>Run the steps to <a data-link-type="dfn" href="#run-an-upgrade-transaction" id="ref-for-run-an-upgrade-transaction-3">run an upgrade transaction</a> using <var>connection</var>, <var>version</var> and <var>request</var>.</p>
        <li data-md="">
@@ -5241,8 +5240,8 @@ Once they are complete, <var>connection</var> is <a data-link-type="dfn" href="#
    </div>
    <aside class="note"> Once the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-7">close pending flag</a> has been set no new transactions
   can be <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-6">created</a> using <var>connection</var>. All methods that <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-7">create</a> transactions first check the <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-8">close pending flag</a> first and throw an exception if it is set. </aside>
-   <aside class="note"> Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-61">connection</a> is closed, this can unblock the steps to <a data-link-type="dfn" href="#run-an-upgrade-transaction" id="ref-for-run-an-upgrade-transaction-4">run an upgrade transaction</a>, and the steps to <a data-link-type="dfn" href="#delete-a-database" id="ref-for-delete-a-database-2">delete a
-  database</a>, which <a href="#delete-close-block">both</a> <a href="#version-change-close-block">wait</a> for <a data-link-type="dfn" href="#connection" id="ref-for-connection-62">connections</a> to
+   <aside class="note"> Once the <a data-link-type="dfn" href="#connection" id="ref-for-connection-63">connection</a> is closed, this can unblock the steps to <a data-link-type="dfn" href="#run-an-upgrade-transaction" id="ref-for-run-an-upgrade-transaction-4">run an upgrade transaction</a>, and the steps to <a data-link-type="dfn" href="#delete-a-database" id="ref-for-delete-a-database-2">delete a
+  database</a>, which <a href="#delete-close-block">both</a> <a href="#version-change-close-block">wait</a> for <a data-link-type="dfn" href="#connection" id="ref-for-connection-64">connections</a> to
   a given <a data-link-type="dfn" href="#database" id="ref-for-database-57">database</a> to be closed before continuing. </aside>
    <h3 class="heading settled" data-level="5.3" id="deleting-a-database"><span class="secno">5.3. </span><span class="content">Deleting a database</span><a class="self-link" href="#deleting-a-database"></a></h3>
    <div class="algorithm">
@@ -5259,7 +5258,7 @@ requested the <a data-link-type="dfn" href="#database" id="ref-for-database-58">
      <li data-md="">
       <p>Let <var>db</var> be the <a data-link-type="dfn" href="#database" id="ref-for-database-59">database</a> <a data-link-type="dfn" href="#database-name" id="ref-for-database-name-6">named</a> <var>name</var> in <var>origin</var>, if one exists. Otherwise, return 0 (zero).</p>
      <li data-md="">
-      <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-63">connections</a> associated with <var>db</var>.</p>
+      <p>Let <var>openConnections</var> be the set of all <a data-link-type="dfn" href="#connection" id="ref-for-connection-65">connections</a> associated with <var>db</var>.</p>
      <li data-md="">
       <p>For each <var>entry</var> in <var>openConnections</var> that does not have its <a data-link-type="dfn" href="#connection-close-pending-flag" id="ref-for-connection-close-pending-flag-9">close pending flag</a> set, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-4">fire a version
 change event</a> named <code>versionchange</code> at <var>entry</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-15">version</a> and null.</p>
@@ -5269,10 +5268,10 @@ change event</a> named <code>versionchange</code> at <var>entry</var> with <var>
      <li data-md="">
       <p>Wait for all of the events to be fired.</p>
      <li data-md="">
-      <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-64">connections</a> in <var>openConnections</var> are
+      <p>If any of the <a data-link-type="dfn" href="#connection" id="ref-for-connection-66">connections</a> in <var>openConnections</var> are
 still not closed, <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-5">fire a version change event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-for-request-blocked-6">blocked</a></code> at <var>request</var> with <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-16">version</a> and null.</p>
      <li data-md="">
-      <p><span id="delete-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-65">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-8">closed</a>.</p>
+      <p><span id="delete-close-block">Wait</span> until all <a data-link-type="dfn" href="#connection" id="ref-for-connection-67">connections</a> in <var>openConnections</var> are <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-8">closed</a>.</p>
      <li data-md="">
       <p>Let <var>version</var> be <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-17">version</a>.</p>
      <li data-md="">
@@ -5325,7 +5324,7 @@ considered deleted for the purposes of other algorithms.</p>
      <li data-md="">
       <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-52">upgrade transaction</a>, run the steps
 to <a data-link-type="dfn" href="#abort-an-upgrade-transaction" id="ref-for-abort-an-upgrade-transaction-2">abort an upgrade transaction</a> with <var>transaction</var>. This
-reverts changes to all <a data-link-type="dfn" href="#connection" id="ref-for-connection-66">connection</a>, <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-64">object store handle</a>,
+reverts changes to all <a data-link-type="dfn" href="#connection" id="ref-for-connection-68">connection</a>, <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-64">object store handle</a>,
 and <a data-link-type="dfn" href="#index-handle" id="ref-for-index-handle-38">index handle</a> instances associated with <var>transaction</var>.</p>
      <li data-md="">
       <p>If <var>error</var> is not null, set <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-2">error</a> to <var>error</var>.</p>
@@ -5425,13 +5424,13 @@ for the <a data-link-type="dfn" href="#database" id="ref-for-database-65">databa
      <li data-md="">
       <p>Let <var>db</var> be <var>connection</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-66">database</a>.</p>
      <li data-md="">
-      <p>Let <var>transaction</var> be a new <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a> with <var>connection</var> used as <a data-link-type="dfn" href="#connection" id="ref-for-connection-67">connection</a>. The <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-16">scope</a> of <var>transaction</var> includes every <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-100">object store</a> in <var>connection</var>.</p>
+      <p>Let <var>transaction</var> be a new <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a> with <var>connection</var> used as <a data-link-type="dfn" href="#connection" id="ref-for-connection-69">connection</a>. The <a data-link-type="dfn" href="#transaction-scope" id="ref-for-transaction-scope-16">scope</a> of <var>transaction</var> includes every <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-100">object store</a> in <var>connection</var>.</p>
      <li data-md="">
       <p>Unset <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-6">active flag</a>.</p>
      <li data-md="">
       <p>Start <var>transaction</var>.</p>
       <aside class="note"> Note that until this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-77">transaction</a> is finished, no
-  other <a data-link-type="dfn" href="#connection" id="ref-for-connection-68">connections</a> can be opened to the same <a data-link-type="dfn" href="#database" id="ref-for-database-67">database</a>. </aside>
+  other <a data-link-type="dfn" href="#connection" id="ref-for-connection-70">connections</a> can be opened to the same <a data-link-type="dfn" href="#database" id="ref-for-database-67">database</a>. </aside>
      <li data-md="">
       <p>Let <var>old version</var> be <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-19">version</a>.</p>
      <li data-md="">
@@ -5474,18 +5473,18 @@ transaction</a> with the <var>error</var> property set to a newly <a data-link-t
   as the change to the <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-20">version</a>. </aside>
     <ol>
      <li data-md="">
-      <p>Let <var>connection</var> be <var>transaction</var>’s <a data-link-type="dfn" href="#connection" id="ref-for-connection-69">connection</a>.</p>
+      <p>Let <var>connection</var> be <var>transaction</var>’s <a data-link-type="dfn" href="#connection" id="ref-for-connection-71">connection</a>.</p>
      <li data-md="">
       <p>Let <var>database</var> be <var>connection</var>’s <a data-link-type="dfn" href="#database" id="ref-for-database-69">database</a>.</p>
      <li data-md="">
       <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-version" id="ref-for-connection-version-4">version</a> to <var>database</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-21">version</a> if <var>database</var> previously existed, or 0 (zero)
 if <var>database</var> was newly created.</p>
-      <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-version" id="ref-for-dom-idbdatabase-version-3">version</a></code> returned by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-12">IDBDatabase</a></code> object. </aside>
+      <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-version" id="ref-for-dom-idbdatabase-version-3">version</a></code> returned by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-10">IDBDatabase</a></code> object. </aside>
      <li data-md="">
       <p>Set <var>connection</var>’s <a data-link-type="dfn" href="#connection-object-store-set" id="ref-for-connection-object-store-set-4">object store set</a> to the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-102">object stores</a> in <var>database</var> if <var>database</var> previously
 existed, or the empty set if <var>database</var> was newly created.</p>
       <aside class="note"> This reverts the value of <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-objectstorenames" id="ref-for-dom-idbdatabase-objectstorenames-5">objectStoreNames</a></code> returned
-  by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-13">IDBDatabase</a></code> object. </aside>
+  by the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-11">IDBDatabase</a></code> object. </aside>
      <li data-md="">
       <p>For each <a data-link-type="dfn" href="#object-store-handle" id="ref-for-object-store-handle-65">object store handle</a> <var>handle</var> associated with <var>transaction</var>, including those for <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-103">object stores</a> that
 were created or deleted during <var>transaction</var>, run these substeps:</p>
@@ -5521,7 +5520,7 @@ its <a data-link-type="dfn" href="#index-handle-index" id="ref-for-index-handle-
       </details>
     </ol>
    </div>
-   <aside class="note"> The <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-name" id="ref-for-dom-idbdatabase-name-3">name</a></code> property of the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-14">IDBDatabase</a></code> instance is
+   <aside class="note"> The <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-name" id="ref-for-dom-idbdatabase-name-3">name</a></code> property of the <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-12">IDBDatabase</a></code> instance is
   not modified, even if the aborted <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-56">upgrade transaction</a> was
   creating a new <a data-link-type="dfn" href="#database" id="ref-for-database-70">database</a>. </aside>
    <h3 class="heading settled" data-level="5.9" id="fire-success-event"><span class="secno">5.9. </span><span class="content">Firing a success event</span><a class="self-link" href="#fire-success-event"></a></h3>
@@ -6564,7 +6563,7 @@ document’s Revision History</a>.</p>
      <li data-md="">
       <p>Correct <var>source</var> used for <code class="idl"><a data-link-type="idl" href="#dom-idbindex-get" id="ref-for-dom-idbindex-get-3">get()</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-idbindex-getkey" id="ref-for-dom-idbindex-getkey-3">getKey()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbindex-openkeycursor" id="ref-for-dom-idbindex-openkeycursor-3">openKeyCursor()</a></code> on <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-18">IDBIndex</a></code>.</p>
      <li data-md="">
-      <p>Added details around garbage collection of <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-15">IDBDatabase</a></code> objects.
+      <p>Added details around garbage collection of <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-13">IDBDatabase</a></code> objects.
 (<a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=25223">bug #25223</a>)</p>
      <li data-md="">
       <p>Added <code>[Exposed=(Window,Worker)]</code> annotations to interfaces.</p>
@@ -7632,14 +7631,14 @@ specification.</p>
     <li><a href="#ref-for-connection-22">2.7.2. Upgrade Transactions</a> <a href="#ref-for-connection-23">(2)</a> <a href="#ref-for-connection-24">(3)</a> <a href="#ref-for-connection-25">(4)</a> <a href="#ref-for-connection-26">(5)</a> <a href="#ref-for-connection-27">(6)</a>
     <li><a href="#ref-for-connection-28">2.8.1. Open Requests</a> <a href="#ref-for-connection-29">(2)</a>
     <li><a href="#ref-for-connection-30">4.3. The IDBFactory interface</a> <a href="#ref-for-connection-31">(2)</a> <a href="#ref-for-connection-32">(3)</a> <a href="#ref-for-connection-33">(4)</a> <a href="#ref-for-connection-34">(5)</a> <a href="#ref-for-connection-35">(6)</a>
-    <li><a href="#ref-for-connection-36">4.4. The IDBDatabase interface</a> <a href="#ref-for-connection-37">(2)</a> <a href="#ref-for-connection-38">(3)</a> <a href="#ref-for-connection-39">(4)</a> <a href="#ref-for-connection-40">(5)</a> <a href="#ref-for-connection-41">(6)</a> <a href="#ref-for-connection-42">(7)</a> <a href="#ref-for-connection-43">(8)</a> <a href="#ref-for-connection-44">(9)</a> <a href="#ref-for-connection-45">(10)</a> <a href="#ref-for-connection-46">(11)</a> <a href="#ref-for-connection-47">(12)</a> <a href="#ref-for-connection-48">(13)</a> <a href="#ref-for-connection-49">(14)</a> <a href="#ref-for-connection-50">(15)</a> <a href="#ref-for-connection-51">(16)</a> <a href="#ref-for-connection-52">(17)</a> <a href="#ref-for-connection-53">(18)</a> <a href="#ref-for-connection-54">(19)</a>
-    <li><a href="#ref-for-connection-55">4.9. The IDBTransaction interface</a> <a href="#ref-for-connection-56">(2)</a>
-    <li><a href="#ref-for-connection-57">5.1. Opening a database</a> <a href="#ref-for-connection-58">(2)</a> <a href="#ref-for-connection-59">(3)</a> <a href="#ref-for-connection-60">(4)</a>
-    <li><a href="#ref-for-connection-61">5.2. Closing a database</a> <a href="#ref-for-connection-62">(2)</a>
-    <li><a href="#ref-for-connection-63">5.3. Deleting a database</a> <a href="#ref-for-connection-64">(2)</a> <a href="#ref-for-connection-65">(3)</a>
-    <li><a href="#ref-for-connection-66">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-connection-67">5.7. Running an upgrade transaction</a> <a href="#ref-for-connection-68">(2)</a>
-    <li><a href="#ref-for-connection-69">5.8. Aborting an upgrade transaction</a>
+    <li><a href="#ref-for-connection-36">4.4. The IDBDatabase interface</a> <a href="#ref-for-connection-37">(2)</a> <a href="#ref-for-connection-38">(3)</a> <a href="#ref-for-connection-39">(4)</a> <a href="#ref-for-connection-40">(5)</a> <a href="#ref-for-connection-41">(6)</a> <a href="#ref-for-connection-42">(7)</a> <a href="#ref-for-connection-43">(8)</a> <a href="#ref-for-connection-44">(9)</a> <a href="#ref-for-connection-45">(10)</a> <a href="#ref-for-connection-46">(11)</a> <a href="#ref-for-connection-47">(12)</a> <a href="#ref-for-connection-48">(13)</a> <a href="#ref-for-connection-49">(14)</a> <a href="#ref-for-connection-50">(15)</a> <a href="#ref-for-connection-51">(16)</a> <a href="#ref-for-connection-52">(17)</a> <a href="#ref-for-connection-53">(18)</a> <a href="#ref-for-connection-54">(19)</a> <a href="#ref-for-connection-55">(20)</a> <a href="#ref-for-connection-56">(21)</a>
+    <li><a href="#ref-for-connection-57">4.9. The IDBTransaction interface</a> <a href="#ref-for-connection-58">(2)</a>
+    <li><a href="#ref-for-connection-59">5.1. Opening a database</a> <a href="#ref-for-connection-60">(2)</a> <a href="#ref-for-connection-61">(3)</a> <a href="#ref-for-connection-62">(4)</a>
+    <li><a href="#ref-for-connection-63">5.2. Closing a database</a> <a href="#ref-for-connection-64">(2)</a>
+    <li><a href="#ref-for-connection-65">5.3. Deleting a database</a> <a href="#ref-for-connection-66">(2)</a> <a href="#ref-for-connection-67">(3)</a>
+    <li><a href="#ref-for-connection-68">5.5. Aborting a transaction</a>
+    <li><a href="#ref-for-connection-69">5.7. Running an upgrade transaction</a> <a href="#ref-for-connection-70">(2)</a>
+    <li><a href="#ref-for-connection-71">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="connection-version">
@@ -8778,10 +8777,10 @@ specification.</p>
    <b><a href="#idbdatabase">#idbdatabase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbdatabase-1">4.1. The IDBRequest interface</a>
-    <li><a href="#ref-for-idbdatabase-2">4.4. The IDBDatabase interface</a> <a href="#ref-for-idbdatabase-3">(2)</a> <a href="#ref-for-idbdatabase-4">(3)</a> <a href="#ref-for-idbdatabase-5">(4)</a> <a href="#ref-for-idbdatabase-6">(5)</a> <a href="#ref-for-idbdatabase-7">(6)</a> <a href="#ref-for-idbdatabase-8">(7)</a> <a href="#ref-for-idbdatabase-9">(8)</a> <a href="#ref-for-idbdatabase-10">(9)</a>
-    <li><a href="#ref-for-idbdatabase-11">4.9. The IDBTransaction interface</a>
-    <li><a href="#ref-for-idbdatabase-12">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-idbdatabase-13">(2)</a> <a href="#ref-for-idbdatabase-14">(3)</a>
-    <li><a href="#ref-for-idbdatabase-15">10. Revision History</a>
+    <li><a href="#ref-for-idbdatabase-2">4.4. The IDBDatabase interface</a> <a href="#ref-for-idbdatabase-3">(2)</a> <a href="#ref-for-idbdatabase-4">(3)</a> <a href="#ref-for-idbdatabase-5">(4)</a> <a href="#ref-for-idbdatabase-6">(5)</a> <a href="#ref-for-idbdatabase-7">(6)</a> <a href="#ref-for-idbdatabase-8">(7)</a>
+    <li><a href="#ref-for-idbdatabase-9">4.9. The IDBTransaction interface</a>
+    <li><a href="#ref-for-idbdatabase-10">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-idbdatabase-11">(2)</a> <a href="#ref-for-idbdatabase-12">(3)</a>
+    <li><a href="#ref-for-idbdatabase-13">10. Revision History</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-idbobjectstoreparameters">

--- a/index.html
+++ b/index.html
@@ -1455,7 +1455,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-24">24 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-04">4 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3412,8 +3412,6 @@ from within an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-u
     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBDatabase" data-dfn-type="method" data-export="" data-lt="transaction(storeNames, mode)|transaction(storeNames)" id="dom-idbdatabase-transaction">transaction(<var>storeNames</var>, <var>mode</var>)</dfn> method, when invoked, must run these steps:</p>
     <ol>
      <li data-md="">
-      <p>If <var>mode</var> parameter is not <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-4">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-5">"readwrite"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>.</p>
-     <li data-md="">
       <p>If this method is called on <code class="idl"><a data-link-type="idl" href="#idbdatabase" id="ref-for-idbdatabase-9">IDBDatabase</a></code> object for which an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-27">upgrade transaction</a> is still running, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
      <li data-md="">
@@ -3428,6 +3426,8 @@ store</a> in the <a data-link-type="dfn" href="#connection" id="ref-for-connecti
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
      <li data-md="">
       <p>If <var>scope</var> is empty, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
+     <li data-md="">
+      <p>If <var>mode</var> parameter is not <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readonly" id="ref-for-dom-idbtransactionmode-readonly-4">"readonly"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-idbtransactionmode-readwrite" id="ref-for-dom-idbtransactionmode-readwrite-5">"readwrite"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>.</p>
      <li data-md="">
       <p>Let <var>transaction</var> be a newly <a data-link-type="dfn" href="#transaction-created" id="ref-for-transaction-created-3">created</a> <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-39">transaction</a> with <var>connection</var>, <var>mode</var> and the set of <a data-link-type="dfn" href="#object-store" id="ref-for-object-store-73">object stores</a> named in <var>scope</var>.</p>
      <li data-md="">


### PR DESCRIPTION
As noted in https://github.com/w3c/web-platform-tests/issues/5313 the spec disagreed with implementations and tests for exception precedence for IDBDatabase.transaction()

Per https://github.com/w3c/IndexedDB/issues/11:

InvalidStateError (closed/version) > InvalidAccessError (empty) > NotFoundError > TypeError (mode)
