### PR TITLE
Editorial: Simplify 'steps to'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -478,7 +478,7 @@ it hasn't already been.
 A [=/connection=] may be closed by a user agent in exceptional
 circumstances, for example due to loss of access to the file system, a
 permission change, or clearing of the origin's storage. If this occurs
-the user agent must run the steps to [=close a database
+the user agent must run [=close a database
 connection=] with the [=/connection=] and with the |forced flag| set.
 
 A [=/connection=] has an <dfn>object store set</dfn>, which is
@@ -726,7 +726,7 @@ To <dfn>compare two keys</dfn> |a| and |b|, run these steps:
 
             1. Let |u| be the [=/key=] in |va| at index |i|.
             1. Let |v| be the [=/key=] in |vb| at index |i|.
-            1. Let |c| be the result of recursively running the steps to [=compare two keys=] with |u| and |v|.
+            1. Let |c| be the result of recursively running [=compare two keys=] with |u| and |v|.
             1. If |c| is not 0, return |c|.
             1. Increase |i| by 1.
 
@@ -739,15 +739,15 @@ To <dfn>compare two keys</dfn> |a| and |b|, run these steps:
 </div>
 
 The [=/key=] |a| is <dfn lt="greater than|ascending">greater than</dfn> the [=/key=] |b| if the
-result of running the steps to [=compare two keys=] with |a| and |b|
+result of running [=compare two keys=] with |a| and |b|
 is 1.
 
 The [=/key=] |a| is <dfn>less than</dfn> the [=/key=] |b| if the
-result of running the steps to [=compare two keys=] with |a| and |b|
+result of running [=compare two keys=] with |a| and |b|
 is -1.
 
 The [=/key=] |a| is <dfn>equal to</dfn> the [=/key=] |b| if the result
-of running the steps to [=compare two keys=] with |a| and |b| is 0.
+of running [=compare two keys=] with |a| and |b| is 0.
 
 <aside class=note>
   As a result of the above rules, negative infinity is the lowest
@@ -1122,7 +1122,7 @@ the case even if the transaction has not yet been
 requests; however, the implementation must keep track of the
 [=/requests=] and their order.
 
-To <dfn id=cleanup-indexed-database-transactions export>cleanup Indexed Database transactions</dfn>, run these steps.
+To <dfn id=cleanup-indexed-database-transactions export>cleanup Indexed Database transactions</dfn>, run the following steps.
 They will return true if any transactions were cleaned up, or false otherwise.
 
 <div class=algorithm>
@@ -1424,9 +1424,8 @@ range=].
 
 <div class=algorithm>
 
-The steps to <dfn>convert a value to a key range</dfn> with
-|value| and optional |null disallowed flag| are as
-follows:
+To <dfn>convert a value to a key range</dfn> with
+|value| and optional |null disallowed flag|, run these steps:
 
 1. If |value| is a [=key range=], return |value|.
 
@@ -1434,7 +1433,7 @@ follows:
     "{{DataError}}" {{DOMException}} if |null disallowed flag| is set, or return an
     [=unbounded key range=] otherwise.
 
