### PR TITLE
Use IDL this

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1090,12 +1090,12 @@ They will return true if any transactions were cleaned up, or false otherwise.
     1. If there are no [=/transactions=] with [=transaction/cleanup
         event loop=] matching the current [=event loop=], return false.
 
-    1. For each [=/transaction=] with [=transaction/cleanup event loop=]
+    1. For each [=/transaction=] |transaction| with [=transaction/cleanup event loop=]
         matching the current [=event loop=]:
 
-        1. Set the [=/transaction=]'s [=transaction/state=] to [=transaction/inactive=].
+        1. Set |transaction|'s [=transaction/state=] to [=transaction/inactive=].
 
-        1. Clear the [=/transaction=]'s [=transaction/cleanup event loop=].
+        1. Clear |transaction|'s [=transaction/cleanup event loop=].
 
     1. Return true.
 </div>
@@ -1572,7 +1572,7 @@ in the call to store the record, a key is generated.
 
   To <dfn>generate a key</dfn> for an [=/object store=] |store|, run these steps:
 
-  1. Let |generator| be the [=key generator=] associated with |store|.
+  1. Let |generator| be |store|'s [=key generator=].
 
   1. Let |key| be |generator|'s [=key generator/current number=].
 
@@ -1601,7 +1601,7 @@ be updated.
 
   1. Let |value| be the largest integer not greater than |value|.
 
-  1. Let |generator| be the [=key generator=] associated with |store|.
+  1. Let |generator| be |store|'s [=key generator=].
 
   1. If |value| is greater than or equal to |generator|'s [=key generator/current number=],
       then set |generator|'s [=key generator/current number=] to |value| + 1.
@@ -2040,28 +2040,27 @@ enum IDBRequestReadyState {
 </dl>
 
 The <dfn attribute for=IDBRequest>result</dfn> attribute's getter must
-[=throw=] an "{{InvalidStateError}}" {{DOMException}} if the [=/request=]'s [=request/done flag=] is
-false. Otherwise, the attribute's getter must return the
-[=/request=]'s [=request/result=], or undefined if the
+[=throw=] an "{{InvalidStateError}}" {{DOMException}} if **this**'s [=request/done flag=] is
+false. Otherwise, the attribute's getter must return **this**'s [=request/result=], or undefined if the
 request resulted in an error.
 
 
 The <dfn attribute for=IDBRequest>error</dfn> attribute's getter must
-[=throw=] an "{{InvalidStateError}}" {{DOMException}} if the [=/request=]'s [=request/done flag=] is false.
-Otherwise, the attribute's getter must return the [=/request=]'s [=request/error=],
+[=throw=] an "{{InvalidStateError}}" {{DOMException}} if **this**'s [=request/done flag=] is false.
+Otherwise, the attribute's getter must return **this**'s [=request/error=],
 or null if no error occurred.
 
 The <dfn attribute for=IDBRequest>source</dfn> attribute's getter must
-return the [=request/source=] of the [=/request=], or null if no
+return **this**'s [=request/source=], or null if no
 [=request/source=] is set.
 
 The <dfn attribute for=IDBRequest>transaction</dfn> attribute's getter
-must return the [=request/transaction=] of the [=/request=]. This
+must return **this**'s [=request/transaction=]. This
 property can be null for certain requests, such as for [=/requests=]
 returned from {{IDBFactory/open()}}.
 
 The <dfn attribute for=IDBRequest>readyState</dfn> attribute's getter
-must return {{"pending"}} if the [=/request=]'s [=request/done flag=] is false, and
+must return {{"pending"}} if **this**'s [=request/done flag=] is false, and
 {{"done"}} otherwise.
 
 
@@ -2236,8 +2235,7 @@ when invoked, must run these steps:
 
 1. If |version| is 0 (zero), [=throw=] a [=TypeError=].
 
-1. Let |origin| be the [=/origin=] of the global scope used
-    to access this {{IDBFactory}}.
+1. Let |origin| be the [=/origin=] of the global scope used to access **this**.
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2307,8 +2305,7 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>deleteDatabase(|name|)</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/origin=] of the global scope used
-    to access this {{IDBFactory}}.
+1. Let |origin| be the [=/origin=] of the global scope used to access **this**.
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2363,8 +2360,7 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>databases()</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/origin=] of the global scope used
-    to access this {{IDBFactory}}.
+1. Let |origin| be the [=/origin=] of the global scope used to access **this**.
 
 1. If |origin| is an [=opaque origin=],
     then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
