### PR TITLE
Remove lastModifiedDate handling

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -762,7 +762,7 @@ following type-specific properties:
 <table class=props>
   <tr><th>Type</th><th>Properties</th></tr>
   <tr><td>{{Blob}}</td><td>{{Blob/size}}, {{Blob/type}}</td></tr>
-  <tr><td>{{File}}</td><td>{{File/name}}, {{File/lastModified}}, `lastModifiedDate`</td></tr>
+  <tr><td>{{File}}</td><td>{{File/name}}, {{File/lastModified}}</td></tr>
   <tr><td>[=Array=]</td><td>`length`</td></tr>
   <tr><td>[=String=]</td><td>`length`</td></tr>
 </table>
@@ -6344,10 +6344,6 @@ ECMAScript value or failure, or the steps may throw an exception.
       : If |value| is a {{File}} and |identifier| is "`lastModified`"
       :: Let |value| be a Number equal to |value|'s {{File/lastModified}}.
 
-      : If |value| is a {{File}} and |identifier| is "`lastModifiedDate`"
-      :: Let |value| be a new [=Date=] object with \[[DateValue]] internal slot
-          equal to |value|'s {{File/lastModified}}.
-
       : Otherwise
       ::
           1. If [=/Type=](|value|) is not Object, return failure.
@@ -6897,6 +6893,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Added {{IDBFactory/databases()}} method. ([Issue #31](https://github.com/w3c/IndexedDB/issues/31))
 * Added {{IDBTransaction/commit()}} method. ([Issue #234](https://github.com/w3c/IndexedDB/issues/234))
 * Added {{IDBCursor/request}} attribute. ([Issue #255](https://github.com/w3c/IndexedDB/issues/255))
+* Removed handling for nonstandard `lastModifiedDate` property of {{File}} objects. ([Issue #215](https://github.com/w3c/IndexedDB/issues/215))
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}


### PR DESCRIPTION
Several browsers used to implement a nonstandard `lastModifiedDate` property on File objects. This has been removed everywhere except Chrome, and it's not in the File API spec. This specification included special cases for keypath evaluation of that property name, and it wasn't tested. Remove the references.

Closes #215


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/300.html" title="Last updated on Sep 23, 2019, 9:24 PM UTC (5a98259)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/300/f3a43a7...5a98259.html" title="Last updated on Sep 23, 2019, 9:24 PM UTC (5a98259)">Diff</a>