### PR TITLE
Editorial: Use settings object definition.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2201,7 +2201,7 @@ when invoked, must run these steps:
 
 1. If |version| is 0 (zero), [=throw=] a [=TypeError=].
 
-1. Let |origin| be the [=/current settings object=]'s [=environment settings object/origin=].
+1. Let |origin| be the [=/relevant settings object=]'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2271,7 +2271,7 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>deleteDatabase(|name|)</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/current settings object=]'s [=environment settings object/origin=].
+1. Let |origin| be the [=/relevant settings object=]'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2326,7 +2326,7 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>databases()</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/current settings object=]'s [=environment settings object/origin=].
+1. Let |origin| be the [=/relevant settings object=]'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=],
     then return [=/a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -2201,7 +2201,7 @@ when invoked, must run these steps:
 
 1. If |version| is 0 (zero), [=throw=] a [=TypeError=].
 
-1. Let |origin| be the [=/origin=] of the global scope used to access [=/this=].
+1. Let |origin| be the [=/current settings object=]'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2271,7 +2271,7 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>deleteDatabase(|name|)</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/origin=] of the global scope used to access [=/this=].
+1. Let |origin| be the [=/current settings object=]'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2326,7 +2326,7 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>databases()</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/origin=] of the global scope used to access [=/this=].
+1. Let |origin| be the [=/current settings object=]'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=],
     then return [=/a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -2201,7 +2201,9 @@ when invoked, must run these steps:
 
 1. If |version| is 0 (zero), [=throw=] a [=TypeError=].
 
-1. Let |origin| be the [=/relevant settings object=]'s [=environment settings object/origin=].
+1. Let |environment| be [=/this=]'s [=/relevant settings object=].
+
+1. Let |origin| be |environment|'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2271,7 +2273,9 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>deleteDatabase(|name|)</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/relevant settings object=]'s [=environment settings object/origin=].
+1. Let |environment| be [=/this=]'s [=/relevant settings object=].
+
+1. Let |origin| be |environment|'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=], [=throw=] a
     "{{SecurityError}}" {{DOMException}} and abort these steps.
@@ -2326,7 +2330,9 @@ when invoked, must run these steps:
 The <dfn method for=IDBFactory>databases()</dfn> method,
 when invoked, must run these steps:
 
-1. Let |origin| be the [=/relevant settings object=]'s [=environment settings object/origin=].
+1. Let |environment| be [=/this=]'s [=/relevant settings object=].
+
+1. Let |origin| be |environment|'s [=environment settings object/origin=].
 
 1. If |origin| is an [=opaque origin=],
     then return [=/a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.


### PR DESCRIPTION
Closes #329

Use the formal definition for environment settings object rather than the imprecise "global scope used to access this".

No normative behavior changes, just being more precise.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/330.html" title="Last updated on Apr 14, 2020, 9:03 PM UTC (656a17f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/330/b226ac6...656a17f.html" title="Last updated on Apr 14, 2020, 9:03 PM UTC (656a17f)">Diff</a>