### PR TITLE
Make transactions inactive during clone

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6823,6 +6823,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Removed handling for nonstandard `lastModifiedDate` property of {{File}} objects. ([Issue #215](https://github.com/w3c/IndexedDB/issues/215))
 * Remove escaping {{IDBKeyRange/includes()}} method. ([Issue #294](https://github.com/w3c/IndexedDB/issues/294))
 * Restrict array keys to [=/Array exotic objects=] (i.e. disallow proxies). ([Issue #309](https://github.com/w3c/IndexedDB/issues/309])
+* Transactions are now temporarily made inactive during clone operations.
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}

--- a/index.bs
+++ b/index.bs
@@ -2983,7 +2983,7 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
 
 1. Let |targetRealm| be a user-agent defined [=Realm=].
 
-1. Let |clone| be a [=clone=] of |value| in |targetRealm|.
+1. Let |clone| be a [=clone=] of |value| in |targetRealm| during |transaction|.
     Rethrow any exceptions.
 
     <details class=note>
@@ -4680,7 +4680,7 @@ invoked, must run these steps:
 
 1. Let |targetRealm| be a user-agent defined [=Realm=].
 
-1. Let |clone| be a [=clone=] of |value| in |targetRealm|.
+1. Let |clone| be a [=clone=] of |value| in |targetRealm| during |transaction|.
     Rethrow any exceptions.
 
     <details class=note>
@@ -5528,8 +5528,7 @@ To <dfn>abort an upgrade transaction</dfn> with |transaction|, run these steps:
 
 <div class=algorithm>
 
-To <dfn>fire a success event</dfn> at a |request|,
-the implementation must run these steps:
+To <dfn>fire a success event</dfn> at a |request|, run these steps:
 
 1. Let |event| be the result of [=creating an event=] using {{Event}}.
 
@@ -5568,8 +5567,7 @@ the implementation must run these steps:
 
 <div class=algorithm>
 
-To <dfn>fire an error event</dfn> at a |request|,
-the implementation must run these steps:
+To <dfn>fire an error event</dfn> at a |request|, run these steps:
 
 1. Let |event| be the result of [=creating an event=] using {{Event}}.
 
@@ -5621,12 +5619,22 @@ the implementation must run these steps:
 
 <div class=algorithm>
 
-  To make a <dfn>clone</dfn> of |value| in |targetRealm|,
-  the implementation must run these steps:
+  To make a <dfn>clone</dfn> of |value| in |targetRealm| during |transaction|,
+  run these steps:
+
+  1. [=/Assert=]: |transaction|'s [=transaction/state=] is [=transaction/active=].
+
+  1. Set |transaction|'s [=transaction/state=] to [=transaction/inactive=].
+
+        <aside class=note>
+          The [=/transaction=] is made [=transaction/inactive=] so that getters or other side effects triggered by the cloning operation are unable to make additional requests against the transaction.
+        </aside>
 
   1. Let |serialized| be [=?=] <a abstract-op>StructuredSerializeForStorage</a>(|value|).
 
   1. Let |clone| be [=?=] <a abstract-op>StructuredDeserialize</a>(|serialized|, |targetRealm|).
+
+  1. Set |transaction|'s [=transaction/state=] to [=transaction/active=].
 
   1. Return |clone|.
 


### PR DESCRIPTION
To avoid side effects from getters during cloning operations (part of put/add/update calls), make transactions temporarily inactive.
 
 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/commit/fee6738f9523f5e257accfaea8ddfef2e28cfbcd

Implementation commitment:

 * [ ] WebKit (TBD)
 * [x] Chromium (https://chromium-review.googlesource.com/c/chromium/src/+/1869384)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1598164)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/310.html" title="Last updated on Nov 26, 2019, 7:15 PM UTC (0942443)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/310/7d425a9...0942443.html" title="Last updated on Nov 26, 2019, 7:15 PM UTC (0942443)">Diff</a>