### PR TITLE
Fix typo in link syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6861,7 +6861,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Added {{IDBCursor/request}} attribute. ([Issue #255](https://github.com/w3c/IndexedDB/issues/255))
 * Removed handling for nonstandard `lastModifiedDate` property of {{File}} objects. ([Issue #215](https://github.com/w3c/IndexedDB/issues/215))
 * Remove escaping {{IDBKeyRange/includes()}} method. ([Issue #294](https://github.com/w3c/IndexedDB/issues/294))
-* Restrict array keys to [=/Array exotic objects=] (i.e. disallow proxies). ([Issue #309](https://github.com/w3c/IndexedDB/issues/309])
+* Restrict array keys to [=/Array exotic objects=] (i.e. disallow proxies). ([Issue #309](https://github.com/w3c/IndexedDB/issues/309))
 * Transactions are now temporarily made inactive during clone operations.
 * Added {{IDBTransactionOptions/durability}} option and {{IDBTransaction/durability}} attribute. ([Issue #50](https://github.com/w3c/IndexedDB/issues/50))
 


### PR DESCRIPTION
Link to GitHub issue was broken because of a wrong bracket.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Simran-B/IndexedDB/pull/315.html" title="Last updated on Jan 23, 2020, 2:45 PM UTC (d12061a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/315/7f341b9...Simran-B:d12061a.html" title="Last updated on Jan 23, 2020, 2:45 PM UTC (d12061a)">Diff</a>