### PR TITLE
Remove WebIDL escaping of includes() method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4214,13 +4214,9 @@ interface IDBKeyRange {
                                        optional boolean lowerOpen = false,
                                        optional boolean upperOpen = false);
 
-  boolean _includes(any key);
+  boolean includes(any key);
 };
 </xmp>
-
-<aside class=note>
-Note: When mapping the `_includes` identifier from [[WEBIDL]] to ECMAScript, the leading U+005F LOW LINE ("_") character is removed. A leading "_" is used to escape the identifier from looking like a reserved word (in this case, the `includes` keyword).
-</aside>
 
 <dl class="domintro note">
     : |range| . {{IDBKeyRange/lower}}
@@ -4361,7 +4357,7 @@ The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|,
 
 <div class=algorithm>
 
-The <dfn method for=IDBKeyRange lt="_includes(key)|includes(key)">includes(|key|)</dfn> method, when
+The <dfn method for=IDBKeyRange>includes(|key|)</dfn> method, when
 invoked, must run these steps:
 
 1. Let |k| be the result of running [=convert a
@@ -6894,6 +6890,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Added {{IDBTransaction/commit()}} method. ([Issue #234](https://github.com/w3c/IndexedDB/issues/234))
 * Added {{IDBCursor/request}} attribute. ([Issue #255](https://github.com/w3c/IndexedDB/issues/255))
 * Removed handling for nonstandard `lastModifiedDate` property of {{File}} objects. ([Issue #215](https://github.com/w3c/IndexedDB/issues/215))
+* Remove escaping {{IDBKeyRange/includes()}} method. ([Issue #294](https://github.com/w3c/IndexedDB/issues/294))
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}


### PR DESCRIPTION
"includes" was added to the WebIDL grammar to avoid needing escaping:

https://heycam.github.io/webidl/#prod-OperationName

Fixes #294


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/299.html" title="Last updated on Sep 24, 2019, 8:26 PM UTC (a5209b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/299/2bc2e3c...a5209b9.html" title="Last updated on Sep 24, 2019, 8:26 PM UTC (a5209b9)">Diff</a>