### PR TITLE
WindowOrWorkerGlobalScope is a mixin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2165,7 +2165,7 @@ interface is present in the global scope of environments that support
 Indexed DB operations.
 
 <pre class=idl>
-partial interface WindowOrWorkerGlobalScope {
+partial interface mixin WindowOrWorkerGlobalScope {
   [SameObject] readonly attribute IDBFactory indexedDB;
 };
 </pre>


### PR DESCRIPTION
...and so extensions should use [`partial interface mixin`](https://heycam.github.io/webidl/#partial-interface-mixin) rather than `interface mixin`.

See also https://github.com/whatwg/html/pull/3650