### PR TITLE
Set request result/done flag appropriately in open/delete

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1273,9 +1273,9 @@ A [=request=]'s [=get the parent=] algorithm returns the request's
   on the same [=request=] object used to open the cursor. And when
   an [=/upgrade transaction=] is necessary, the same [=open
   request=] is used for both the <code>[=upgradeneeded=]</code>
-  event and final result of the open operation itself. In both cases,
+  event and final result of the open operation itself. In some cases,
   the request's [=request/done flag=] will be unset then set again, and the
-  [=request/result=] can change.
+  [=request/result=] can change or [=request/error=] could be set insead.
 </aside>
 
 <!-- ============================================================ -->
@@ -2258,6 +2258,7 @@ when invoked, must run these steps:
     2. [=Queue a task=] to run these steps:
 
         1. If |result| is an error,
+            set |request|'s [=request/result=] to undefined,
             set |request|'s [=request/error=] to |result|,
             set |request|'s [=request/done flag=],
             and [=fire an event=] named
@@ -5262,7 +5263,8 @@ database |name|, a database |version|, and a |request|.
     "{{UnknownError}}" {{DOMException}}).
 
 7. If |db|'s [=database/version=] is greater than |version|,
-    abort these steps and return a new "{{VersionError}}" {{DOMException}}.
+    return a newly [=exception/created=] "{{VersionError}}" {{DOMException}}
+    and abort these steps.
 
 8. Let |connection| be a new [=/connection=] to |db|.
 
@@ -5299,13 +5301,13 @@ database |name|, a database |version|, and a |request|.
     6. Run the steps to [=run an upgrade transaction=]
         using |connection|, |version| and |request|.
 
-    7. If |connection| was [=connection/closed=], create and
-        return a newly <a for=exception>created</a>
+    7. If |connection| was [=connection/closed=],
+        return a newly [=exception/created=]
         "{{AbortError}}" {{DOMException}} and abort these steps.
 
     8. If the [=/upgrade transaction=] was aborted, run the steps
         to [=close a database connection=] with |connection|,
-        create and return a newly <a for=exception>created</a>
+        return a newly [=exception/created=]
         "{{AbortError}}" {{DOMException}} and abort these steps.
 
 11. Return |connection|.

--- a/index.bs
+++ b/index.bs
@@ -2257,13 +2257,17 @@ when invoked, must run these steps:
 
     2. [=Queue a task=] to run these steps:
 
-        1. If |result| is an error, set the [=request/error=]
-            of |request| to |result| and [=fire an event=] named
+        1. If |result| is an error,
+            set |request|'s [=request/error=] to |result|,
+            set |request|'s [=request/done flag=],
+            and [=fire an event=] named
             <code>error</code> at |request| with its
             {{Event/bubbles}} and {{Event/cancelable}} attributes initialized to true.
 
-        2. Otherwise, set the [=request/result=] of |request|
-            to |result| and [=fire an event=] named
+        2. Otherwise,
+            set |request|'s [=request/result=] to |result|,
+            set |request|'s [=request/done flag=],
+            and [=fire an event=] named
             <code>success</code> at |request|. If the steps
             above resulted in an [=/upgrade transaction=] being run,
             then firing the "<code>success</code>" event must be done
@@ -2312,13 +2316,17 @@ when invoked, must run these steps:
         |name|, and |request|.
 
     2. [=Queue a task=] to run these steps:
-        1. If |result| is an error set the [=request/error=] of
-            |request| to |result| and [=fire an event=]
+        1. If |result| is an error,
+            set |request|'s [=request/error=] to |result|,
+            set |request|'s [=request/done flag=],
+            and [=fire an event=]
             named <code>error</code> at |request| with
             its {{Event/bubbles}} and {{Event/cancelable}} attributes initialized to true.
 
-        2. Otherwise, set the [=request/result=] of |request|
-            to undefined and [=fire a version change event=] named
+        2. Otherwise,
+            set |request|'s [=request/result=] to undefined,
+            set |request|'s [=request/done flag=],
+            and [=fire a version change event=] named
             <code>success</code> at [=request=] with |result| and
             null.
 
@@ -5512,9 +5520,12 @@ takes two arguments: the |transaction| to abort, and |error|.
     2. [=Fire an event=] named <code>abort</code> at |transaction|
         with its {{Event/bubbles}} attribute initialized to true.
 
-    3. If |transaction| is an [=/upgrade transaction=], then
-        let |request| be the [=request=] associated with |transaction|
-        and set |request|'s [=request/transaction=] to null.
+    2. If |transaction| is an [=/upgrade transaction=], then:
+
+        1. Let |request| be the [=request=] associated with |transaction|.
+        2. Set |request|'s [=request/transaction=] to null.
+        3. Set |request|'s [=request/result=] to undefined.
+        4. Unset |request|'s [=request/done flag=].
 
 </div>
 
