### PR TITLE
`abort()` to set transaction state to inactive

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5266,7 +5266,7 @@ must run these steps:
     or [=transaction/finished=],
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Set the [=/transaction=]'s [=transaction/state=] to [=transaction/active=] and run the
+1. Set the [=/transaction=]'s [=transaction/state=] to [=transaction/inactive=] and run the
     steps to [=abort a transaction=] with null as |error|.
 
 </div>


### PR DESCRIPTION
Closes #???

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brettz9/IndexedDB/pull/258.html" title="Last updated on Mar 21, 2019, 7:31 AM UTC (7cfb189)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/258/318c6ec...brettz9:7cfb189.html" title="Last updated on Mar 21, 2019, 7:31 AM UTC (7cfb189)">Diff</a>