### PR TITLE
Editorial: Fix some incorrect capitalization, and make sections less shouty

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -433,7 +433,7 @@ which is either null or an [=/upgrade transaction=], and is initially null.
 </div>
 
 <!-- ============================================================ -->
-### Database Connection ### {#database-connection}
+### Database connection ### {#database-connection}
 <!-- ============================================================ -->
 
 Script does not interact with [=databases=] directly. Instead,
@@ -501,7 +501,7 @@ to allow the upgrade or delete to proceed.
 
 
 <!-- ============================================================ -->
-## Object Store ## {#object-store-construct}
+## Object store ## {#object-store-construct}
 <!-- ============================================================ -->
 
 An <dfn>object store</dfn> is the primary storage mechanism for
@@ -544,7 +544,7 @@ one of three sources:
 </div>
 
 <!-- ============================================================ -->
-### Object Store Handle ### {#object-store-handle-construct}
+### Object store handle ### {#object-store-handle-construct}
 <!-- ============================================================ -->
 
 Script does not interact with [=/object stores=] directly. Instead,
@@ -737,7 +737,7 @@ of running [=compare two keys=] with |a| and |b| is 0.
 
 
 <!-- ============================================================ -->
-## Key Path ## {#key-path-construct}
+## Key path ## {#key-path-construct}
 <!-- ============================================================ -->
 
 A <dfn>key path</dfn> is a string or list of strings
@@ -857,7 +857,7 @@ one [=object-store/record=] is added to the index for each of the [=subkeys=].
 </div>
 
 <!-- ============================================================ -->
-### Index Handle ### {#index-handle-construct}
+### Index handle ### {#index-handle-construct}
 <!-- ============================================================ -->
 
 Script does not interact with [=/indexes=] directly. Instead, within
@@ -973,7 +973,7 @@ A <dfn>read/write transaction</dfn>
 is a [=/transaction=] with [=transaction/mode=] {{"readwrite"}}.
 
 <!-- ============================================================ -->
-### Transaction Lifecycle ### {#transaction-lifecycle}
+### Transaction lifecycle ### {#transaction-lifecycle}
 <!-- ============================================================ -->
 
 A [=/transaction=] has a <dfn>state</dfn>, which is one
@@ -1124,7 +1124,7 @@ They will return true if any transactions were cleaned up, or false otherwise.
 </aside>
 
 <!-- ============================================================ -->
-### Transaction Scheduling ### {#transaction-scheduling}
+### Transaction scheduling ### {#transaction-scheduling}
 <!-- ============================================================ -->
 
 An event with type <dfn event>`complete`</dfn> is fired at
@@ -1206,7 +1206,7 @@ The following constraints define when a [=/transaction=] can be
 
 
 <!-- ============================================================ -->
-### Upgrade Transactions ### {#upgrade-transaction-construct}
+### Upgrade transactions ### {#upgrade-transaction-construct}
 <!-- ============================================================ -->
 
 An <dfn>upgrade transaction</dfn> is a [=/transaction=] with [=transaction/mode=]
@@ -1298,7 +1298,7 @@ A [=/request=]'s [=get the parent=] algorithm returns the request's
 </aside>
 
 <!-- ============================================================ -->
-### Open Requests ### {#open-requests}
+### Open requests ### {#open-requests}
 <!-- ============================================================ -->
 
 An <dfn>open request</dfn> is a special type of [=/request=] used
@@ -1336,7 +1336,7 @@ further requests to be processed.
 </div>
 
 <!-- ============================================================ -->
-## Key Range ## {#range-construct}
+## Key range ## {#range-construct}
 <!-- ============================================================ -->
 
 Records can be retrieved from [=/object stores=] and [=/indexes=]
@@ -1532,7 +1532,7 @@ whether the cursor's [=cursor/value=] is exposed via the API.
 </div>
 
 <!-- ============================================================ -->
-## Key Generators ## {#key-generator-construct}
+## Key generators ## {#key-generator-construct}
 <!-- ============================================================ -->
 
 When a [=/object store=] is created it can be specified to use a
@@ -5697,7 +5697,7 @@ a request=].
 </aside>
 
 <!-- ============================================================ -->
-## Object Store Storage Operation ## {#object-store-storage-operation}
+## Object store storage operation ## {#object-store-storage-operation}
 <!-- ============================================================ -->
 
 <div class=algorithm>
