### PR TITLE
Editorial: Fix _includes link, add note.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4361,6 +4361,10 @@ interface IDBKeyRange {
 };
 </xmp>
 
+<aside class=note>
+Note: When mapping the `_includes` identifier from [[WEBIDL]] to ECMAScript, the leading U+005F LOW LINE ("_") character is removed. A leading "_" is used to escape the identifier from looking like a reserved word (in this case, the `includes` keyword).
+</aside>
+
 <div class=note>
   <dl class=domintro>
     <dt><var>range</var> . {{IDBKeyRange/lower}}</dt>
@@ -4517,7 +4521,7 @@ The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|,
 
 <div class=algorithm>
 
-The <dfn method for=IDBKeyRange>includes(|key|)</dfn> method, when
+The <dfn method for=IDBKeyRange lt="_includes(key)|includes(key)">includes(|key|)</dfn> method, when
 invoked, must run these steps:
 
 1. Let |k| be the result of running the steps to [=convert a


### PR DESCRIPTION
"includes" is reserved word in WebIDL, so a method with that name
needs to be escaped with a leading underscore in IDL fragments.
This confuses Bikeshed (tabatkins/bikeshed#1489) so manually
correct the link. Also, the 2.0 version of the IDB spec had a note
which gave context for this; transplant that to the 3.0 version.

Resolves #270


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/273.html" title="Last updated on Jun 7, 2019, 12:19 AM UTC (7d837ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/273/d401d30...7d837ef.html" title="Last updated on Jun 7, 2019, 12:19 AM UTC (7d837ef)">Diff</a>