### PR TITLE
chore(w3c.json): switch to WebAppsWG

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      83482
+    "group":      114929
 ,   "contacts":   ["siusin"]
 ,   "policy":     "open"
 ,   "repo-type":  "rec-track"


### PR DESCRIPTION
Just a heads up that this repo is now moving to the new WebAppsWG. While this is happening over next few days, and folks are joining the new working group, any IPR bot might get upset if you try to merge any pull requests.