@@ -2483,16 +2479,15 @@ dictionary IDBObjectStoreParameters {
 </dl>
 
 The <dfn attribute for=IDBDatabase>name</dfn> attribute's getter must
-return the [=database/name=] of the [=connected=]
-[=database=]. The attribute must return this name even if the
-[=/connection=]'s [=close pending flag=] is true. In
+return **this**'s associated [=database=]'s [=database/name=].
+The attribute must return this name even if
+**this**'s [=close pending flag=] is true. In
 other words, the value of this attribute stays constant for the
 lifetime of the {{IDBDatabase}} instance.
 
 
 The <dfn attribute for=IDBDatabase>version</dfn> attribute's getter
-must return this [=/connection=]'s
-[=connection/version=].
+must return **this**'s [=connection/version=].
 
 <details class=note>
   <summary>
@@ -2530,7 +2525,7 @@ must return this [=/connection=]'s
 
 The <dfn attribute for=IDBDatabase>objectStoreNames</dfn> attribute's
 getter must return a {{DOMStringList}} associated with a [=sorted name list=] of the [=object-store/names=] of
-the [=/object stores=] in this [=/connection=]'s [=object store set=].
+the [=/object stores=] in **this**'s [=object store set=].
 
 <details class=note>
   <summary>
@@ -2549,8 +2544,7 @@ the [=/object stores=] in this [=/connection=]'s [=object store set=].
 The <dfn method for=IDBDatabase>createObjectStore(|name|,
 |options|)</dfn> method, when invoked, must run these steps:
 
-1. Let |database| be the [=database=] associated with this
-    [=/connection=].
+1. Let |database| be **this**'s associated [=database=].
 
 1. Let |transaction| be |database|'s [=database/upgrade transaction=]
     if it is not null, or [=throw=] an "{{InvalidStateError}}"
@@ -2616,8 +2610,7 @@ error.
 The <dfn method for=IDBDatabase>deleteObjectStore(|name|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |database| be the [=database=] associated with this
-    [=/connection=].
+1. Let |database| be **this**'s associated [=database=].
 
 1. Let |transaction| be |database|'s [=database/upgrade transaction=]
     if it is not null, or [=throw=] an "{{InvalidStateError}}"
@@ -2630,8 +2623,7 @@ method, when invoked, must run these steps:
     [=object-store/named=] |name| in |database|,
     or [=throw=] a "{{NotFoundError}}" {{DOMException}} if none.
 
-1. Remove |store| from this [=/connection=]'s [=object
-    store set=].
+1. Remove |store| from **this**'s [=object store set=].
 
 1. If there is an [=/object store handle=] associated with
     |store| and |transaction|, remove all entries from its
@@ -2675,8 +2667,7 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|,
 1. If a running [=/upgrade transaction=] is associated with the [=/connection=],
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If the [=/connection=]'s
-    [=close pending flag=] is true, [=throw=] an
+1. If **this**'s [=close pending flag=] is true, then [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
 1. Let |scope| be the set of unique strings in |storeNames| if it is a
@@ -2815,8 +2806,7 @@ dictionary IDBIndexParameters {
 
 
 The <dfn attribute for=IDBObjectStore>name</dfn> attribute's getter
-must return this [=/object store handle=]'s
-[=object-store/name=].
+must return **this**'s [=object-store/name=].
 
 <details class=note>
   <summary>
@@ -2836,11 +2826,9 @@ The {{IDBObjectStore/name}} attribute's setter must run these steps:
 
 1. Let |name| be the given value.
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -2860,15 +2848,13 @@ The {{IDBObjectStore/name}} attribute's setter must run these steps:
 
 1. Set |store|'s [=object-store/name=] to |name|.
 
-1. Set this [=/object store handle=]'s
-    [=object-store-handle/name=] to |name|.
+1. Set **this**'s [=object-store-handle/name=] to |name|.
 
 </div>
 
 
 The <dfn attribute for=IDBObjectStore>keyPath</dfn> attribute's getter
-must return this [=/object store handle=]'s
-[=object-store-handle/object store=]'s [=object-store/key path=], or
+must return **this**'s [=object-store-handle/object store=]'s [=object-store/key path=], or
 null if none. The [=/key path=] is converted as a {{DOMString}} (if a
 string) or a [=sequence&lt;DOMString&gt;=] (if a list of strings), per
 [[!WEBIDL]].
@@ -2882,8 +2868,7 @@ object has no effect on the [=/object store=].
 
 The <dfn attribute for=IDBObjectStore>indexNames</dfn> attribute's
 getter must return a {{DOMStringList}} associated with a [=sorted name list=] of the [=index/names=]
-of [=/indexes=] in this [=/object store handle=]'s
-[=index set=].
+of [=/indexes=] in **this**'s [=index set=].
 
 <details class=note>
   <summary>
@@ -2899,13 +2884,11 @@ of [=/indexes=] in this [=/object store handle=]'s
 
 
 The <dfn attribute for=IDBObjectStore>transaction</dfn> attribute's
-getter must return this [=/object store handle=]'s
-[=object-store-handle/transaction=].
+getter must return **this**'s [=object-store-handle/transaction=].
 
 
 The <dfn attribute for=IDBObjectStore>autoIncrement</dfn> attribute's
-getter must return true if this [=/object store handle=]'s
-[=object-store-handle/object store=] has a [=key generator=],
+getter must return true if **this**'s [=object-store-handle/object store=] has a [=key generator=],
 and false otherwise.
 
 
@@ -2957,13 +2940,11 @@ and false otherwise.
 
 The <dfn method for=IDBObjectStore>put(|value|, |key|)</dfn> method,
 when invoked, must return the result of running [=add or
-put=] with this [=/object store handle=], |value|, |key| and the
-|no-overwrite flag| false.
+put=] with **this**, |value|, |key| and the |no-overwrite flag| false.
 
 The <dfn method for=IDBObjectStore>add(|value|, |key|)</dfn> method,
 when invoked, must return the result of running [=add or
-put=] with this [=/object store handle=], |value|, |key| and the
-|no-overwrite flag| true.
+put=] with **this**, |value|, |key| and the |no-overwrite flag| true.
 
 <div class=algorithm>
 
