### PR TITLE
Editorial: Call out browser versions for new features

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5010,7 +5010,7 @@ must run these steps:
 <aside class=advisement>
   &#x1F6A7;
   The {{IDBTransaction/commit()}} method is new in this edition.
-  It is supported in Chrome 76, Edge 79, and Firefox 75.
+  It is supported in Chrome 76, Edge 79, and Firefox 74.
 
   &#x1F6A7;
 </aside>

--- a/index.bs
+++ b/index.bs
@@ -2407,6 +2407,7 @@ when invoked, must run these steps:
 <aside class=advisement>
   &#x1F6A7;
   The {{IDBFactory/databases()}} method is new in this edition.
+  It is supported in Chrome 71 and Edge 79.
   &#x1F6A7;
 </aside>
 
@@ -2717,6 +2718,7 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|, |mode|, |options|)</df
 <aside class=advisement>
   &#x1F6A7;
   The {{IDBTransactionOptions/durability}} option is new in this edition.
+  It is supported in Chrome 82 and Edge 82.
   &#x1F6A7;
 </aside>
 
@@ -4425,6 +4427,7 @@ return **this**'s [=cursor/request=].
 <aside class=advisement>
   &#x1F6A7;
   The {{IDBCursor/request}} attribute is new in this edition.
+  It is supported in Chrome 76 and Edge 79.
   &#x1F6A7;
 </aside>
 
@@ -4897,6 +4900,7 @@ The <dfn attribute for=IDBTransaction>durability</dfn> attribute's getter must r
 <aside class=advisement>
   &#x1F6A7;
   The {{IDBTransaction/durability}} attribute is new in this edition.
+  It is supported in Chrome 82 and Edge 82.
   &#x1F6A7;
 </aside>
 
@@ -5006,6 +5010,8 @@ must run these steps:
 <aside class=advisement>
   &#x1F6A7;
   The {{IDBTransaction/commit()}} method is new in this edition.
+  It is supported in Chrome 76, Edge 79, and Firefox 75.
+
   &#x1F6A7;
 </aside>
 


### PR DESCRIPTION
While the spec is in "draft" mode, it has banners indicating what's new, e.g.:

> 🚧 The databases() method is new in this edition. 🚧

While v2 was in draft I called out when new features appeared in the various browsers. Trying that again this time. I used wpt.fyi to figure out support, then investigated dates as best I could...

@asutherland - can you verify the Firefox date (commit() is new in 75 per wpt.fyi I think?)

@aliams - can you verify the Edge dates? I'm assuming anything coming in Chrome 82 will be in Edge 82, and anything that appeared prior to Chrome 79 will would have first appeared in Edge 79 ?

Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/321.html" title="Last updated on Mar 2, 2020, 6:06 PM UTC (3983273)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/321/d3e301d...3983273.html" title="Last updated on Mar 2, 2020, 6:06 PM UTC (3983273)">Diff</a>