### PR TITLE
Editorial: Simplify wording around async request invocation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3114,9 +3114,9 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
             |clone| and |store|'s [=object-store/key path=] return
             false, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with |handle| as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with |handle| as |source| and
     [=store a record into an object store=] as
     |operation|, using |store|, the |clone| as |value|, |key|, and
     |no-overwrite flag|.
@@ -3147,9 +3147,9 @@ invoked, must run these steps:
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=/object store handle=] as |source| and
     [=delete records from an object store=] as
     |operation|, using |store| and |range|.
 
@@ -3186,9 +3186,9 @@ must run these steps:
 1. If |transaction| is a [=read-only transaction=],
     [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=/object store handle=] as |source| and
     [=clear an object store=] as
     |operation|, using |store|.
 
@@ -3281,13 +3281,13 @@ invoked, must run these steps:
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-      return the {{IDBRequest}} created by these steps. The steps
-      are run with this [=/object store handle=] as
-      |source| and [=retrieve a value from
-      an object store=] as |operation|, using the
-      [=current Realm=] as |targetRealm|,
-      |store| and |range|.
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=/object store handle=] as
+    |source| and [=retrieve a value from
+    an object store=] as |operation|, using the
+    [=current Realm=] as |targetRealm|,
+    |store| and |range|.
 
 </div>
 
@@ -3327,12 +3327,12 @@ invoked, must run these steps:
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-      return the {{IDBRequest}} created by these steps. The steps
-      are run with this [=/object store handle=] as
-      |source| and [=retrieve a key from an
-      object store=] as |operation|, using |store|
-      and |range|.
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=/object store handle=] as
+    |source| and [=retrieve a key from an
+    object store=] as |operation|, using |store|
+    and |range|.
 
 </div>
 
@@ -3363,9 +3363,9 @@ method, when invoked, must run these steps:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=/object store handle=] as |source| and
     [=retrieve multiple values from an object store=]
     as |operation|, using the [=current Realm=] as |targetRealm|,
     |store|, |range|, and |count| if given.
@@ -3400,9 +3400,9 @@ method, when invoked, must run these steps:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=/object store handle=] as |source| and
     [=retrieve multiple keys from an object store=] as
     |operation|, using |store|, |range|, and |count| if given.
 
@@ -3436,10 +3436,10 @@ invoked, must run these steps:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=/object store handle=] as |source| and
-    [=count the records in a range=] as |operation|, with
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=/object store handle=] as |source| and
+    [=count the records in a range=] as |operation|, using
     |source| and |range|.
 
 </div>
@@ -4040,12 +4040,12 @@ must run these steps:
     [=convert a value to a key range=] with |query| and
     |null disallowed flag| set. Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-      return the {{IDBRequest}} created by these steps. The steps
-      are run with this [=index handle=] as |source| and
-      [=retrieve a referenced value from an index=]
-      as |operation|, using the [=current Realm=] as |targetRealm|,
-      |index| and |range|.
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=index handle=] as |source| and
+    [=retrieve a referenced value from an index=]
+    as |operation|, using the [=current Realm=] as |targetRealm|,
+    |index| and |range|.
 
 </div>
 
@@ -4086,9 +4086,9 @@ invoked, must run these steps:
     value to a key range=] with |query| and |null disallowed flag|
     set. Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=index handle=] as |source| and
     [=retrieve a value from an index=] as |operation|, using |index|
     and |range|.
 
@@ -4121,9 +4121,9 @@ when invoked, must run these steps:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=index handle=] as |source| and
     [=retrieve multiple referenced values from an index=] as
     |operation|, using the [=current Realm=] as |targetRealm|,
     |index|, |range|, and |count| if given.
@@ -4158,9 +4158,9 @@ method, when invoked, must run these steps:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=index handle=] as |source| and
     [=retrieve multiple values from an index=] as |operation|, using
     |index|, |range|, and |count| if given.
 
@@ -4194,10 +4194,10 @@ invoked, must run these steps:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=index handle=] as |source| and
-    [=count the records in a range=] as |operation|, with
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=index handle=] as |source| and
+    [=count the records in a range=] as |operation|, using
     [=/index=] as |source| and |range|.
 
 </div>
@@ -4942,9 +4942,9 @@ invoked, must run these steps:
         the cursor's [=effective key=], [=throw=] a
         "{{DataError}}" {{DOMException}}.
 
-1. Run [=asynchronously execute a request=] and return
-    the {{IDBRequest}} created by these steps. The steps are run with
-    this [=cursor=] as |source| and [=store a
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=cursor=] as |source| and [=store a
     record into an object store=] as |operation|, using this
     cursor's [=effective object store=] as |store|, the |clone| as
     |value|, this cursor's [=effective key=] as |key|, and with the
@@ -4983,9 +4983,9 @@ must run these steps:
 1. If this cursor's [=key only flag=] is set, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
-1. Run [=asynchronously execute a request=] and
-    return the {{IDBRequest}} created by these steps. The steps are
-    run with this [=cursor=] as |source| and
+1. Return the result (an {{IDBRequest}}) of running
+    [=asynchronously execute a request=]
+    with this [=cursor=] as |source| and
     [=delete records from an object store=] as |operation|, using
     this cursor's [=effective object store=] and [=effective
     key=] as |store| and |key| respectively.


### PR DESCRIPTION
Use the more common "return the result of..." wording and
eliminate the passive voice ".... steps are run with..."

No normative changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/278.html" title="Last updated on Jun 12, 2019, 5:30 PM UTC (be84fef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/278/d08bc14...be84fef.html" title="Last updated on Jun 12, 2019, 5:30 PM UTC (be84fef)">Diff</a>