@@ -2972,7 +2953,7 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
 1. Let |transaction| be |handle|'s
     [=object-store-handle/transaction=].
 
-1. Let |store| be this |handle|'s
+1. Let |store| be |handle|'s
     [=object-store-handle/object store=].
 
 1. If |store| has been deleted,
@@ -3048,11 +3029,9 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
 The <dfn method for=IDBObjectStore>delete(|query|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3069,7 +3048,7 @@ invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=/object store handle=] as |source| and
+    with **this** as |source| and
     [=delete records from an object store=] as
     |operation|, using |store| and |range|.
 
@@ -3091,11 +3070,9 @@ deleted.
 The <dfn method for=IDBObjectStore>clear()</dfn> method, when invoked,
 must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3108,7 +3085,7 @@ must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=/object store handle=] as |source| and
+    with **this** as |source| and
     [=clear an object store=] as
     |operation|, using |store|.
 
@@ -3170,11 +3147,9 @@ must run these steps:
 The <dfn method for=IDBObjectStore>get(|query|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3188,8 +3163,7 @@ invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=/object store handle=] as
-    |source| and [=retrieve a value from
+    with **this** as |source| and [=retrieve a value from
     an object store=] as |operation|, using the
     [=current Realm=] as |targetRealm|,
     |store| and |range|.
@@ -3216,11 +3190,9 @@ that range.
 The <dfn method for=IDBObjectStore>getKey(|query|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3234,8 +3206,7 @@ invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=/object store handle=] as
-    |source| and [=retrieve a key from an
+    with **this** as |source| and [=retrieve a key from an
     object store=] as |operation|, using |store|
     and |range|.
 
@@ -3252,11 +3223,9 @@ the first existing key in that range.
 The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3270,7 +3239,7 @@ method, when invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=/object store handle=] as |source| and
+    with **this** as |source| and
     [=retrieve multiple values from an object store=]
     as |operation|, using the [=current Realm=] as |targetRealm|,
     |store|, |range|, and |count| if given.
@@ -3289,11 +3258,9 @@ will be retrieved.
 The <dfn method for=IDBObjectStore>getAllKeys(|query|, |count|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3307,7 +3274,7 @@ method, when invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=/object store handle=] as |source| and
+    with **this** as |source| and
     [=retrieve multiple keys from an object store=] as
     |operation|, using |store|, |range|, and |count| if given.
 
@@ -3325,11 +3292,9 @@ will be retrieved.
 The <dfn method for=IDBObjectStore>count(|query|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3343,7 +3308,7 @@ invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=/object store handle=] as |source| and
+    with **this** as |source| and
     [=count the records in a range=] as |operation|, using
     |source| and |range|.
 
@@ -3389,11 +3354,9 @@ given, an [=unbounded key range=] is used.
 The <dfn method for=IDBObjectStore>openCursor(|query|,
 |direction|)</dfn> method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3416,8 +3379,7 @@ The <dfn method for=IDBObjectStore>openCursor(|query|,
     [=cursor/key only flag=] set to false.
 
 1. Let |request| be the result of running
-    [=asynchronously execute a request=] with this [=/object store
-    handle=] as |source| and [=iterate a cursor=] as
+    [=asynchronously execute a request=] with **this** as |source| and [=iterate a cursor=] as
     |operation|, using the [=current Realm=] as |targetRealm|, and
     |cursor|.
 
@@ -3437,11 +3399,9 @@ If null or not given, an [=unbounded key range=] is used.
 The <dfn method for=IDBObjectStore>openKeyCursor(|query|,
 |direction|)</dfn> method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3464,8 +3424,7 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|,
     [=cursor/key only flag=] set to true.
 
 1. Let |request| be the result of running
-    [=asynchronously execute a request=] with this [=/object store
-    handle=] as |source| and [=iterate a cursor=] as
+    [=asynchronously execute a request=] with **this** as |source| and [=iterate a cursor=] as
     |operation|, using the [=current Realm=] as |targetRealm|, and
     |cursor|.
 
@@ -3511,11 +3470,9 @@ or not given, an [=unbounded key range=] is used.
 The <dfn method for=IDBObjectStore>createIndex(|name|, |keyPath|,
 |options|)</dfn> method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |transaction| is not an [=/upgrade transaction=],
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -3548,11 +3505,9 @@ The <dfn method for=IDBObjectStore>createIndex(|name|, |keyPath|,
     [=unique flag=] to |unique|, and
     [=multiEntry flag=] to |multiEntry|.
 
-1. Add |index| to this [=/object store handle=]'s [=index
-      set=].
+1. Add |index| to **this**'s [=index set=].
 
-1. Return a new [=index handle=] associated with |index|
-    and this [=/object store handle=].
+1. Return a new [=index handle=] associated with |index| and **this**.
 
 </div>
 
@@ -3618,11 +3573,9 @@ must be used as error.
 The <dfn method for=IDBObjectStore>index(|name|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |store| has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
@@ -3631,12 +3584,11 @@ invoked, must run these steps:
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 1. Let |index| be the [=/index=]
-    [=index/named=] |name| in this [=/object
-    store handle=]'s [=index set=] if one exists, or [=throw=]
+    [=index/named=] |name| in **this**'s
+    [=index set=] if one exists, or [=throw=]
     a "{{NotFoundError}}" {{DOMException}} otherwise.
 
-1. Return an [=index handle=] associated with |index| and
-    this [=/object store handle=].
+1. Return an [=index handle=] associated with |index| and **this**.
 
 </div>
 
@@ -3658,11 +3610,9 @@ invoked, must run these steps:
 The <dfn method for=IDBObjectStore>deleteIndex(|name|)</dfn> method,
 when invoked, must run these steps:
 
-1. Let |transaction| be this [=/object store handle=]'s
-    [=object-store-handle/transaction=].
+1. Let |transaction| be **this**'s [=object-store-handle/transaction=].
 
-1. Let |store| be this [=/object store handle=]'s
-    [=object-store-handle/object store=].
+1. Let |store| be **this**'s [=object-store-handle/object store=].
 
 1. If |transaction| is not an [=/upgrade transaction=],
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -3677,8 +3627,7 @@ when invoked, must run these steps:
     in |store| if one exists, or [=throw=] a "{{NotFoundError}}" {{DOMException}}
     otherwise.
 
-1. Remove |index| from this [=/object store handle=]'s
-    [=index set=].
+1. Remove |index| from **this**'s [=index set=].
 
 1. Destroy |index|.
 
@@ -3750,7 +3699,7 @@ interface IDBIndex {
 </dl>
 
 The <dfn attribute for=IDBIndex>name</dfn> attribute's getter must
-return this [=index handle=]'s [=index/name=].
+return **this**'s [=index/name=].
 
 <details class=note>
   <summary>
@@ -3770,11 +3719,9 @@ The {{IDBIndex/name}} attribute's setter must run these steps:
 
 1. Let |name| be the given value.
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |transaction| is not an [=/upgrade transaction=],
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -3795,18 +3742,16 @@ The {{IDBIndex/name}} attribute's setter must run these steps:
 1. Set |index|'s [=index/name=] to
     |name|.
 
-1. Set this [=index handle=]'s
-    [=index-handle/name=] to |name|.
+1. Set **this**'s [=index-handle/name=] to |name|.
 
 </div>
 
 
 The <dfn attribute for=IDBIndex>objectStore</dfn> attribute's getter
-must return this [=index handle=]'s [=index-handle/object
-store handle=].
+must return **this**'s [=index-handle/object store handle=].
 
 The <dfn attribute for=IDBIndex>keyPath</dfn> attribute's getter must
-return this [=index handle=]'s [=index-handle/index=]'s
+return **this**'s [=index-handle/index=]'s
 [=object-store/key path=]. The [=/key path=] is converted as a
 {{DOMString}} (if a string) or a [=sequence&lt;DOMString&gt;=] (if a
 list of strings), per [[!WEBIDL]].
@@ -3818,12 +3763,10 @@ instance every time it is inspected. Changing the properties of the
 object has no effect on the [=/index=].
 
 The <dfn attribute for=IDBIndex>multiEntry</dfn> attribute's getter
-must return this [=index handle=]'s
-[=index-handle/index=]'s [=multiEntry flag=].
+must return **this**'s [=index-handle/index=]'s [=multiEntry flag=].
 
 The <dfn attribute for=IDBIndex>unique</dfn> attribute's getter must
-return this [=index handle=]'s
-[=index-handle/index=]'s [=unique flag=].
+return **this**'s [=index-handle/index=]'s [=unique flag=].
 
 
 <div class=note>
@@ -3886,11 +3829,9 @@ return this [=index handle=]'s
 The <dfn method for=IDBIndex>get(|query|)</dfn> method, when invoked,
 must run these steps:
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |index| or |index|'s [=/object store=] has
     been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -3904,7 +3845,7 @@ must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=index handle=] as |source| and
+    with **this** as |source| and
     [=retrieve a referenced value from an index=]
     as |operation|, using the [=current Realm=] as |targetRealm|,
     |index| and |range|.
@@ -3932,11 +3873,9 @@ that range.
 The <dfn method for=IDBIndex>getKey(|query|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |index| or |index|'s [=/object store=] has been deleted,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -3950,7 +3889,7 @@ invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=index handle=] as |source| and
+    with **this** as |source| and
     [=retrieve a value from an index=] as |operation|, using |index|
     and |range|.
 
@@ -3967,11 +3906,9 @@ in that range.
 The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method,
 when invoked, must run these steps:
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |index| or |index|'s [=/object store=] has
     been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -3985,7 +3922,7 @@ when invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=index handle=] as |source| and
+    with **this** as |source| and
     [=retrieve multiple referenced values from an index=] as
     |operation|, using the [=current Realm=] as |targetRealm|,
     |index|, |range|, and |count| if given.
@@ -4004,11 +3941,9 @@ will be retrieved.
 The <dfn method for=IDBIndex>getAllKeys(|query|, |count|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |index| or |index|'s [=/object store=] has
     been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -4022,7 +3957,7 @@ method, when invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=index handle=] as |source| and
+    with **this** as |source| and
     [=retrieve multiple values from an index=] as |operation|, using
     |index|, |range|, and |count| if given.
 
@@ -4040,11 +3975,9 @@ will be retrieved.
 The <dfn method for=IDBIndex>count(|query|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |index| or |index|'s [=/object store=] has
     been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -4058,7 +3991,7 @@ invoked, must run these steps:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=index handle=] as |source| and
+    with **this** as |source| and
     [=count the records in a range=] as |operation|, using
     [=/index=] as |source| and |range|.
 
@@ -4103,11 +4036,9 @@ given, an [=unbounded key range=] is used.
 The <dfn method for=IDBIndex>openCursor(|query|, |direction|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |index| or |index|'s [=/object store=] has been deleted,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -4130,7 +4061,7 @@ method, when invoked, must run these steps:
     [=cursor/key only flag=] set to false.
 
 1. Let |request| be the result of running
-    [=asynchronously execute a request=] with this [=index handle=] as
+    [=asynchronously execute a request=] with **this** as
     |source| and [=iterate a cursor=] as |operation|,
     using the [=current Realm=] as |targetRealm|, and |cursor|.
 
@@ -4150,11 +4081,9 @@ or not given, an [=unbounded key range=] is used.
 The <dfn method for=IDBIndex>openKeyCursor(|query|, |direction|)</dfn>
 method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=index handle=]'s
-    [=index-handle/transaction=].
+1. Let |transaction| be **this**'s [=index-handle/transaction=].
 
-1. Let |index| be this [=index handle=]'s
-    [=index-handle/index=].
+1. Let |index| be **this**'s [=index-handle/index=].
 
 1. If |index| or |index|'s [=/object store=] has
     been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -4177,7 +4106,7 @@ method, when invoked, must run these steps:
     [=cursor/key only flag=] set to true.
 
 1. Let |request| be the result of running
-    [=asynchronously execute a request=] with this [=index handle=] as
+    [=asynchronously execute a request=] with **this** as
     |source| and [=iterate a cursor=] as |operation|,
     using the [=current Realm=] as |targetRealm|, and |cursor|.
 
@@ -4236,18 +4165,18 @@ interface IDBKeyRange {
 
 The <dfn attribute for=IDBKeyRange>lower</dfn> attribute's getter must
 return result of running [=convert a key to a value=]
-with the [=/range=]'s [=lower bound=] if it is not null, or undefined otherwise.
+with **this**'s [=lower bound=] if it is not null, or undefined otherwise.
 
 The <dfn attribute for=IDBKeyRange>upper</dfn> attribute's getter must
 return the result of running [=convert a key to a
-value=] with the [=/range=]'s [=upper bound=] if it is not null, or undefined
+value=] with **this**'s [=upper bound=] if it is not null, or undefined
 otherwise.
 
 The <dfn attribute for=IDBKeyRange>lowerOpen</dfn> attribute's getter
-must return the [=/range=]'s [=lower open flag=].
+must return **this**'s [=lower open flag=].
 
 The <dfn attribute for=IDBKeyRange>upperOpen</dfn> attribute's getter
-must return the [=/range=]'s [=upper open flag=].
+must return **this**'s [=upper open flag=].
 
 <dl class="domintro note">
     : |range| = {{IDBKeyRange}} .
@@ -4436,13 +4365,13 @@ enum IDBCursorDirection {
 
 
 The <dfn attribute for=IDBCursor>source</dfn> attribute's getter must
-return the [=cursor/source=] of the [=cursor=]. This
+return **this**'s [=cursor/source=]. This
 attribute never returns null or throws an exception, even if the
 cursor is currently being iterated, has iterated past its end, or its
 [=/transaction=] is not [=transaction/active=].
 
 The <dfn attribute for=IDBCursor>direction</dfn> attribute's getter
-must return the [=cursor/direction=] of the [=cursor=].
+must return **this**'s [=cursor/direction=].
 
 The <dfn attribute for=IDBCursor>key</dfn> attribute's getter must
 return the result of running [=convert a key to a
@@ -4465,7 +4394,7 @@ inspecting the value of the cursor. However modifying such an object
 does not modify the contents of the database.
 
 The <dfn attribute for=IDBCursor>request</dfn> attribute's getter must
-return the [=cursor/request=] of the [=cursor=].
+return **this**'s [=cursor/request=].
 
 <aside class=advisement>
   &#x1F6A7;
@@ -4520,31 +4449,30 @@ invoked, must run these steps:
 
 1. If |count| is 0 (zero), [=throw=] a [=TypeError=].
 
-1. Let |transaction| be this [=cursor=]'s
-    [=cursor/transaction=].
+1. Let |transaction| be **this**'s [=cursor/transaction=].
 
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. If the cursor's [=cursor/source=] or [=effective object
+1. If **this**'s [=cursor/source=] or [=effective object
     store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/got value flag=] is false, indicating that
+1. If **this**'s [=cursor/got value flag=] is false, indicating that
     the cursor is being iterated or has iterated past its end,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Set this [=cursor=]'s [=cursor/got value flag=] to false.
+1. Set **this**'s [=cursor/got value flag=] to false.
 
-1. Let |request| be this [=cursor=]'s [=cursor/request=].
+1. Let |request| be **this**'s [=cursor/request=].
 
 1. Set |request|'s [=request/processed flag=] to false.
 
 1. Set |request|'s [=request/done flag=] to false.
 
 1. Run [=asynchronously execute a request=] with
-    the cursor's [=cursor/source=] as |source|,
+    **this**'s [=cursor/source=] as |source|,
     [=iterate a cursor=] as |operation| and |request|, using
-    the [=current Realm=] as |targetRealm|, this [=cursor=] and |count|.
+    the [=current Realm=] as |targetRealm|, **this**, and |count|.
 
 </div>
 
@@ -4562,17 +4490,16 @@ invoked, must run these steps:
 The <dfn method for=IDBCursor>continue(|key|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=cursor=]'s
-    [=cursor/transaction=].
+1. Let |transaction| be **this**'s [=cursor/transaction=].
 
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. If the cursor's [=cursor/source=] or
+1. If **this**'s [=cursor/source=] or
     [=effective object store=] has been deleted, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/got value flag=] is false, indicating that
+1. If **this**'s [=cursor/got value flag=] is false, indicating that
     the cursor is being iterated or has iterated past its end,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
@@ -4585,27 +4512,27 @@ invoked, must run these steps:
 
     1. Let |key| be |r|.
 
-    1. If |key| is [=less than=] or [=equal to=] this cursor's
-        [=cursor/position=] and this cursor's [=cursor/direction=] is
-        {{"next"}} or {{"nextunique"}}, [=throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |key| is [=less than=] or [=equal to=] **this**'s
+        [=cursor/position=] and **this**'s [=cursor/direction=] is
+        {{"next"}} or {{"nextunique"}}, then [=throw=] a "{{DataError}}" {{DOMException}}.
 
-    1. If |key| is [=greater than=] or [=equal to=] this
-        cursor's [=cursor/position=] and this cursor's [=cursor/direction=] is
-        {{"prev"}} or {{"prevunique"}}, [=throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |key| is [=greater than=] or [=equal to=] **this**'s
+        [=cursor/position=] and **this**'s [=cursor/direction=] is
+        {{"prev"}} or {{"prevunique"}}, then [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Set this [=cursor=]'s [=cursor/got value flag=] to false.
+1. Set **this**'s [=cursor/got value flag=] to false.
 
-1. Let |request| be this [=cursor=]'s [=cursor/request=].
+1. Let |request| be **this**'s [=cursor/request=].
 
 1. Set |request|'s [=request/processed flag=] to false.
 
 1. Set |request|'s [=request/done flag=] to false.
 
 1. Run [=asynchronously execute a request=] with
-    the cursor's [=cursor/source=] as |source|,
+    **this**'s [=cursor/source=] as |source|,
     [=iterate a cursor=] as |operation| and |request|,
     using the [=current Realm=] as |targetRealm|,
-    this [=cursor=] and |key| (if given).
+    **this**, and |key| (if given).
 
 </div>
 
@@ -4623,22 +4550,21 @@ invoked, must run these steps:
 The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 |primaryKey|)</dfn> method, when invoked, must run these steps:
 
-1. Let |transaction| be this [=cursor=]'s
-    [=cursor/transaction=].
+1. Let |transaction| be **this**'s [=cursor/transaction=].
 
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. If the cursor's [=cursor/source=] or [=effective object
+1. If **this**'s [=cursor/source=] or [=effective object
     store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/source=] is not an
+1. If **this**'s [=cursor/source=] is not an
     [=/index=] [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/direction=] is not {{"next"}} or {{"prev"}},
+1. If **this**'s [=cursor/direction=] is not {{"next"}} or {{"prev"}},
     [=throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/got value flag=] is false, indicating that
+1. If **this**'s [=cursor/got value flag=] is false, indicating that
     the cursor is being iterated or has iterated past its end,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
@@ -4656,38 +4582,38 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 
 1. Let |primaryKey| be |r|.
 
-1. If |key| is [=less than=] this cursor's
-    [=cursor/position=] and this cursor's [=cursor/direction=] is {{"next"}},
+1. If |key| is [=less than=] **this**'s
+    [=cursor/position=] and **this**'s [=cursor/direction=] is {{"next"}},
     [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. If |key| is [=greater than=] this cursor's
-    [=cursor/position=] and this cursor's [=cursor/direction=] is {{"prev"}},
+1. If |key| is [=greater than=] **this**'s
+    [=cursor/position=] and **this**'s [=cursor/direction=] is {{"prev"}},
     [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. If |key| is [=equal to=] this cursor's [=cursor/position=] and
-    |primaryKey| is [=less than=] or [=equal to=] this cursor's
-    [=object store position=] and this cursor's [=cursor/direction=] is
+1. If |key| is [=equal to=] **this**'s [=cursor/position=] and
+    |primaryKey| is [=less than=] or [=equal to=] **this**'s
+    [=object store position=] and **this**'s [=cursor/direction=] is
     {{"next"}}, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. If |key| is [=equal to=] this cursor's [=cursor/position=] and
-    |primaryKey| is [=greater than=] or [=equal to=] this
-    cursor's [=object store position=] and this cursor's
+1. If |key| is [=equal to=] **this**'s [=cursor/position=] and
+    |primaryKey| is [=greater than=] or [=equal to=] **this**'s
+    [=object store position=] and **this**'s
     [=cursor/direction=] is {{"prev"}}, [=throw=] a
     "{{DataError}}" {{DOMException}}.
 
-1. Set this [=cursor=]'s [=cursor/got value flag=] to false.
+1. Set **this**'s [=cursor/got value flag=] to false.
 
-1. Let |request| be this [=cursor=]'s [=cursor/request=].
+1. Let |request| be **this**'s [=cursor/request=].
 
 1. Set |request|'s [=request/processed flag=] to false.
 
 1. Set |request|'s [=request/done flag=] to false.
 
 1. Run [=asynchronously execute a request=] with
-    the cursor's [=cursor/source=] as |source|,
+    **this**'s [=cursor/source=] as |source|,
     [=iterate a cursor=] as |operation| and |request|,
     using the [=current Realm=] as |targetRealm|,
-    this [=cursor=], |key| and |primaryKey|.
+    **this**, |key| and |primaryKey|.
 
 </div>
 
@@ -4734,8 +4660,7 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|,
 The <dfn method for=IDBCursor>update(|value|)</dfn> method, when
 invoked, must run these steps:
 
-1. Let |transaction| be this [=cursor=]'s
-    [=cursor/transaction=].
+1. Let |transaction| be **this**'s [=cursor/transaction=].
 
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
@@ -4743,14 +4668,14 @@ invoked, must run these steps:
 1. If |transaction| is a [=read-only transaction=], [=throw=] a
     "{{ReadOnlyError}}" {{DOMException}}.
 
-1. If the cursor's [=cursor/source=] or [=effective object
+1. If **this**'s [=cursor/source=] or [=effective object
     store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/got value flag=] is false, indicating that
+1. If **this**'s [=cursor/got value flag=] is false, indicating that
     the cursor is being iterated or has iterated past its end,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/key only flag=] is true, [=throw=] an
+1. If **this**'s [=cursor/key only flag=] is true, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
 1. Let |targetRealm| be a user-agent defined [=Realm=].
@@ -4766,25 +4691,25 @@ invoked, must run these steps:
       if the difference in behavior is not observable.
     </details>
 
-1. If the [=effective object store=] of this cursor uses [=in-line
+1. If **this**'s [=effective object store=] uses [=in-line
     keys=], then:
 
     1. Let |kpk| be the result of running
         [=extract a key from a value using a key path=] with
         |clone| and the [=object-store/key
-        path=] of the [=effective object store=].
+        path=] of **this**'s [=effective object store=].
         Rethrow any exceptions.
 
     1. If |kpk| is failure, invalid, or not [=equal to=]
-        the cursor's [=effective key=], [=throw=] a
+        **this**'s [=effective key=], [=throw=] a
         "{{DataError}}" {{DOMException}}.
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=cursor=] as |source| and [=store a
-    record into an object store=] as |operation|, using this
-    cursor's [=effective object store=] as |store|, the |clone| as
-    |value|, this cursor's [=effective key=] as |key|, and with the
+    with **this** as |source| and [=store a
+    record into an object store=] as |operation|, using **this**'s
+    [=effective object store=] as |store|, the |clone| as
+    |value|, **this**'s [=effective key=] as |key|, and with the
     |no-overwrite flag| false.
 
 </div>
@@ -4801,8 +4726,7 @@ invoked, must run these steps:
 The <dfn method for=IDBCursor>delete()</dfn> method, when invoked,
 must run these steps:
 
-1. Let |transaction| be this [=cursor=]'s
-    [=cursor/transaction=].
+1. Let |transaction| be **this**'s [=cursor/transaction=].
 
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
@@ -4810,21 +4734,21 @@ must run these steps:
 1. If |transaction| is a [=read-only transaction=], [=throw=] a
     "{{ReadOnlyError}}" {{DOMException}}.
 
-1. If the cursor's [=cursor/source=] or [=effective object
+1. If **this**'s [=cursor/source=] or [=effective object
     store=] has been deleted, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/got value flag=] is false, indicating that