@@ -7172,6 +7183,10 @@ document's Revision History</a>.
     align exceptions thrown from {{IDBDatabase/createObjectStore()}} and
     {{IDBDatabase/deleteObjectStore()}} with tests and implementations.
     (<a href="https://github.com/w3c/IndexedDB/issues/192">issue #192</a>)
+
+* Set [=request/result]/[=request/done flag=] appropriately for requests
+    from {{IDBFactory/open()}} and {{IDBFactory/deleteDatabase()}}.
+    (<a href="https://github.com/w3c/IndexedDB/issues/161">issue #161</a>)
 
 
 <!-- ============================================================ -->

--- a/index.html
+++ b/index.html
@@ -1459,7 +1459,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-11">11 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-12">12 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3170,9 +3170,15 @@ otherwise, and <var>request</var>.</p>
         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these steps:</p>
         <ol>
          <li data-md="">
-          <p>If <var>result</var> is an error, set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-4">error</a> of <var>request</var> to <var>result</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at <var>request</var> with its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attributes initialized to true.</p>
+          <p>If <var>result</var> is an error,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-4">error</a> to <var>result</var>,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-9">done flag</a>,
+and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at <var>request</var> with its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attributes initialized to true.</p>
          <li data-md="">
-          <p>Otherwise, set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-5">result</a> of <var>request</var> to <var>result</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>success</code> at <var>request</var>. If the steps
+          <p>Otherwise,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-5">result</a> to <var>result</var>,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-10">done flag</a>,
+and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>success</code> at <var>request</var>. If the steps
 above resulted in an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-18">upgrade transaction</a> being run,
 then firing the "<code>success</code>" event must be done
 after the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-19">upgrade transaction</a> completes.</p>
@@ -3214,10 +3220,16 @@ to access this <code class="idl"><a data-link-type="idl" href="#idbfactory" id="
         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these steps:</p>
         <ol>
          <li data-md="">
-          <p>If <var>result</var> is an error set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-5">error</a> of <var>request</var> to <var>result</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at <var>request</var> with
+          <p>If <var>result</var> is an error,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-5">error</a> to <var>result</var>,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-11">done flag</a>,
+and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at <var>request</var> with
 its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attributes initialized to true.</p>
          <li data-md="">
-          <p>Otherwise, set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-6">result</a> of <var>request</var> to undefined and <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-1">fire a version change event</a> named <code>success</code> at <a data-link-type="dfn" href="#request" id="ref-for-request-20">request</a> with <var>result</var> and
+          <p>Otherwise,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-6">result</a> to undefined,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-12">done flag</a>,
+and <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-1">fire a version change event</a> named <code>success</code> at <a data-link-type="dfn" href="#request" id="ref-for-request-20">request</a> with <var>result</var> and
 null.</p>
           <details class="note">
            <summary> Why aren’t the steps to <a data-link-type="dfn" href="#fire-a-success-event" id="ref-for-fire-a-success-event-2">fire a success event</a> or <a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-2">fire an error event</a> used? </summary>
@@ -4815,7 +4827,7 @@ the cursor is being iterated or has iterated past its end, <a data-link-type="df
      <li data-md="">
       <p>Let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-for-request-24">request</a> created when this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-34">cursor</a> was created.</p>
      <li data-md="">
-      <p>Unset the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-9">done flag</a> on <var>request</var>.</p>
+      <p>Unset the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-13">done flag</a> on <var>request</var>.</p>
      <li data-md="">
       <p>Run the steps to <a data-link-type="dfn" href="#asynchronously-execute-a-request" id="ref-for-asynchronously-execute-a-request-20">asynchronously execute a request</a> with
 the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-17">source</a> as <var>source</var>, the steps
@@ -4862,7 +4874,7 @@ cursor’s <a data-link-type="dfn" href="#cursor-position" id="ref-for-cursor-po
      <li data-md="">
       <p>Let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-for-request-25">request</a> created when this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-37">cursor</a> was created.</p>
      <li data-md="">
-      <p>Unset the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-10">done flag</a> on <var>request</var>.</p>
+      <p>Unset the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-14">done flag</a> on <var>request</var>.</p>
      <li data-md="">
       <p>Run the steps to <a data-link-type="dfn" href="#asynchronously-execute-a-request" id="ref-for-asynchronously-execute-a-request-21">asynchronously execute a request</a> with
 the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-19">source</a> as <var>source</var>, the steps
@@ -4921,7 +4933,7 @@ cursor’s <a data-link-type="dfn" href="#cursor-object-store-position" id="ref-
      <li data-md="">
       <p>Let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-for-request-26">request</a> created when this <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-40">cursor</a> was created.</p>
      <li data-md="">
-      <p>Unset the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-11">done flag</a> on <var>request</var>.</p>
+      <p>Unset the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-15">done flag</a> on <var>request</var>.</p>
      <li data-md="">
       <p>Run the steps to <a data-link-type="dfn" href="#asynchronously-execute-a-request" id="ref-for-asynchronously-execute-a-request-22">asynchronously execute a request</a> with
 the cursor’s <a data-link-type="dfn" href="#cursor-source" id="ref-for-cursor-source-22">source</a> as <var>source</var>, the steps
@@ -5361,12 +5373,12 @@ to <a data-link-type="dfn" href="#abort-an-upgrade-transaction" id="ref-for-abor
      <li data-md="">
       <p>If <var>error</var> is not null, set <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-2">error</a> to <var>error</var>.</p>
      <li data-md="">
-      <p>For each <var>request</var> in <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-request-list" id="ref-for-transaction-request-list-1">request list</a> with <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-12">done flag</a> unset, abort the steps to <a data-link-type="dfn" href="#asynchronously-execute-a-request" id="ref-for-asynchronously-execute-a-request-25">asynchronously
+      <p>For each <var>request</var> in <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-request-list" id="ref-for-transaction-request-list-1">request list</a> with <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-16">done flag</a> unset, abort the steps to <a data-link-type="dfn" href="#asynchronously-execute-a-request" id="ref-for-asynchronously-execute-a-request-25">asynchronously
 execute a request</a> for <var>request</var> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to
 run these steps:</p>
       <ol>
        <li data-md="">
-        <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-13">done flag</a> on <var>request</var>.</p>
+        <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-17">done flag</a> on <var>request</var>.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-7">result</a> of <var>request</var> to undefined.</p>
        <li data-md="">
@@ -5386,8 +5398,17 @@ run these steps:</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>abort</code> at <var>transaction</var> with its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> attribute initialized to true.</p>
        <li data-md="">
-        <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a>, then
-let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-for-request-32">request</a> associated with <var>transaction</var> and set <var>request</var>’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-5">transaction</a> to null.</p>
+        <p>If <var>transaction</var> is an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-54">upgrade transaction</a>, then:</p>
+        <ol>
+         <li data-md="">
+          <p>Let <var>request</var> be the <a data-link-type="dfn" href="#request" id="ref-for-request-32">request</a> associated with <var>transaction</var>.</p>
+         <li data-md="">
+          <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-5">transaction</a> to null.</p>
+         <li data-md="">
+          <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-8">result</a> to undefined.</p>
+         <li data-md="">
+          <p>Unset <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-18">done flag</a>.</p>
+        </ol>
       </ol>
     </ol>
    </div>
@@ -5412,7 +5433,7 @@ created <a data-link-type="dfn" href="#request" id="ref-for-request-34">request<
       <p>Run these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Wait until all previously added <a data-link-type="dfn" href="#request" id="ref-for-request-35">requests</a> in <var>transaction</var> have their <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-14">done flag</a> set.</p>
+        <p>Wait until all previously added <a data-link-type="dfn" href="#request" id="ref-for-request-35">requests</a> in <var>transaction</var> have their <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-19">done flag</a> set.</p>
        <li data-md="">
         <p>Let <var>result</var> be the result of performing <var>operation</var>.</p>
        <li data-md="">
@@ -5423,12 +5444,12 @@ created <a data-link-type="dfn" href="#request" id="ref-for-request-34">request<
         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these steps:</p>
         <ol>
          <li data-md="">
-          <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-15">done flag</a> on <var>request</var>.</p>
+          <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-20">done flag</a> on <var>request</var>.</p>
          <li data-md="">
           <p>If <var>result</var> is an error, then:</p>
           <ol>
            <li data-md="">
-            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-8">result</a> of <var>request</var> to undefined.</p>
+            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-9">result</a> of <var>request</var> to undefined.</p>
            <li data-md="">
             <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-8">error</a> of <var>request</var> to <var>result</var>.</p>
            <li data-md="">
@@ -5438,7 +5459,7 @@ created <a data-link-type="dfn" href="#request" id="ref-for-request-34">request<
           <p>Otherwise:</p>
           <ol>
            <li data-md="">
-            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-9">result</a> of <var>request</var> to <var>result</var>.</p>
+            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-10">result</a> of <var>request</var> to <var>result</var>.</p>
            <li data-md="">
             <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-9">error</a> of <var>request</var> to undefined.</p>
            <li data-md="">
@@ -5479,11 +5500,11 @@ transaction is <a data-link-type="dfn" href="#transaction-abort" id="ref-for-tra
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these steps:</p>
       <ol>
        <li data-md="">
-        <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-10">result</a> to <var>connection</var>.</p>
+        <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-11">result</a> to <var>connection</var>.</p>
        <li data-md="">
         <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-6">transaction</a> to <var>transaction</var>.</p>
        <li data-md="">
-        <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-16">done flag</a> on the <a data-link-type="dfn" href="#request" id="ref-for-request-36">request</a>.</p>
+        <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-21">done flag</a> on the <a data-link-type="dfn" href="#request" id="ref-for-request-36">request</a>.</p>
        <li data-md="">
         <p>Set <var>transaction</var>’s <a data-link-type="dfn" href="#transaction-active-flag" id="ref-for-transaction-active-flag-7">active flag</a>.</p>
        <li data-md="">
@@ -6695,9 +6716,16 @@ replacing monkey patching.
 the <a data-link-type="dfn" href="#asynchronously-execute-a-request" id="ref-for-asynchronously-execute-a-request-27">asynchronously execute a request</a> steps.
 (<a href="https://github.com/w3c/IndexedDB/issues/192">issue #192</a>)</p>
      <li data-md="">
+      <p>Use <a data-link-type="biblio" href="#biblio-html">[HTML]</a>'s <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserializeforstorage">StructuredSerializeForStorage</a> hook.
+(<a href="https://github.com/w3c/IndexedDB/issues/197">issue #197</a>, <a href="https://github.com/w3c/IndexedDB/issues/197">issue #152</a>)</p>
+     <li data-md="">
       <p>Define <a data-link-type="dfn" href="#database" id="ref-for-database-75">database</a>'s associated <a data-link-type="dfn" href="#database-upgrade-transaction" id="ref-for-database-upgrade-transaction-6">upgrade transaction</a> to
 align exceptions thrown from <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-createobjectstore" id="ref-for-dom-idbdatabase-createobjectstore-4">createObjectStore()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbdatabase-deleteobjectstore" id="ref-for-dom-idbdatabase-deleteobjectstore-3">deleteObjectStore()</a></code> with tests and implementations.
 (<a href="https://github.com/w3c/IndexedDB/issues/192">issue #192</a>)</p>
+     <li data-md="">
+      <p>Set [=request/result]/<a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-22">done flag</a> appropriately for requests
+from <code class="idl"><a data-link-type="idl" href="#dom-idbfactory-open" id="ref-for-dom-idbfactory-open-6">open()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-idbfactory-deletedatabase" id="ref-for-dom-idbfactory-deletedatabase-5">deleteDatabase()</a></code>.
+(<a href="https://github.com/w3c/IndexedDB/issues/161">issue #161</a>)</p>
     </ul>
     <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
     <p>Special thanks to Nikunj Mehta, the original author of the first
@@ -8383,10 +8411,12 @@ specification.</p>
    <ul>
     <li><a href="#ref-for-request-done-flag-1">2.8. Requests</a> <a href="#ref-for-request-done-flag-2">(2)</a> <a href="#ref-for-request-done-flag-3">(3)</a> <a href="#ref-for-request-done-flag-4">(4)</a> <a href="#ref-for-request-done-flag-5">(5)</a>
     <li><a href="#ref-for-request-done-flag-6">4.1. The IDBRequest interface</a> <a href="#ref-for-request-done-flag-7">(2)</a> <a href="#ref-for-request-done-flag-8">(3)</a>
-    <li><a href="#ref-for-request-done-flag-9">4.8. The IDBCursor interface</a> <a href="#ref-for-request-done-flag-10">(2)</a> <a href="#ref-for-request-done-flag-11">(3)</a>
-    <li><a href="#ref-for-request-done-flag-12">5.5. Aborting a transaction</a> <a href="#ref-for-request-done-flag-13">(2)</a>
-    <li><a href="#ref-for-request-done-flag-14">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-done-flag-15">(2)</a>
-    <li><a href="#ref-for-request-done-flag-16">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-request-done-flag-9">4.3. The IDBFactory interface</a> <a href="#ref-for-request-done-flag-10">(2)</a> <a href="#ref-for-request-done-flag-11">(3)</a> <a href="#ref-for-request-done-flag-12">(4)</a>
+    <li><a href="#ref-for-request-done-flag-13">4.8. The IDBCursor interface</a> <a href="#ref-for-request-done-flag-14">(2)</a> <a href="#ref-for-request-done-flag-15">(3)</a>
+    <li><a href="#ref-for-request-done-flag-16">5.5. Aborting a transaction</a> <a href="#ref-for-request-done-flag-17">(2)</a> <a href="#ref-for-request-done-flag-18">(3)</a>
+    <li><a href="#ref-for-request-done-flag-19">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-done-flag-20">(2)</a>
+    <li><a href="#ref-for-request-done-flag-21">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-request-done-flag-22">10. Revision History</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-source">
@@ -8403,9 +8433,9 @@ specification.</p>
     <li><a href="#ref-for-request-result-1">2.8. Requests</a> <a href="#ref-for-request-result-2">(2)</a>
     <li><a href="#ref-for-request-result-3">4.1. The IDBRequest interface</a> <a href="#ref-for-request-result-4">(2)</a>
     <li><a href="#ref-for-request-result-5">4.3. The IDBFactory interface</a> <a href="#ref-for-request-result-6">(2)</a>
-    <li><a href="#ref-for-request-result-7">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-request-result-8">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-result-9">(2)</a>
-    <li><a href="#ref-for-request-result-10">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-request-result-7">5.5. Aborting a transaction</a> <a href="#ref-for-request-result-8">(2)</a>
+    <li><a href="#ref-for-request-result-9">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-result-10">(2)</a>
+    <li><a href="#ref-for-request-result-11">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-error">
@@ -8840,14 +8870,14 @@ specification.</p>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-open-1">4.1. The IDBRequest interface</a>
     <li><a href="#ref-for-dom-idbfactory-open-2">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-idbfactory-open-3">(2)</a> <a href="#ref-for-dom-idbfactory-open-4">(3)</a>
-    <li><a href="#ref-for-dom-idbfactory-open-5">10. Revision History</a>
+    <li><a href="#ref-for-dom-idbfactory-open-5">10. Revision History</a> <a href="#ref-for-dom-idbfactory-open-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-idbfactory-deletedatabase">
    <b><a href="#dom-idbfactory-deletedatabase">#dom-idbfactory-deletedatabase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-deletedatabase-1">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-idbfactory-deletedatabase-2">(2)</a>
-    <li><a href="#ref-for-dom-idbfactory-deletedatabase-3">10. Revision History</a> <a href="#ref-for-dom-idbfactory-deletedatabase-4">(2)</a>
+    <li><a href="#ref-for-dom-idbfactory-deletedatabase-3">10. Revision History</a> <a href="#ref-for-dom-idbfactory-deletedatabase-4">(2)</a> <a href="#ref-for-dom-idbfactory-deletedatabase-5">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-idbfactory-cmp">

--- a/index.html
+++ b/index.html
@@ -1459,7 +1459,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Indexed Database API 2.0</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-12">12 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-15">15 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2507,8 +2507,8 @@ type <code>error</code> is fired at the request.</p>
     <aside class="note"> Requests are not typically re-used, but there are exceptions. When a <a data-link-type="dfn" href="#cursor" id="ref-for-cursor-1">cursor</a> is iterated, the success of the iteration is reported
   on the same <a data-link-type="dfn" href="#request" id="ref-for-request-15">request</a> object used to open the cursor. And when
   an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-16">upgrade transaction</a> is necessary, the same <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-1">open
-  request</a> is used for both the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-6">upgradeneeded</a></code> event and final result of the open operation itself. In both cases,
-  the request’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-5">done flag</a> will be unset then set again, and the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-2">result</a> can change. </aside>
+  request</a> is used for both the <code><a data-link-type="dfn" href="#request-upgradeneeded" id="ref-for-request-upgradeneeded-6">upgradeneeded</a></code> event and final result of the open operation itself. In some cases,
+  the request’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-5">done flag</a> will be unset then set again, and the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-2">result</a> can change or <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-2">error</a> could be set insead. </aside>
     <h4 class="heading settled" data-level="2.8.1" id="open-requests"><span class="secno">2.8.1. </span><span class="content">Open Requests</span><a class="self-link" href="#open-requests"></a></h4>
     <p>An <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport="" id="request-open-request">open request</dfn> is a special type of <a data-link-type="dfn" href="#request" id="ref-for-request-16">request</a> used
 when opening a <a data-link-type="dfn" href="#connection" id="ref-for-connection-28">connection</a> or deleting a <a data-link-type="dfn" href="#database" id="ref-for-database-29">database</a>.
@@ -3019,7 +3019,7 @@ request<span class="p">.</span>onerror <span class="o">=</span> <span class="kd"
         or <code>undefined</code> if the request failed. Throws a
         "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> if the request is still pending. 
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-error" id="ref-for-dom-idbrequest-error-2">error</a></code>
-     <dd> When a request is completed, returns the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-2">error</a> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>), or null if the request succeeded. Throws
+     <dd> When a request is completed, returns the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-3">error</a> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>), or null if the request succeeded. Throws
         a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> if the request is still pending. 
      <dt><var>request</var> . <code class="idl"><a data-link-type="idl" href="#dom-idbrequest-source" id="ref-for-dom-idbrequest-source-2">source</a></code>
      <dd> Returns the <code class="idl"><a data-link-type="idl" href="#idbobjectstore" id="ref-for-idbobjectstore-2">IDBObjectStore</a></code>, <code class="idl"><a data-link-type="idl" href="#idbindex" id="ref-for-idbindex-2">IDBIndex</a></code>, or <code class="idl"><a data-link-type="idl" href="#idbcursor" id="ref-for-idbcursor-2">IDBCursor</a></code> the request was made against, or null if is was an <a data-link-type="dfn" href="#request-open-request" id="ref-for-request-open-request-9">open
@@ -3036,7 +3036,7 @@ request<span class="p">.</span>onerror <span class="o">=</span> <span class="kd"
 unset. Otherwise, the attribute’s getter must return the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-4">result</a> of the request, or undefined if the
 request resulted in an error.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-error">error</dfn> attribute’s getter must <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> if the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-7">done flag</a> is unset.
-Otherwise, the attribute’s getter must return the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-3">error</a> of
+Otherwise, the attribute’s getter must return the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-4">error</a> of
 the request, or null if no error occurred.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBRequest" data-dfn-type="attribute" data-export="" id="dom-idbrequest-source">source</dfn> attribute’s getter must
 return the <a data-link-type="dfn" href="#request-source" id="ref-for-request-source-2">source</a> of the <a data-link-type="dfn" href="#request" id="ref-for-request-17">request</a>, or null if no <a data-link-type="dfn" href="#request-source" id="ref-for-request-source-3">source</a> is set.</p>
@@ -3171,12 +3171,13 @@ otherwise, and <var>request</var>.</p>
         <ol>
          <li data-md="">
           <p>If <var>result</var> is an error,
-set <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-4">error</a> to <var>result</var>,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-5">result</a> to undefined,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-5">error</a> to <var>result</var>,
 set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-9">done flag</a>,
 and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at <var>request</var> with its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attributes initialized to true.</p>
          <li data-md="">
           <p>Otherwise,
-set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-5">result</a> to <var>result</var>,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-6">result</a> to <var>result</var>,
 set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-10">done flag</a>,
 and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>success</code> at <var>request</var>. If the steps
 above resulted in an <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-18">upgrade transaction</a> being run,
@@ -3221,13 +3222,13 @@ to access this <code class="idl"><a data-link-type="idl" href="#idbfactory" id="
         <ol>
          <li data-md="">
           <p>If <var>result</var> is an error,
-set <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-5">error</a> to <var>result</var>,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-6">error</a> to <var>result</var>,
 set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-11">done flag</a>,
 and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at <var>request</var> with
 its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attributes initialized to true.</p>
          <li data-md="">
           <p>Otherwise,
-set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-6">result</a> to undefined,
+set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-7">result</a> to undefined,
 set <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-12">done flag</a>,
 and <a data-link-type="dfn" href="#fire-a-version-change-event" id="ref-for-fire-a-version-change-event-1">fire a version change event</a> named <code>success</code> at <a data-link-type="dfn" href="#request" id="ref-for-request-20">request</a> with <var>result</var> and
 null.</p>
@@ -5135,7 +5136,7 @@ return the <a data-link-type="dfn" href="#database" id="ref-for-database-54">dat
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="IDBTransaction" data-dfn-type="attribute" data-export="" id="dom-idbtransaction-error">error</dfn> attribute’s getter
 must return this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-62">transaction</a>'s <a data-link-type="dfn" href="#transaction-error" id="ref-for-transaction-error-1">error</a>, or null if
 none.</p>
-   <aside class="note"> If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-63">transaction</a> was aborted due to a failed <a data-link-type="dfn" href="#request" id="ref-for-request-27">request</a>, this will be the same as the <a data-link-type="dfn" href="#request" id="ref-for-request-28">request</a>'s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-6">error</a>. If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-64">transaction</a> was aborted
+   <aside class="note"> If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-63">transaction</a> was aborted due to a failed <a data-link-type="dfn" href="#request" id="ref-for-request-27">request</a>, this will be the same as the <a data-link-type="dfn" href="#request" id="ref-for-request-28">request</a>'s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-7">error</a>. If this <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-64">transaction</a> was aborted
   due to an uncaught exception in an event handler, the error will be
   a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>. If the <a data-link-type="dfn" href="#transaction-concept" id="ref-for-transaction-concept-65">transaction</a> was aborted due to
   an error while committing, it will reflect the reason for the
@@ -5215,7 +5216,7 @@ appropriate error (e.g. a "<code class="idl"><a data-link-type="idl" href="https
 "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>).</p>
      <li data-md="">
       <p>If <var>db</var>’s <a data-link-type="dfn" href="#database-version" id="ref-for-database-version-11">version</a> is greater than <var>version</var>,
-abort these steps and return a new "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#versionerror">VersionError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
+return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#versionerror">VersionError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
      <li data-md="">
       <p>Let <var>connection</var> be a new <a data-link-type="dfn" href="#connection" id="ref-for-connection-59">connection</a> to <var>db</var>.</p>
      <li data-md="">
@@ -5243,12 +5244,12 @@ event</a> named <code><a data-link-type="dfn" href="#request-blocked" id="ref-fo
        <li data-md="">
         <p>Run the steps to <a data-link-type="dfn" href="#run-an-upgrade-transaction" id="ref-for-run-an-upgrade-transaction-3">run an upgrade transaction</a> using <var>connection</var>, <var>version</var> and <var>request</var>.</p>
        <li data-md="">
-        <p>If <var>connection</var> was <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-6">closed</a>, create and
+        <p>If <var>connection</var> was <a data-link-type="dfn" href="#connection-closed" id="ref-for-connection-closed-6">closed</a>,
 return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
        <li data-md="">
         <p>If the <a data-link-type="dfn" href="#upgrade-transaction" id="ref-for-upgrade-transaction-48">upgrade transaction</a> was aborted, run the steps
 to <a data-link-type="dfn" href="#close-a-database-connection" id="ref-for-close-a-database-connection-4">close a database connection</a> with <var>connection</var>,
-create and return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
+return a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
       </ol>
      <li data-md="">
       <p>Return <var>connection</var>.</p>
@@ -5380,9 +5381,9 @@ run these steps:</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-17">done flag</a> on <var>request</var>.</p>
        <li data-md="">
-        <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-7">result</a> of <var>request</var> to undefined.</p>
+        <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-8">result</a> of <var>request</var> to undefined.</p>
        <li data-md="">
-        <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-7">error</a> of <var>request</var> to a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
+        <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-8">error</a> of <var>request</var> to a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code>.</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>error</code> at <var>request</var> with its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attributes initialized to true.</p>
       </ol>
@@ -5405,7 +5406,7 @@ run these steps:</p>
          <li data-md="">
           <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-5">transaction</a> to null.</p>
          <li data-md="">
-          <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-8">result</a> to undefined.</p>
+          <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-9">result</a> to undefined.</p>
          <li data-md="">
           <p>Unset <var>request</var>’s <a data-link-type="dfn" href="#request-done-flag" id="ref-for-request-done-flag-18">done flag</a>.</p>
         </ol>
@@ -5449,9 +5450,9 @@ created <a data-link-type="dfn" href="#request" id="ref-for-request-34">request<
           <p>If <var>result</var> is an error, then:</p>
           <ol>
            <li data-md="">
-            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-9">result</a> of <var>request</var> to undefined.</p>
+            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-10">result</a> of <var>request</var> to undefined.</p>
            <li data-md="">
-            <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-8">error</a> of <var>request</var> to <var>result</var>.</p>
+            <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-9">error</a> of <var>request</var> to <var>result</var>.</p>
            <li data-md="">
             <p><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">Fire an error event</a> at <var>request</var>.</p>
           </ol>
@@ -5459,9 +5460,9 @@ created <a data-link-type="dfn" href="#request" id="ref-for-request-34">request<
           <p>Otherwise:</p>
           <ol>
            <li data-md="">
-            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-10">result</a> of <var>request</var> to <var>result</var>.</p>
+            <p>Set the <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-11">result</a> of <var>request</var> to <var>result</var>.</p>
            <li data-md="">
-            <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-9">error</a> of <var>request</var> to undefined.</p>
+            <p>Set the <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-10">error</a> of <var>request</var> to undefined.</p>
            <li data-md="">
             <p><a data-link-type="dfn" href="#fire-a-success-event" id="ref-for-fire-a-success-event-3">Fire a success event</a> at <var>request</var>.</p>
           </ol>
@@ -5500,7 +5501,7 @@ transaction is <a data-link-type="dfn" href="#transaction-abort" id="ref-for-tra
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these steps:</p>
       <ol>
        <li data-md="">
-        <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-11">result</a> to <var>connection</var>.</p>
+        <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-result" id="ref-for-request-result-12">result</a> to <var>connection</var>.</p>
        <li data-md="">
         <p>Set <var>request</var>’s <a data-link-type="dfn" href="#request-transaction" id="ref-for-request-transaction-6">transaction</a> to <var>transaction</var>.</p>
        <li data-md="">
@@ -5634,10 +5635,10 @@ the implementation must run these steps:</p>
 run the steps to <a data-link-type="dfn" href="#abort-a-transaction" id="ref-for-abort-a-transaction-13">abort a transaction</a> with <var>transaction</var> and a newly <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">created</a> "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and terminate these steps. This is done even if the
 event’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is not set.</p>
       <aside class="note"> This means that if an error event is fired and any of the event
-  handlers throw an exception, <var>transaction</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-error" id="ref-for-dom-idbtransaction-error-3">error</a></code> property is set to an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code> rather than <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-10">error</a>, even if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a></code> is never called. </aside>
+  handlers throw an exception, <var>transaction</var>’s <code class="idl"><a data-link-type="idl" href="#dom-idbtransaction-error" id="ref-for-dom-idbtransaction-error-3">error</a></code> property is set to an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror">AbortError</a></code> rather than <var>request</var>’s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-11">error</a>, even if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a></code> is never called. </aside>
      <li data-md="">
       <p>If the event’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is not set, run the steps
-to <a data-link-type="dfn" href="#abort-a-transaction" id="ref-for-abort-a-transaction-14">abort a transaction</a> using <var>transaction</var> and <a data-link-type="dfn" href="#request" id="ref-for-request-38">request</a>'s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-11">error</a>.</p>
+to <a data-link-type="dfn" href="#abort-a-transaction" id="ref-for-abort-a-transaction-14">abort a transaction</a> using <var>transaction</var> and <a data-link-type="dfn" href="#request" id="ref-for-request-38">request</a>'s <a data-link-type="dfn" href="#request-error" id="ref-for-request-error-12">error</a>.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="5.11" id="clone-value"><span class="secno">5.11. </span><span class="content">Clone a value</span><a class="self-link" href="#clone-value"></a></h3>
@@ -8432,22 +8433,22 @@ specification.</p>
    <ul>
     <li><a href="#ref-for-request-result-1">2.8. Requests</a> <a href="#ref-for-request-result-2">(2)</a>
     <li><a href="#ref-for-request-result-3">4.1. The IDBRequest interface</a> <a href="#ref-for-request-result-4">(2)</a>
-    <li><a href="#ref-for-request-result-5">4.3. The IDBFactory interface</a> <a href="#ref-for-request-result-6">(2)</a>
-    <li><a href="#ref-for-request-result-7">5.5. Aborting a transaction</a> <a href="#ref-for-request-result-8">(2)</a>
-    <li><a href="#ref-for-request-result-9">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-result-10">(2)</a>
-    <li><a href="#ref-for-request-result-11">5.7. Running an upgrade transaction</a>
+    <li><a href="#ref-for-request-result-5">4.3. The IDBFactory interface</a> <a href="#ref-for-request-result-6">(2)</a> <a href="#ref-for-request-result-7">(3)</a>
+    <li><a href="#ref-for-request-result-8">5.5. Aborting a transaction</a> <a href="#ref-for-request-result-9">(2)</a>
+    <li><a href="#ref-for-request-result-10">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-result-11">(2)</a>
+    <li><a href="#ref-for-request-result-12">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-error">
    <b><a href="#request-error">#request-error</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-error-1">2.8. Requests</a>
-    <li><a href="#ref-for-request-error-2">4.1. The IDBRequest interface</a> <a href="#ref-for-request-error-3">(2)</a>
-    <li><a href="#ref-for-request-error-4">4.3. The IDBFactory interface</a> <a href="#ref-for-request-error-5">(2)</a>
-    <li><a href="#ref-for-request-error-6">4.9. The IDBTransaction interface</a>
-    <li><a href="#ref-for-request-error-7">5.5. Aborting a transaction</a>
-    <li><a href="#ref-for-request-error-8">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-error-9">(2)</a>
-    <li><a href="#ref-for-request-error-10">5.10. Firing an error event</a> <a href="#ref-for-request-error-11">(2)</a>
+    <li><a href="#ref-for-request-error-1">2.8. Requests</a> <a href="#ref-for-request-error-2">(2)</a>
+    <li><a href="#ref-for-request-error-3">4.1. The IDBRequest interface</a> <a href="#ref-for-request-error-4">(2)</a>
+    <li><a href="#ref-for-request-error-5">4.3. The IDBFactory interface</a> <a href="#ref-for-request-error-6">(2)</a>
+    <li><a href="#ref-for-request-error-7">4.9. The IDBTransaction interface</a>
+    <li><a href="#ref-for-request-error-8">5.5. Aborting a transaction</a>
+    <li><a href="#ref-for-request-error-9">5.6. Asynchronously executing a request</a> <a href="#ref-for-request-error-10">(2)</a>
+    <li><a href="#ref-for-request-error-11">5.10. Firing an error event</a> <a href="#ref-for-request-error-12">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-transaction">

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 5bd73bb15eb04ad9f7d1a57f012e9ee6eca5a765" name="generator">
+  <meta content="Bikeshed version edf04655cdbbf30dd4c7dbad313044553232b75a" name="generator">
   <link href="https://www.w3.org/TR/IndexedDB-2/" rel="canonical">
   <link href="logo-db.png" rel="icon">
 <style>
@@ -1467,7 +1467,7 @@ pre.idl.highlight { color: #708090; }
      <dt>Latest published version:
      <dd><a href="https://www.w3.org/TR/IndexedDB-2/">https://www.w3.org/TR/IndexedDB-2/</a>
      <dt>Previous Versions:
-     <dd><a href="https://www.w3.org/TR/IndexedDB/" rel="previous">https://www.w3.org/TR/IndexedDB/</a>
+     <dd><a href="https://www.w3.org/TR/IndexedDB/" rel="prev">https://www.w3.org/TR/IndexedDB/</a>
      <dt>Test Suite:
      <dd><a href="https://github.com/w3c/web-platform-tests/tree/master/IndexedDB">https://github.com/w3c/web-platform-tests/tree/master/IndexedDB</a>
      <dt>Issue Tracking:


### PR DESCRIPTION
For https://github.com/w3c/IndexedDB/issues/161:

* When an open or delete succeeds the done flag should be set.
* When an open fails aborts, the request's result should be cleared.

I need to verify we have WPT coverage for this.

@brettz9 - can you review?
