### PR TITLE
Use (DOMString or sequence<DOMString>) for keyPath

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2721,7 +2721,7 @@ interface represents an [=/object store handle=].
 [Exposed=(Window,Worker)]
 interface IDBObjectStore {
   attribute DOMString name;
-  readonly attribute any keyPath;
+  readonly attribute (DOMString or sequence&lt;DOMString&gt;) keyPath;
   readonly attribute DOMStringList indexNames;
   [SameObject] readonly attribute IDBTransaction transaction;
   readonly attribute boolean autoIncrement;
@@ -3824,7 +3824,7 @@ The {{IDBIndex}} interface represents an [=index handle=].
 interface IDBIndex {
   attribute DOMString name;
   [SameObject] readonly attribute IDBObjectStore objectStore;
-  readonly attribute any keyPath;
+  readonly attribute (DOMString or sequence&lt;DOMString&gt;) keyPath;
   readonly attribute boolean multiEntry;
   readonly attribute boolean unique;
 


### PR DESCRIPTION
Fixes #235 

[Per the spec](https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-keypath):

>The key path is converted as a DOMString (if a string) or a sequence<DOMString> (if a list of strings), per [WEBIDL].