@@ -5803,7 +5803,7 @@ To <dfn>store a record into an object store</dfn> with
 
 
 <!-- ============================================================ -->
-## Object Store Retrieval Operations ## {#object-store-retrieval-operation}
+## Object store retrieval operations ## {#object-store-retrieval-operation}
 <!-- ============================================================ -->
 
 <div class=algorithm>
@@ -5890,7 +5890,7 @@ with |store|, |range| and optional |count|, run these steps:
 
 
 <!-- ============================================================ -->
-## Index Retrieval Operations ## {#index-retrieval-operation}
+## Index retrieval operations ## {#index-retrieval-operation}
 <!-- ============================================================ -->
 
 <div class=algorithm>
@@ -5977,7 +5977,7 @@ To <dfn>retrieve multiple values from an index</dfn> with
 
 
 <!-- ============================================================ -->
-## Object Store Deletion Operation ## {#object-store-deletion-operation}
+## Object store deletion operation ## {#object-store-deletion-operation}
 <!-- ============================================================ -->
 
 <div class=algorithm>
@@ -5999,7 +5999,7 @@ with |store| and |range|, run these steps:
 
 
 <!-- ============================================================ -->
-## Record Counting Operation ## {#record-counting-operation}
+## Record counting operation ## {#record-counting-operation}
 <!-- ============================================================ -->
 
 <div class=algorithm>
@@ -6016,7 +6016,7 @@ To <dfn>count the records in a range</dfn> with |source| and
 
 
 <!-- ============================================================ -->
-## Object Store Clear Operation ## {#object-store-clear-operation}
+## Object store clear operation ## {#object-store-clear-operation}
 <!-- ============================================================ -->
 
 <div class=algorithm>
@@ -6034,7 +6034,7 @@ To <dfn>clear an object store</dfn> with |store|, run these steps:
 
 
 <!-- ============================================================ -->
-## Cursor Iteration Operation ## {#cursor-iteration-operation}
+## Cursor iteration operation ## {#cursor-iteration-operation}
 <!-- ============================================================ -->
 
 <div class=algorithm>
@@ -6640,7 +6640,7 @@ steps may throw an exception.
 
 
 <!-- ============================================================ -->
-# Privacy Considerations # {#privacy}
+# Privacy considerations # {#privacy}
 <!-- ============================================================ -->
 
 *This section is non-normative.*
@@ -6753,7 +6753,7 @@ it is promptly deleted from the underlying storage.
 
 
 <!-- ============================================================ -->
-# Security Considerations # {#security}
+# Security considerations # {#security}
 <!-- ============================================================ -->
 
 ## DNS spoofing attacks ## {#dns-spoofing-attacks}
@@ -6843,7 +6843,7 @@ format, and to reconstruct any internal state from script-visible
 state when older data is encountered.
 
 <!-- ============================================================ -->
-# Revision History # {#revision-history}
+# Revision history # {#revision-history}
 <!-- ============================================================ -->
 
 *This section is non-normative.*

--- a/index.bs
+++ b/index.bs
@@ -885,7 +885,7 @@ an [=/upgrade transaction=] is running.
 ## Transactions ## {#transaction-construct}
 <!-- ============================================================ -->
 
-A <dfn id=transaction-concept>Transaction</dfn> is used to interact
+A <dfn id=transaction-concept>transaction</dfn> is used to interact
 with the data in a [=database=]. Whenever data is read or written
 to the database it is done by using a [=/transaction=].
 
@@ -4809,7 +4809,7 @@ the contents of the database.
 ## The {{IDBTransaction}} interface ## {#transaction}
 <!-- ============================================================ -->
 
-[=/transaction=] objects implement the following interface:
+[=/Transaction=] objects implement the following interface:
 
 <xmp class=idl>
 [Exposed=(Window,Worker)]


### PR DESCRIPTION
Non-normative.

* Fix a couple incorrect capitalization instances
* Make section titles consistently "Sentence case" instead of "Title Case"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/320.html" title="Last updated on Feb 27, 2020, 12:25 AM UTC (26e9d90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/320/e103766...26e9d90.html" title="Last updated on Feb 27, 2020, 12:25 AM UTC (26e9d90)">Diff</a>