-1. Let |key| be the result of running the steps to [=convert
+1. Let |key| be the result of running [=convert
     a value to a key=] with |value|. Rethrow any exceptions.
 
 1. If |key| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -2300,7 +2299,7 @@ when invoked, must run these steps:
 
 1. Run these steps [=in parallel=]:
 
-    1. Let |result| be the result of running the steps to
+    1. Let |result| be the result of running
         [=open a database=], with |origin|,
         |name|, |version| if given and undefined
         otherwise, and |request|.
@@ -2317,7 +2316,7 @@ when invoked, must run these steps:
 
     1. [=Queue a task=] to run these steps:
 
-        1. If |result| is an error, then run these steps:
+        1. If |result| is an error, then:
 
             1. Set |request|'s [=request/result=] to undefined.
             1. Set |request|'s [=request/error=] to |result|.
@@ -2325,7 +2324,7 @@ when invoked, must run these steps:
             1. [=Fire an event=] named <a event>`error`</a> at |request| with its
                 {{Event/bubbles}} and {{Event/cancelable}} attributes initialized to true.
 
-        1. Otherwise, run these steps:
+        1. Otherwise:
 
             1. Set |request|'s [=request/result=] to |result|.
             1. Set |request|'s [=request/done flag=].
@@ -2371,7 +2370,7 @@ when invoked, must run these steps:
 
 1. Run these steps [=in parallel=]:
 
-    1. Let |result| be the result of running the steps to
+    1. Let |result| be the result of running
         [=delete a database=], with |origin|,
         |name|, and |request|.
 
@@ -2473,17 +2472,17 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>cmp(|first|, |second|)</dfn> method,
 when invoked, must run these steps:
 
-1. Let |a| be the result of running the steps to [=convert a
+1. Let |a| be the result of running [=convert a
     value to a key=] with |first|. Rethrow any exceptions.
 
 1. If |a| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Let |b| be the result of running the steps to [=convert a
+1. Let |b| be the result of running [=convert a
     value to a key=] with |second|. Rethrow any exceptions.
 
 1. If |b| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Return the results of running the steps to [=compare two keys=]
+1. Return the results of running [=compare two keys=]
     with |a| and |b|.
 
 </div>
@@ -2786,7 +2785,7 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|,
 The <dfn method for=IDBDatabase>close()</dfn> method, when invoked,
 must run these steps:
 
-1. Run the steps to [=close a database connection=] with this
+1. Run [=close a database connection=] with this
     [=/connection=].
 
 </div>
@@ -3037,19 +3036,18 @@ and false otherwise.
 
 
 The <dfn method for=IDBObjectStore>put(|value|, |key|)</dfn> method,
-when invoked, must return the result of running the steps to [=add or
+when invoked, must return the result of running [=add or
 put=] with this [=/object store handle=], |value|, |key| and the
 |no-overwrite flag| unset.
 
 The <dfn method for=IDBObjectStore>add(|value|, |key|)</dfn> method,
-when invoked, must return the result of running the steps to [=add or
+when invoked, must return the result of running [=add or
 put=] with this [=/object store handle=], |value|, |key| and the
 |no-overwrite flag| set.
 
 <div class=algorithm>
 
-The steps to <dfn>add or put</dfn> are as follows. The algorithm
-takes four arguments: |handle|, |value|, |key|, and |no-overwrite flag|.
+To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|, run these steps:
 
 1. Let |transaction| be |handle|'s
     [=object-store-handle/transaction=].
@@ -3075,7 +3073,7 @@ takes four arguments: |handle|, |value|, |key|, and |no-overwrite flag|.
 
 1. If |key| was given, then:
 
-    1. Let |r| be the result of running the steps to [=convert a
+    1. Let |r| be the result of running [=convert a
         value to a key=] with |key|. Rethrow any exceptions.
 
     1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -3097,7 +3095,7 @@ takes four arguments: |handle|, |value|, |key|, and |no-overwrite flag|.
 
 1. If |store| uses [=in-line keys=], then:
 
-    1. Let |kpk| be the result of running the steps to [=extract a
+    1. Let |kpk| be the result of running [=extract a
         key from a value using a key path=] with |clone| and
         |store|'s [=object-store/key path=]. Rethrow any
         exceptions.
@@ -3111,15 +3109,15 @@ takes four arguments: |handle|, |value|, |key|, and |no-overwrite flag|.
         1. If |store| does not have a [=key generator=], [=throw=]
             a "{{DataError}}" {{DOMException}}.
 
-        1. Otherwise, if the steps to
+        1. Otherwise, if
             [=check that a key could be injected into a value=] with
-            |clone| and  |store|'s [=object-store/key path=] return
+            |clone| and |store|'s [=object-store/key path=] return
             false, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with |handle| as |source| and the
-    steps to [=store a record into an object store=] as
+    run with |handle| as |source| and
+    [=store a record into an object store=] as
     |operation|, using |store|, the |clone| as |value|, |key|, and
     |no-overwrite flag|.
 
@@ -3145,14 +3143,14 @@ invoked, must run these steps:
 1. If |transaction| is a [=read-only transaction=],
     [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
     run with this [=/object store handle=] as |source| and
-    the steps to [=delete records from an object store=] as
+    [=delete records from an object store=] as
     |operation|, using |store| and |range|.
 
 </div>
@@ -3188,10 +3186,10 @@ must run these steps:
 1. If |transaction| is a [=read-only transaction=],
     [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
     run with this [=/object store handle=] as |source| and
-    the steps to [=clear an object store=] as
+    [=clear an object store=] as
     |operation|, using |store|.
 
 
@@ -3279,14 +3277,14 @@ invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
       return the {{IDBRequest}} created by these steps. The steps
       are run with this [=/object store handle=] as
-      |source| and the steps to [=retrieve a value from
+      |source| and [=retrieve a value from
       an object store=] as |operation|, using the
       [=current Realm=] as |targetRealm|,
       |store| and |range|.
@@ -3325,14 +3323,14 @@ invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
       return the {{IDBRequest}} created by these steps. The steps
       are run with this [=/object store handle=] as
-      |source| and the steps to [=retrieve a key from an
+      |source| and [=retrieve a key from an
       object store=] as |operation|, using |store|
       and |range|.
 
@@ -3361,14 +3359,14 @@ method, when invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and the
-    steps to [=retrieve multiple values from an object store=]
+    run with this [=/object store handle=] as |source| and
+    [=retrieve multiple values from an object store=]
     as |operation|, using the [=current Realm=] as |targetRealm|,
     |store|, |range|, and |count| if given.
 
@@ -3398,14 +3396,14 @@ method, when invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and the
-    steps to [=retrieve multiple keys from an object store=] as
+    run with this [=/object store handle=] as |source| and
+    [=retrieve multiple keys from an object store=] as
     |operation|, using |store|, |range|, and |count| if given.
 
 </div>
@@ -3434,14 +3432,14 @@ invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and the
-    steps to [=count the records in a range=] as |operation|, with
+    run with this [=/object store handle=] as |source| and
+    [=count the records in a range=] as |operation|, with
     |source| and |range|.
 
 </div>
@@ -3504,7 +3502,7 @@ The <dfn method for=IDBObjectStore>openCursor(|query|,
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
@@ -3515,9 +3513,9 @@ The <dfn method for=IDBObjectStore>openCursor(|query|,
     [=cursor/value=]. The [=cursor/source=] of |cursor| is
     |store|. The [=cursor/range=] of |cursor| is |range|.
 
-1. Let |request| be the result of running the steps to
+1. Let |request| be the result of running
     [=asynchronously execute a request=] with this [=/object store
-    handle=] as |source| and the steps to [=iterate a cursor=] as
+    handle=] as |source| and [=iterate a cursor=] as
     |operation|, using the [=current Realm=] as |targetRealm|, and
     |cursor|.
 
@@ -3549,7 +3547,7 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|,
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
@@ -3564,9 +3562,9 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|,
     |range|. The [=key only flag=] of |cursor| is
     set.
 
-1. Let |request| be the result of running the steps to
+1. Let |request| be the result of running
     [=asynchronously execute a request=] with this [=/object store
-    handle=] as |source| and the steps to [=iterate a cursor=] as
+    handle=] as |source| and [=iterate a cursor=] as
     |operation|, using the [=current Realm=] as |targetRealm|, and
     |cursor|.
 
@@ -4038,14 +4036,14 @@ must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
       return the {{IDBRequest}} created by these steps. The steps
       are run with this [=index handle=] as |source| and
-      the steps to [=retrieve a referenced value from an index=]
+      [=retrieve a referenced value from an index=]
       as |operation|, using the [=current Realm=] as |targetRealm|,
       |index| and |range|.
 
@@ -4084,13 +4082,13 @@ invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to [=convert a
+1. Let |range| be the result of running [=convert a
     value to a key range=] with |query| and |null disallowed flag|
     set. Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and the steps to
+    run with this [=index handle=] as |source| and
     [=retrieve a value from an index=] as |operation|, using |index|
     and |range|.
 
@@ -4119,13 +4117,13 @@ when invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and the steps to
+    run with this [=index handle=] as |source| and
     [=retrieve multiple referenced values from an index=] as
     |operation|, using the [=current Realm=] as |targetRealm|,
     |index|, |range|, and |count| if given.
@@ -4156,13 +4154,13 @@ method, when invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and the steps to
+    run with this [=index handle=] as |source| and
     [=retrieve multiple values from an index=] as |operation|, using
     |index|, |range|, and |count| if given.
 
@@ -4192,13 +4190,13 @@ invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and the steps to
+    run with this [=index handle=] as |source| and
     [=count the records in a range=] as |operation|, with
     [=/index=] as |source| and |range|.
 
@@ -4261,7 +4259,7 @@ method, when invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
@@ -4272,9 +4270,9 @@ method, when invoked, must run these steps:
     [=cursor/value=]. The [=cursor/source=] of |cursor| is
     |index|. The [=cursor/range=] of |cursor| is |range|.
 
-1. Let |request| be the result of running the steps to
+1. Let |request| be the result of running
     [=asynchronously execute a request=] with this [=index handle=] as
-    |source| and the steps to [=iterate a cursor=] as |operation|,
+    |source| and [=iterate a cursor=] as |operation|,
     using the [=current Realm=] as |targetRealm|, and |cursor|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
@@ -4305,7 +4303,7 @@ method, when invoked, must run these steps:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running the steps to
+1. Let |range| be the result of running
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
@@ -4317,9 +4315,9 @@ method, when invoked, must run these steps:
     |index|. The [=cursor/range=] of |cursor| is |range|. The [=key only
     flag=] of |cursor| is set.
 
-1. Let |request| be the result of running the steps to
+1. Let |request| be the result of running
     [=asynchronously execute a request=] with this [=index handle=] as
-    |source| and the steps to [=iterate a cursor=] as |operation|,
+    |source| and [=iterate a cursor=] as |operation|,
     using the [=current Realm=] as |targetRealm|, and |cursor|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
@@ -4388,11 +4386,11 @@ Note: When mapping the `_includes` identifier from [[WEBIDL]] to ECMAScript, the
 </div>
 
 The <dfn attribute for=IDBKeyRange>lower</dfn> attribute's getter must
-return result of running the steps to [=convert a key to a value=]
+return result of running [=convert a key to a value=]
 with the [=lower bound=] if it is not null, or undefined otherwise.
 
 The <dfn attribute for=IDBKeyRange>upper</dfn> attribute's getter must
-return the result of running the steps to [=convert a key to a
+return the result of running [=convert a key to a
 value=] with the [=upper bound=] if it is not null, or undefined
 otherwise.
 
@@ -4441,7 +4439,7 @@ otherwise.
 The <dfn method for=IDBKeyRange>only(|value|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |key| be the result of running the steps to [=convert
+1. Let |key| be the result of running [=convert
     a value to a key=] with |value|. Rethrow any exceptions.
 
 1. If |key| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4456,7 +4454,7 @@ invoked, must run these steps:
 The <dfn method for=IDBKeyRange>lowerBound(|lower|, |open|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |lowerKey| be the result of running the steps to [=convert a
+1. Let |lowerKey| be the result of running [=convert a
     value to a key=] with |lower|. Rethrow any exceptions.
 
 1. If |lowerKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4473,7 +4471,7 @@ method, when invoked, must run these steps:
 The <dfn method for=IDBKeyRange>upperBound(|upper|, |open|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |upperKey| be the result of running the steps to [=convert a
+1. Let |upperKey| be the result of running [=convert a
     value to a key=] with |upper|. Rethrow any exceptions.
 
 1. If |upperKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4489,12 +4487,12 @@ method, when invoked, must run these steps:
 The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|,
 |upperOpen|)</dfn> method, when invoked, must run these steps:
 
-1. Let |lowerKey| be the result of running the steps to [=convert a
+1. Let |lowerKey| be the result of running [=convert a
     value to a key=] with |lower|. Rethrow any exceptions.
 
 1. If |lowerKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Let |upperKey| be the result of running the steps to [=convert a
+1. Let |upperKey| be the result of running [=convert a
     value to a key=] with |upper|. Rethrow any exceptions.
 
 1. If |upperKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4524,7 +4522,7 @@ The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|,
 The <dfn method for=IDBKeyRange lt="_includes(key)|includes(key)">includes(|key|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |k| be the result of running the steps to [=convert a
+1. Let |k| be the result of running [=convert a
     value to a key=] with |key|. Rethrow any exceptions.
 
 1. If |k| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4611,7 +4609,7 @@ The <dfn attribute for=IDBCursor>direction</dfn> attribute's getter
 must return the [=cursor/direction=] of the [=cursor=].
 
 The <dfn attribute for=IDBCursor>key</dfn> attribute's getter must
-return the result of running the steps to [=convert a key to a
+return the result of running [=convert a key to a
 value=] with the cursor's current [=cursor/key=]. Note that
 if this property returns an object (e.g. a [=Date=] or
 [=Array=]), it returns the same object instance every time it is
@@ -4621,7 +4619,7 @@ by anyone inspecting the value of the cursor. However modifying such
 an object does not modify the contents of the database.
 
 The <dfn attribute for=IDBCursor>primaryKey</dfn> attribute's getter
-must return the result of running the steps to [=convert a key to a
+must return the result of running [=convert a key to a
 value=] with the cursor's current [=effective key=]. Note that if
 this property returns an object (e.g. a [=Date=] or [=Array=]),
 it returns the same object instance every time it is inspected, until
@@ -4709,9 +4707,9 @@ invoked, must run these steps:
 
 1. Unset |request|'s [=request/processed flag=] and [=request/done flag=].
 
-1. Run the steps to [=asynchronously execute a request=] with
-    the cursor's [=cursor/source=] as |source|, the steps
-    to [=iterate a cursor=] as |operation| and |request|, using
+1. Run [=asynchronously execute a request=] with
+    the cursor's [=cursor/source=] as |source|,
+    [=iterate a cursor=] as |operation| and |request|, using
     the [=current Realm=] as |targetRealm|, this [=cursor=] and |count|.
 
 </div>
@@ -4746,7 +4744,7 @@ invoked, must run these steps:
 
 1. If |key| is given, then:
 
-    1. Let |r| be the result of running the steps to [=convert a
+    1. Let |r| be the result of running [=convert a
         value to a key=] with |key|. Rethrow any exceptions.
 
     1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4767,9 +4765,9 @@ invoked, must run these steps:
 
 1. Unset |request|'s [=request/processed flag=] and [=request/done flag=].
 
-1. Run the steps to [=asynchronously execute a request=] with
-    the cursor's [=cursor/source=] as |source|, the steps
-    to [=iterate a cursor=] as |operation| and |request|,
+1. Run [=asynchronously execute a request=] with
+    the cursor's [=cursor/source=] as |source|,
+    [=iterate a cursor=] as |operation| and |request|,
     using the [=current Realm=] as |targetRealm|,
     this [=cursor=] and |key| (if given).
 
@@ -4808,14 +4806,14 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
     the cursor is being iterated or has iterated past its end,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Let |r| be the result of running the steps to [=convert a value to
+1. Let |r| be the result of running [=convert a value to
     a key=] with |key|. Rethrow any exceptions.
 
 1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 1. Let |key| be |r|.
 
-1. Let |r| be the result of running the steps to [=convert a value
+1. Let |r| be the result of running [=convert a value
      to a key=] with |primaryKey|. Rethrow any exceptions.
 
 1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4847,9 +4845,9 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 
 1. Unset |request|'s [=request/processed flag=] and [=request/done flag=].
 
-1. Run the steps to [=asynchronously execute a request=] with
-    the cursor's [=cursor/source=] as |source|, the steps
-    to [=iterate a cursor=] as |operation| and |request|,
+1. Run [=asynchronously execute a request=] with
+    the cursor's [=cursor/source=] as |source|,
+    [=iterate a cursor=] as |operation| and |request|,
     using the [=current Realm=] as |targetRealm|,
     this [=cursor=], |key| and |primaryKey|.
 
@@ -4934,7 +4932,7 @@ invoked, must run these steps:
 1. If the [=effective object store=] of this cursor uses [=in-line
     keys=], then:
 
-    1. Let |kpk| be the result of running the steps to
+    1. Let |kpk| be the result of running
         [=extract a key from a value using a key path=] with
         |clone| and the [=object-store/key
         path=] of the [=effective object store=].
@@ -4944,9 +4942,9 @@ invoked, must run these steps:
         the cursor's [=effective key=], [=throw=] a
         "{{DataError}}" {{DOMException}}.
 
-1. Run the steps to [=asynchronously execute a request=] and return
+1. Run [=asynchronously execute a request=] and return
     the {{IDBRequest}} created by these steps. The steps are run with
-    this [=cursor=] as |source| and the steps to [=store a
+    this [=cursor=] as |source| and [=store a
     record into an object store=] as |operation|, using this
     cursor's [=effective object store=] as |store|, the |clone| as
     |value|, this cursor's [=effective key=] as |key|, and with the
@@ -4985,9 +4983,9 @@ must run these steps:
 1. If this cursor's [=key only flag=] is set, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
-1. Run the steps to [=asynchronously execute a request=] and
+1. Run [=asynchronously execute a request=] and
     return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=cursor=] as |source| and the steps to
+    run with this [=cursor=] as |source| and
     [=delete records from an object store=] as |operation|, using
     this cursor's [=effective object store=] and [=effective
     key=] as |store| and |key| respectively.
@@ -5201,8 +5199,8 @@ must run these steps:
     or [=transaction/finished=],
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Set the [=/transaction=]'s [=transaction/state=] to [=transaction/inactive=] and run the
-    steps to [=abort a transaction=] with null as |error|.
+1. Set the [=/transaction=]'s [=transaction/state=] to [=transaction/inactive=] and run
+    [=abort a transaction=] with null as |error|.
 
 </div>
 
@@ -5214,7 +5212,7 @@ must run these steps:
 1. If this [=/transaction=]'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Run the steps to [=commit a transaction=] with this [=/transaction=].
+1. Run [=commit a transaction=] with this [=/transaction=].
 
 </div>
 
@@ -5262,10 +5260,7 @@ event handler for the <a event>`error`</a> event.
 
 <div class=algorithm>
 
-The steps to <dfn>open a database</dfn> are as follows.
-The algorithm in these steps takes four arguments:
-the |origin| which requested the [=database=] to be opened, a
-database |name|, a database |version|, and a |request|.
+To <dfn>open a database</dfn> with |origin| which requested the [=database=] to be opened, a database |name|, a database |version|, and a |request|, run these steps:
 
 1. Let |queue| be the [=connection queue=] for |origin| and |name|.
 
@@ -5321,7 +5316,7 @@ database |name|, a database |version|, and a |request|.
         [=/connections=] in |openConnections| are
         [=connection/closed=].
 
-    1. Run the steps to [=run an upgrade transaction=]
+    1. Run [=run an upgrade transaction=]
         using |connection|, |version| and |request|.
 
     1. If |connection| was [=connection/closed=],
@@ -5343,14 +5338,13 @@ database |name|, a database |version|, and a |request|.
 
 <div class=algorithm>
 
-The steps to <dfn>close a database connection</dfn> are as follows.
-These steps take two arguments, a |connection| object, and an
-optional |forced flag|.
+To <dfn>close a database connection</dfn> with a |connection| object, and an
+optional |forced flag|, run these steps:
 
 1. Set |connection|'s [=close pending flag=].
 
 1. If the |forced flag| is set, then for each |transaction|
-    [=transaction/created=] using |connection| run the steps to [=abort a
+    [=transaction/created=] using |connection| run [=abort a
     transaction=] with |transaction| and newly <a for=exception>created</a>
     "{{AbortError}}" {{DOMException}}.
 
@@ -5391,10 +5385,9 @@ optional |forced flag|.
 
 <div class=algorithm>
 
-The steps to <dfn>delete a database</dfn> are as follows. The
-algorithm in these steps takes three arguments: the |origin| that
+To <dfn>delete a database</dfn> with the |origin| that
 requested the [=database=] to be deleted, a database |name|, and a
-|request|.
+|request|, run these steps:
 
 1. Let |queue| be the [=connection queue=] for |origin| and |name|.
 
@@ -5447,8 +5440,7 @@ requested the [=database=] to be deleted, a database |name|, and a
 
 <div class=algorithm>
 
-The steps to <dfn>commit a transaction</dfn> are as follows.
-This algorithm takes one argument, the |transaction| to commit.
+To <dfn>commit a transaction</dfn> with the |transaction| to commit, run these steps:
 
 1. Set |transaction|'s [=transaction/state=] to [=transaction/committing=].
 
@@ -5463,8 +5455,7 @@ This algorithm takes one argument, the |transaction| to commit.
     1. Attempt to write any outstanding changes made by |transaction| to the [=database=].
 
     1. If an error occurs while writing the changes to the [=database=],
-        then run the steps
-        to [=abort a transaction=] with |transaction| and an
+        then run [=abort a transaction=] with |transaction| and an
         appropriate type for the error, for example "{{QuotaExceededError}}" or
         "{{UnknownError}}" {{DOMException}}, and terminate these steps.
 
@@ -5498,9 +5489,7 @@ This algorithm takes one argument, the |transaction| to commit.
 
 <div class=algorithm>
 
-The steps to <dfn>abort a transaction</dfn> are as follows.
-This algorithm
-takes two arguments: the |transaction| to abort, and |error|.
+To <dfn>abort a transaction</dfn> with the |transaction| to abort, and |error|, run these steps:
 
 1. All the changes made to the [=database=] by the [=/transaction=]
     are reverted. For [=/upgrade transactions=] this includes changes
@@ -5567,10 +5556,7 @@ takes two arguments: the |transaction| to abort, and |error|.
 
 <div class=algorithm>
 
-The steps to <dfn>asynchronously execute a request</dfn> are as follows.
-The
-algorithm takes a |source| object and an |operation| to perform on a
-database, and an optional |request|.
+To <dfn>asynchronously execute a request</dfn> with the |source| object and an |operation| to perform on a database, and an optional |request|, run these steps:
 
 These steps can be aborted at any point if the [=/transaction=] the
 created [=/request=] belongs to is [=transaction/aborted=] using the steps to
@@ -5594,7 +5580,7 @@ created [=/request=] belongs to is [=transaction/aborted=] using the steps to
     1. Let |result| be the result of performing |operation|.
 
     1. If |result| is an error and |transaction|'s [=transaction/state=] is [=committing=],
-        then run the steps to [=abort a transaction=] with |transaction| and |error|,
+        then run [=abort a transaction=] with |transaction| and |error|,
         and terminate these steps.
 
     1. If |result| is an error,
@@ -5636,10 +5622,9 @@ created [=/request=] belongs to is [=transaction/aborted=] using the steps to
 
 <div class=algorithm>
 
-The steps to <dfn>run an upgrade transaction</dfn> are as
-follows. This algorithm takes three arguments: a |connection| object
+To <dfn>run an upgrade transaction</dfn> with a |connection| object
 which is used to update the [=database=], a new |version| to be set
-for the [=database=], and a |request|.
+for the [=database=], and a |request|, run these steps:
 
 1. Let |db| be |connection|'s [=database=].
 
@@ -5674,12 +5659,12 @@ for the [=database=], and a |request|.
     1. Set |request|'s [=request/transaction=] to |transaction|.
     1. Set |request|'s [=request/done flag=].
     1. Set |transaction|'s [=transaction/state=] to [=transaction/active=].
-    1. Let |didThrow| be the result of running the steps to
+    1. Let |didThrow| be the result of running
         [=fire a version change event=] named
         <a event>`upgradeneeded`</a> at |request| with |old
         version| and |version|.
     1. Set |transaction|'s [=transaction/state=] to [=transaction/inactive=].
-    1. If |didThrow| is set, run the steps to [=abort a
+    1. If |didThrow| is set, run [=abort a
         transaction=] with the |error| property set to a newly
         <a for=exception>created</a> "{{AbortError}}" {{DOMException}}.
 
@@ -5701,8 +5686,7 @@ for the [=database=], and a |request|.
 
 <div class=algorithm>
 
-The steps to <dfn>abort an upgrade transaction</dfn> with |transaction|
-are as follows.
+To <dfn>abort an upgrade transaction</dfn> with |transaction|, run these steps:
 
 <aside class=note>
   These steps are run as needed by the steps to [=abort a
@@ -5816,17 +5800,17 @@ the implementation must run these steps:
 1. [=Dispatch=] |event| at |request| with |legacyOutputDidListenersThrowFlag|.
 
 1. If |transaction|'s [=transaction/state=] is [=transaction/active=],
-    then run these steps:
+    then:
 
     1. Set |transaction|'s [=transaction/state=] to [=transaction/inactive=].
 
     1. If |legacyOutputDidListenersThrowFlag| is set,
-        then run the steps to [=abort a transaction=] with
+        then run [=abort a transaction=] with
         |transaction| and a newly <a for=exception>created</a>
         "{{AbortError}}" {{DOMException}}.
 
     1. If |transaction|'s [=transaction/request list=] is empty,
-        then run the steps to [=commit a transaction=] with |transaction|.
+        then run [=commit a transaction=] with |transaction|.
 
 </div>
 
@@ -5856,12 +5840,12 @@ the implementation must run these steps:
 1. [=Dispatch=] |event| at [=/request=] with |legacyOutputDidListenersThrowFlag|.
 
 1. If |transaction|'s [=transaction/state=] is [=transaction/active=],
-    then run these steps:
+    then:
 
     1. Set |transaction|'s [=transaction/state=] to [=transaction/inactive=].
 
     1. If |legacyOutputDidListenersThrowFlag| is set,
-        then run the steps to [=abort a transaction=] with
+        then run [=abort a transaction=] with
         |transaction| and a newly <a for=exception>created</a>
         "{{AbortError}}" {{DOMException}} and terminate these steps.
         This is done even if the event's [=canceled flag=] is not set.
@@ -5875,12 +5859,12 @@ the implementation must run these steps:
         </aside>
 
     1. If the event's [=canceled flag=] is not set,
-        then run the steps to [=abort a transaction=] using
+        then run [=abort a transaction=] using
         |transaction| and [=/request=]'s [=request/error=], and
         terminate these steps.
 
     1. If |transaction|'s [=transaction/request list=] is empty,
-        then run the steps to [=commit a transaction=] with |transaction|.
+        then run [=commit a transaction=] with |transaction|.
 
 </div>
 
@@ -5924,27 +5908,26 @@ a request=].
 
 <div class=algorithm>
 
-The steps to <dfn>store a record into an object store</dfn> with
-|store|, |value|, an optional |key|, and a |no-overwrite flag| are as
-follows.
+To <dfn>store a record into an object store</dfn> with
+|store|, |value|, an optional |key|, and a |no-overwrite flag|, run these steps:
 
 1. If |store| uses a [=key generator=], then:
 
     1. If |key| is undefined, then:
 
-        1. Let |key| be the result of running the steps to
+        1. Let |key| be the result of running
             [=generate a key=] for |store|.
 
         1. If |key| is failure, then this operation failed with a
             "{{ConstraintError}}" {{DOMException}}. Abort this
             algorithm without taking any further steps.
 
-        1. If |store| also uses [=in-line keys=], then run the
-            steps to [=inject a key into a value using a key path=]
+        1. If |store| also uses [=in-line keys=], then run
+            [=inject a key into a value using a key path=]
             with |value|, |key| and |store|'s [=object-store/key
             path=].
 
-    1. Otherwise, run the steps to [=possibly update the key generator=]
+    1. Otherwise, run [=possibly update the key generator=]
         for |store| with |key|.
 
 1. If the |no-overwrite flag| was given to these steps and is set, and
@@ -5953,8 +5936,8 @@ follows.
     Abort this algorithm without taking any further steps.
 
 1. If a [=object-store/record=] already exists in |store| with its key [=equal
-    to=] |key|, then remove the [=object-store/record=] from |store| using the
-    steps to [=delete records from an object store=].
+    to=] |key|, then remove the [=object-store/record=] from |store| using
+    [=delete records from an object store=].
 
 1. Store a record in |store| containing |key| as its key and
     [=!=] <a abstract-op>StructuredSerializeForStorage</a>(|value|)
@@ -5964,7 +5947,7 @@ follows.
 
 1. For each |index| which [=references=] |store|:
 
-    1. Let |index key| be the result of running the steps to
+    1. Let |index key| be the result of running
         [=extract a key from a value using a key path=] with
         |value|, |index|'s [=index/key path=], and |index|'s
         [=multiEntry flag=].
@@ -6031,8 +6014,8 @@ follows.
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve a value from an object store</dfn> with
-|targetRealm|, |store| and |range| are as follows:
+To <dfn>retrieve a value from an object store</dfn> with
+|targetRealm|, |store| and |range|, run these steps:
 
 1. Let |record| be the first [=object-store/record=] in |store|'s
     [=object-store/list of records=] whose [=/key=] is [=in=] |range|, if
@@ -6049,8 +6032,8 @@ The steps to <dfn>retrieve a value from an object store</dfn> with
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve multiple values from an object
-store</dfn> with |targetRealm|, |store|, |range| and optional |count| are as follows:
+To <dfn>retrieve multiple values from an object
+store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these steps:
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 
@@ -6073,8 +6056,8 @@ store</dfn> with |targetRealm|, |store|, |range| and optional |count| are as fol
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve a key from an object store</dfn> with
-|store| and |range| are as follows:
+To <dfn>retrieve a key from an object store</dfn>
+with |store| and |range|, run these steps:
 
 1. Let |record| be the first [=object-store/record=] in |store|'s
     [=object-store/list of records=] whose [=/key=] is [=in=] |range|, if
@@ -6082,7 +6065,7 @@ The steps to <dfn>retrieve a key from an object store</dfn> with
 
 1. If |record| was not found, return undefined.
 
-1. Return the result of running the steps to [=convert a
+1. Return the result of running [=convert a
     key to a value=] with |record|'s key.
 
 </div>
@@ -6090,8 +6073,8 @@ The steps to <dfn>retrieve a key from an object store</dfn> with
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve multiple keys from an object store</dfn>
-with |store|, |range| and optional |count| are as follows:
+To <dfn>retrieve multiple keys from an object store</dfn>
+with |store|, |range| and optional |count|, run these steps:
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 
@@ -6103,7 +6086,7 @@ with |store|, |range| and optional |count| are as follows:
 
 1. [=list/For each=] |record| of |records|:
 
-    1. Let |entry| be the result of running the steps to [=convert a
+    1. Let |entry| be the result of running [=convert a
         key to a value=] with |record|'s key.
     1. Append |entry| to |list|.
 
@@ -6118,8 +6101,8 @@ with |store|, |range| and optional |count| are as follows:
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve a referenced value from an index</dfn>
-with |targetRealm|, |index| and |range| are as follows.
+To <dfn>retrieve a referenced value from an index</dfn>
+with |targetRealm|, |index| and |range|, run these steps:
 
 1. Let |record| be the first [=object-store/record=] in |index|'s [=index/list of
     records=] whose [=index/key=] is [=in=] |range|, if any.
@@ -6135,8 +6118,8 @@ with |targetRealm|, |index| and |range| are as follows.
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve multiple referenced values from an
-index</dfn> with |targetRealm|, |index|, |range| and optional |count| are as follows:
+To <dfn>retrieve multiple referenced values from an
+index</dfn> with |targetRealm|, |index|, |range| and optional |count|, run these steps:
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 
@@ -6162,15 +6145,15 @@ index</dfn> with |targetRealm|, |index|, |range| and optional |count| are as fol
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve a value from an index</dfn> with
-|index| and |range| are as follows.
+To <dfn>retrieve a value from an index</dfn> with
+|index| and |range|, run these steps:
 
 1. Let |record| be the first [=index/record=] in |index|'s [=index/list of
     records=] whose [=index/key=] is [=in=] |range|, if any.
 
 1. If |record| was not found, return undefined.
 
-1. Return the of running the steps to [=convert a
+1. Return the result of running [=convert a
         key to a value=] with |record|'s [=/value=].
 
 </div>
@@ -6178,8 +6161,8 @@ The steps to <dfn>retrieve a value from an index</dfn> with
 
 <div class=algorithm>
 
-The steps to <dfn>retrieve multiple values from an index</dfn> with
-|index|, |range| and optional |count| are as follows:
+To <dfn>retrieve multiple values from an index</dfn> with
+|index|, |range| and optional |count|, run these steps:
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 
@@ -6190,7 +6173,7 @@ The steps to <dfn>retrieve multiple values from an index</dfn> with
 
 1. [=list/For each=] |record| of |records|:
 
-    1. Let |entry| be the result of running the steps to [=convert a
+    1. Let |entry| be the result of running [=convert a
         key to a value=] with |record|'s value.
     1. Append |entry| to |list|.
 
@@ -6205,8 +6188,8 @@ The steps to <dfn>retrieve multiple values from an index</dfn> with
 
 <div class=algorithm>
 
-The steps to <dfn>delete records from an object store</dfn>
-with |store| and |range| are as follows.
+To <dfn>delete records from an object store</dfn>
+with |store| and |range|, run these steps:
 
 1. Remove all records, if any, from |store|'s [=object-store/list
     of records=] with key [=in=]
@@ -6227,8 +6210,8 @@ with |store| and |range| are as follows.
 
 <div class=algorithm>
 
-The steps to <dfn>count the records in a range</dfn> with |source| and
-|range| are as follows:
+To <dfn>count the records in a range</dfn> with |source| and
+|range|, run these steps:
 
 1. Let |count| be the number of records, if any, in |source|'s list of
     records with key [=in=] |range|.
@@ -6244,7 +6227,7 @@ The steps to <dfn>count the records in a range</dfn> with |source| and
 
 <div class=algorithm>
 
-The steps to <dfn>clear an object store</dfn> with |store| are as follows.
+To <dfn>clear an object store</dfn> with |store|, run these steps:
 
 1. Remove all records from |store|.
 
@@ -6262,9 +6245,8 @@ The steps to <dfn>clear an object store</dfn> with |store| are as follows.
 
 <div class=algorithm>
 
-The steps to <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
-|key| and |primaryKey| to iterate to, and an optional |count| are as
-follows.
+To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
+|key| and |primaryKey| to iterate to, and an optional |count|, run these steps:
 
 1. Let |source| be |cursor|'s [=cursor/source=].
 
@@ -6451,20 +6433,20 @@ algorithm conventions from the ECMAScript Language Specification.
 
 <div class=algorithm>
 
-The steps to <dfn>extract a key from a value using a key path</dfn>
-with |value|, |keyPath| and an optional |multiEntry flag| are as
-follows. The result of these steps is a [=/key=], invalid, or
+To <dfn>extract a key from a value using a key path</dfn>
+with |value|, |keyPath| and an optional |multiEntry flag|, run the
+following steps. The result of these steps is a [=/key=], invalid, or
 failure, or the steps may throw an exception.
 
-1. Let |r| be the result of running the steps to [=evaluate a key
+1. Let |r| be the result of running [=evaluate a key
     path on a value=] with |value| and |keyPath|. Rethrow any
     exceptions.
 
 1. If |r| is failure, return failure.
 
-1. Let |key| be the result of running the steps to [=convert a value
+1. Let |key| be the result of running [=convert a value
     to a key=] with |r| if the |multiEntry flag| is unset, and the
-    result of running the steps to [=convert a value to a multiEntry
+    result of running [=convert a value to a multiEntry
     key=] with |r| otherwise. Rethrow any exceptions.
 
 1. If |key| is invalid, return invalid.
@@ -6476,8 +6458,8 @@ failure, or the steps may throw an exception.
 
 <div class=algorithm>
 
-The steps to <dfn>evaluate a key path on a value</dfn> with |value|
-and |keyPath| are as follows. The result of these steps is an
+To <dfn>evaluate a key path on a value</dfn> with |value|
+and |keyPath|, run the following steps. The result of these steps is an
 ECMAScript value or failure, or the steps may throw an exception.
 
 1. If |keyPath| is a [=/list=] of strings, then:
@@ -6489,7 +6471,7 @@ ECMAScript value or failure, or the steps may throw an exception.
 
     1. [=list/For each=] |item| of |keyPath|:
 
-        1. Let |key| be the result of recursively running the steps to
+        1. Let |key| be the result of recursively running
             [=evaluate a key path on a value=] using
             |item| as |keyPath| and |value| as |value|.
 
@@ -6587,9 +6569,8 @@ ECMAScript value or failure, or the steps may throw an exception.
 
 <div class=algorithm>
 
-The steps to <dfn>check that a key could be injected into a value</dfn> are
-as follows. The algorithm takes a |value| and a |keyPath|, and outputs
-true or false.
+To <dfn>check that a key could be injected into a value</dfn> with |value| and a |keyPath|, run the following steps.
+The result of these steps is either true or false.
 
 <div class=algorithm>
 
@@ -6621,8 +6602,7 @@ true or false.
 
 <div class=algorithm>
 
-The steps to <dfn>inject a key into a value using a key path</dfn> are
-as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
+To <dfn>inject a key into a value using a key path</dfn> with |value|, a |key| and a |keyPath|, run these steps:
 
 1. Let |identifiers| be the result of <a lt="strictly split a string">strictly splitting</a>
     |keyPath| on U+002E FULL STOP characters (.).
@@ -6652,7 +6632,7 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
 
 1. Assert: |value| is an [=Object=] or an [=Array=].
 
-1. Let |keyValue| be the result of running the steps to [=convert a
+1. Let |keyValue| be the result of running [=convert a
     key to a value=] with |key|.
 
 1. Let |status| be [=CreateDataProperty=](|value|, |last|, |keyValue|).
@@ -6675,8 +6655,8 @@ as follows. The algorithm takes a |value|, a |key| and a |keyPath|.
 
 <div class=algorithm>
 
-The steps to <dfn>convert a key to a value</dfn> are as follows. These
-steps take one argument, |key|, and return an ECMAScript value.
+To <dfn>convert a key to a value</dfn> with |key|, run the following steps.
+The steps return an ECMAScript value.
 
 1. Let |type| be |key|'s [=key/type=].
 
@@ -6722,7 +6702,7 @@ steps take one argument, |key|, and return an ECMAScript value.
         1. Let |index| be 0.
         1. While |index| is less than |len|:
 
-            1. Let |entry| be the result of running the steps to
+            1. Let |entry| be the result of running
                 [=convert a key to a value=] with the |index|th
                 entry of |value| as input.
             1. Let |status| be [=CreateDataProperty=](|array|, |index|,
@@ -6744,9 +6724,9 @@ steps take one argument, |key|, and return an ECMAScript value.
 
 <div class=algorithm>
 
-The steps to <dfn>convert a value to a key</dfn> are as follows. These
-steps take two arguments, an ECMAScript value |input|, and an optional
-set |seen|. The result of these steps is a [=/key=] or invalid, or the
+To <dfn>convert a value to a key</dfn> with an ECMAScript value |input|, and an optional
+set |seen|, run the following steps.
+The result of these steps is a [=/key=] or invalid, or the
 steps may throw an exception.
 
 1. If |seen| was not given, let |seen| be a new empty set.
@@ -6794,7 +6774,7 @@ steps may throw an exception.
         If |input| is a [=buffer source type=]</dt>
       <dd>
 
-        1. Let |octets| be the result of running the steps to
+        1. Let |octets| be the result of running
             <a lt="get a copy of the buffer source">get a copy of the bytes held by the buffer source</a>
             |input|. Rethrow any exceptions.
 
@@ -6820,7 +6800,7 @@ steps may throw an exception.
 
             1. Let |entry| be [=?=] [=Get=](|input|, |index|).
 
-            1. Let |key| be the result of running the steps to
+            1. Let |key| be the result of running
                 [=convert a value to a key=] with arguments |entry|
                 and |seen|.
 
@@ -6847,8 +6827,7 @@ steps may throw an exception.
 
 <div class=algorithm>
 
-The steps to <dfn>convert a value to a multiEntry key</dfn> are as
-follows. These steps take one argument, an ECMAScript value |input|.
+To <dfn>convert a value to a multiEntry key</dfn> with an ECMAScript value |input|, run the following steps.
 The result of these steps is a [=/key=] or invalid, or the
 steps may throw an exception.
 
@@ -6868,7 +6847,7 @@ steps may throw an exception.
 
         1. If |entry| is not an [=abrupt completion=], then:
 
-             1. Let |key| be the result of running the steps to
+             1. Let |key| be the result of running
                  [=convert a value to a key=] with arguments
                  |entry| and |seen|.
 
@@ -6881,7 +6860,7 @@ steps may throw an exception.
     1. Return a new [=array key=] with [=key/value=] set to
         a list of the members of |keys|.
 
-1. Otherwise, return the result of running the steps to [=convert a
+1. Otherwise, return the result of running [=convert a
     value to a key=] with argument |input|.
     Rethrow any exceptions.
 


### PR DESCRIPTION
* Invocation: reword "run the steps to XXX" to just "run XXX".
* Definition: reword "The steps to XXX are as follows." to "To
    XXX, run these steps:" (w/ argument/result details)
* Simplify "then run these steps:" to just "then:"

No normative changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/277.html" title="Last updated on Jun 12, 2019, 4:22 PM UTC (2632aec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/277/b9a06c2...2632aec.html" title="Last updated on Jun 12, 2019, 4:22 PM UTC (2632aec)">Diff</a>