+1. If **this**'s [=cursor/got value flag=] is false, indicating that
     the cursor is being iterated or has iterated past its end,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this cursor's [=cursor/key only flag=] is true, [=throw=] an
+1. If **this**'s [=cursor/key only flag=] is true, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with this [=cursor=] as |source| and
+    with **this** as |source| and
     [=delete records from an object store=] as |operation|, using
-    this cursor's [=effective object store=] and [=effective
+    **this**'s [=effective object store=] and [=effective
     key=] as |store| and |key| respectively.
 
 </div>
@@ -4847,7 +4771,7 @@ interface IDBCursorWithValue : IDBCursor {
 
 
 The <dfn attribute for=IDBCursorWithValue>value</dfn> attribute's
-getter must return the cursor's current [=cursor/value=]. Note
+getter must return **this**'s current [=cursor/value=]. Note
 that if this property returns an object, it returns the same object
 instance every time it is inspected, until the cursor's
 [=cursor/value=] is changed. This means that if the object is
@@ -4916,15 +4840,13 @@ enum IDBTransactionMode {
 The <dfn attribute for=IDBTransaction>objectStoreNames</dfn>
 attribute's getter must run these steps:
 
-1. If this [=/transaction=] is an [=/upgrade transaction=],
-    return a {{DOMStringList}} associated with a [=sorted name list=] of the [=object-store/names=]
-    of the [=/object stores=] in this
-    [=/transaction=]'s [=/connection=]'s [=object store
-    set=].
+1. If **this** is an [=/upgrade transaction=],
+    then return a {{DOMStringList}} associated with a [=sorted name list=] of the [=object-store/names=]
+    of the [=/object stores=] in **this**'s [=/connection=]'s [=object store set=].
 
 1. Otherwise, return a {{DOMStringList}} associated with a [=sorted name list=] of the
     [=object-store/names=] of the [=/object stores=] in
-    this [=/transaction=]'s [=transaction/scope=].
+    **this**'s [=transaction/scope=].
 
 </div>
 
@@ -4936,14 +4858,13 @@ attribute's getter must run these steps:
 </aside>
 
 The <dfn attribute for=IDBTransaction>mode</dfn> attribute's getter
-must return the [=transaction/mode=] of the [=/transaction=].
+must return **this**'s [=transaction/mode=].
 
 The <dfn attribute for=IDBTransaction>db</dfn> attribute's getter must
-return the [=database=] [=/connection=] of which this [=/transaction=]
-is a part.
+return **this**'s [=transaction/connection=]'s associated [=/database=].
 
 The <dfn attribute for=IDBTransaction>error</dfn> attribute's getter
-must return this [=/transaction=]'s [=transaction/error=], or null if
+must return **this**'s [=transaction/error=], or null if
 none.
 
 <aside class=note>
@@ -4993,12 +4914,12 @@ when invoked, must run these steps:
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 1. Let |store| be the [=/object store=]
-    [=object-store/named=] |name| in this
-    [=/transaction=]'s [=transaction/scope=], or [=throw=] a
+    [=object-store/named=] |name| in **this**'s
+    [=transaction/scope=], or [=throw=] a
     "{{NotFoundError}}" {{DOMException}} if none.
 
 1. Return an [=/object store handle=] associated with |store|
-    and this [=/transaction=].
+    and **this**.
 
 </div>
 
@@ -5020,11 +4941,11 @@ when invoked, must run these steps:
 The <dfn method for=IDBTransaction>abort()</dfn> method, when invoked,
 must run these steps:
 
-1. If this [=/transaction=]'s [=transaction/state=] is [=transaction/committing=]
+1. If **this**'s [=transaction/state=] is [=transaction/committing=]
     or [=transaction/finished=],
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Set the [=/transaction=]'s [=transaction/state=] to [=transaction/inactive=] and run
+1. Set **this**'s [=transaction/state=] to [=transaction/inactive=] and run
     [=abort a transaction=] with null as |error|.
 
 </div>
@@ -5034,10 +4955,10 @@ must run these steps:
 The <dfn method for=IDBTransaction>commit()</dfn> method, when invoked,
 must run these steps:
 
-1. If this [=/transaction=]'s [=transaction/state=] is not [=transaction/active=],
+1. If **this**'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Run [=commit a transaction=] with this [=/transaction=].
+1. Run [=commit a transaction=] with **this**.
 
 </div>
 
@@ -5286,8 +5207,8 @@ To <dfn>commit a transaction</dfn> with the |transaction| to commit, run these s
 
     1. [=Queue a task=] to run these steps:
 
-        1. If |transaction| is an [=/upgrade transaction=], set the
-            [=database=]'s [=database/upgrade transaction=] to null.
+        1. If |transaction| is an [=/upgrade transaction=], then set |transaction|'s
+            [=transaction/connection=]'s associated [=/database=]'s [=database/upgrade transaction=] to null.
 
         1. Set |transaction|'s [=transaction/state=] to [=transaction/finished=].
 
@@ -5359,8 +5280,8 @@ To <dfn>abort a transaction</dfn> with the |transaction| to abort, and |error|, 
 
 1. [=Queue a task=] to run these steps:
 
-    1. If |transaction| is an [=/upgrade transaction=], set the
-        [=database=]'s [=database/upgrade transaction=] to null.
+    1. If |transaction| is an [=/upgrade transaction=], then set |transaction|'s
+        [=transaction/connection=]'s associated [=/database=]'s [=database/upgrade transaction=] to null.
 
     1. [=Fire an event=] named <a event>`abort`</a> at |transaction|
         with its {{Event/bubbles}} attribute initialized to true.
@@ -5674,7 +5595,7 @@ the implementation must run these steps:
         then run [=abort a transaction=] with
         |transaction| and a newly <a for=exception>created</a>
         "{{AbortError}}" {{DOMException}} and terminate these steps.
-        This is done even if the event's [=canceled flag=] is false.
+        This is done even if |event|'s [=canceled flag=] is false.
 
         <aside class=note>
           This means that if an error event is fired and any of the event
@@ -5684,7 +5605,7 @@ the implementation must run these steps:
           {{Event/preventDefault()}} is never called.
         </aside>
 
-    1. If the event's [=canceled flag=] is false,
+    1. If |event|'s [=canceled flag=] is false,
         then run [=abort a transaction=] using
         |transaction| and [=/request=]'s [=request/error=], and
         terminate these steps.


### PR DESCRIPTION
Use WebIDL's **this** and **this**'s instead of "the cursor", "this range's", etc.

This addresses the bulk of the spec changes needed for issue #10 

Also tossed in a few "then"s in "if" sentences, and made some |var| usage more consistent.

No normative behavior changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/303.html" title="Last updated on Sep 27, 2019, 10:55 PM UTC (c92fc51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/303/6f17004...c92fc51.html" title="Last updated on Sep 27, 2019, 10:55 PM UTC (c92fc51)">Diff</a>