### PR TITLE
Editorial: Use Bikeshed's algorithm and var more better

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3120,7 +3120,7 @@ The <dfn method for=IDBObjectStore>get(|query|)</dfn> method steps are:
 
 1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
 
-1. Let |operation| be an algorithm to run [=retrieve a value from an object store=] with [=current Realm=], |store| and |range|.
+1. Let |operation| be an algorithm to run [=retrieve a value from an object store=] with the [=/current Realm=], |store|, and |range|.
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
@@ -3191,7 +3191,7 @@ The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn> method steps a
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Let |operation| be an algorithm to run [=retrieve multiple values from an object store=] with [=current Realm=], |store|, |range|, and |count| if given.
+1. Let |operation| be an algorithm to run [=retrieve multiple values from an object store=] with the [=/current Realm=], |store|, |range|, and |count| if given.
 
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
@@ -3328,7 +3328,7 @@ The <dfn method for=IDBObjectStore>openCursor(|query|, |direction|)</dfn> method
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to false.
 
-1. Let |operation| be an algorithm to run [=iterate a cursor=] with [=current Realm=] |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=/current Realm=] |cursor|.
 
 1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
@@ -3373,7 +3373,7 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|, |direction|)</dfn> met
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to true.
 
-1. Let |operation| be an algorithm to run [=iterate a cursor=] with [=current Realm=] and |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=/current Realm=] and |cursor|.
 
 1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
@@ -3789,7 +3789,7 @@ The <dfn method for=IDBIndex>get(|query|)</dfn> method steps are:
 
 1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
 
-1. Let |operation| be an algorithm to run [=retrieve a referenced value from an index=] with [=current Realm=], |index| and |range|.
+1. Let |operation| be an algorithm to run [=retrieve a referenced value from an index=] with the [=/current Realm=], |index|, and |range|.
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
@@ -3860,7 +3860,7 @@ The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method steps are:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Let |operation| be an algorithm to run [=retrieve multiple referenced values from an index=] with [=current Realm=], |index|, |range|, and |count| if given.
+1. Let |operation| be an algorithm to run [=retrieve multiple referenced values from an index=] with the [=/current Realm=], |index|, |range|, and |count| if given.
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
@@ -3995,7 +3995,7 @@ The <dfn method for=IDBIndex>openCursor(|query|, |direction|)</dfn> method steps
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to false.
 
-1. Let |operation| be an algorithm to run [=iterate a cursor=] with [=current Realm=] and |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=/current Realm=] and |cursor|.
 
 1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
@@ -4040,7 +4040,7 @@ The <dfn method for=IDBIndex>openKeyCursor(|query|, |direction|)</dfn> method st
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to true.
 
-1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=current Realm=], and |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=/current Realm=] and |cursor|.
 
 1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
@@ -4411,7 +4411,7 @@ The <dfn method for=IDBCursor>advance(|count|)</dfn> method steps are:
 
 1. Set |request|'s [=request/done flag=] to false.
 
-1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=current Realm=], [=/this=], and |count|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=/current Realm=], [=/this=], and |count|.
 
 1. Run [=asynchronously execute a request=] with [=/this=]'s [=cursor/source=], |operation|, and |request|.
 
@@ -4468,7 +4468,7 @@ The <dfn method for=IDBCursor>continue(|key|)</dfn> method steps are:
 
 1. Set |request|'s [=request/done flag=] to false.
 
-1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=current Realm=], [=/this=], and |key| (if given).
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=/current Realm=], [=/this=], and |key| (if given).
 
 1. Run [=asynchronously execute a request=] with [=/this=]'s [=cursor/source=], |operation|, and |request|.
 
@@ -4546,7 +4546,7 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|, |primaryKey|)</dfn> meth
 
 1. Set |request|'s [=request/done flag=] to false.
 
-1. Let |operation| be the an algorithm to run [=iterate a cursor=] with the [=current Realm=], [=/this=], |key|, and |primaryKey|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=/current Realm=], [=/this=], |key|, and |primaryKey|.
 
 1. Run [=asynchronously execute a request=] with [=/this=]'s [=cursor/source=], |operation|, and |request|.
 

--- a/index.bs
+++ b/index.bs
@@ -477,7 +477,7 @@ A [=/connection=] may be closed by a user agent in exceptional
 circumstances, for example due to loss of access to the file system, a
 permission change, or clearing of the origin's storage. If this occurs
 the user agent must run [=close a database
-connection=] with the [=/connection=] and with the |forced flag| set to true.
+connection=] with the [=/connection=] and with the <var ignore>forced flag</var> set to true.
 
 A [=/connection=] has an <dfn>object store set</dfn>, which is
 initialized to the set of [=/object stores=] in the associated
@@ -638,7 +638,7 @@ An <dfn>array key</dfn> is a [=/key=] with [=key/type=] *array*.
 The <dfn>subkeys</dfn> of an [=array key=] are the [=list/items=] of the
 [=array key=]'s [=key/value=].
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>compare two keys</dfn> |a| and |b|, run these steps:
 
@@ -1093,10 +1093,11 @@ the case even if the transaction has not yet been
 requests; however, the implementation must keep track of the
 [=/requests=] and their order.
 
+<div algorithm>
+
 To <dfn id=cleanup-indexed-database-transactions export>cleanup Indexed Database transactions</dfn>, run the following steps.
 They will return true if any transactions were cleaned up, or false otherwise.
 
-<div class=algorithm>
     1. If there are no [=/transactions=] with [=transaction/cleanup
         event loop=] matching the current [=/event loop=], return false.
 
@@ -1352,7 +1353,7 @@ An <dfn>unbounded key range</dfn> is a [=key range=] that has both
 [=/keys=] are [=in=] an [=unbounded key
 range=].
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>convert a value to a key range</dfn> with
 |value| and optional |null disallowed flag|, run these steps:
@@ -1533,7 +1534,7 @@ generator.
 When a [=object-store/record=] is stored and a [=/key=] is not specified
 in the call to store the record, a key is generated.
 
-<div class=algorithm>
+<div algorithm>
 
   To <dfn>generate a key</dfn> for an [=/object store=] |store|, run these steps:
 
@@ -1553,7 +1554,7 @@ When a [=object-store/record=] is stored and a [=/key=] is specified
 in the call to store the record, the associated [=key generator=] may
 be updated.
 
-<div class=algorithm>
+<div algorithm>
 
   To <dfn>possibly update the key generator</dfn> for an [=/object store=] |store| with |key|,
   run these steps:
@@ -2004,7 +2005,7 @@ enum IDBRequestReadyState {
         then returns {{"done"}}.
 </div>
 
-<div class=algorithm>
+<div algorithm>
 The <dfn attribute for=IDBRequest>result</dfn> getter steps are:
 
 1. If [=/this=]'s [=request/done flag=] is false, then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -2012,7 +2013,7 @@ The <dfn attribute for=IDBRequest>result</dfn> getter steps are:
 
 </div>
 
-<div class=algorithm>
+<div algorithm>
 The <dfn attribute for=IDBRequest>error</dfn> getter steps are:
 
 1. If [=/this=]'s [=request/done flag=] is false, then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -2087,7 +2088,7 @@ The <dfn attribute for=IDBVersionChangeEvent>newVersion</dfn> getter steps are t
 
 Events are constructed as defined in [[DOM#constructing-events]].
 
-<div class=algorithm>
+<div algorithm>
 
   To <dfn>fire a version change event</dfn> named |e| at |target| given
   |oldVersion| and |newVersion|, run these steps:
@@ -2159,7 +2160,7 @@ dictionary IDBDatabaseInfo {
         {{IDBFactory/open()|open}}(|name|, |version|)
     ::
         Attempts to open a [=/connection=] to the named [=/database=]
-        with the specified version. If the database already exists
+        with the specified |version|. If the database already exists
         with a lower version and there are open [=/connections=]
         that don't close in response to a
         <a event>`versionchange`</a> event, the request will be
@@ -2192,7 +2193,7 @@ dictionary IDBDatabaseInfo {
         to create, upgrade, or delete databases by this context or others.
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBFactory>open(|name|, |version|)</dfn> method steps are:
 
@@ -2265,7 +2266,7 @@ The <dfn method for=IDBFactory>open(|name|, |version|)</dfn> method steps are:
 
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBFactory>deleteDatabase(|name|)</dfn> method steps are:
 
@@ -2321,7 +2322,7 @@ The <dfn method for=IDBFactory>deleteDatabase(|name|)</dfn> method steps are:
 
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBFactory>databases()</dfn> method steps are:
 
@@ -2375,7 +2376,7 @@ The <dfn method for=IDBFactory>databases()</dfn> method steps are:
         Throws a "{{DataError}}" {{DOMException}} if either input is not a valid [=/key=].
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBFactory>cmp(|first|, |second|)</dfn> method steps are:
 
@@ -2515,7 +2516,7 @@ the [=/object stores=] in [=/this=]'s [=object store set=].
 </details>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBDatabase>createObjectStore(|name|, |options|)</dfn> method steps are:
 
@@ -2580,7 +2581,7 @@ failed due to quota reasons, a "{{QuotaExceededError}}" {{DOMException}} must be
 error.
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBDatabase>deleteObjectStore(|name|)</dfn> method steps are:
 
@@ -2634,7 +2635,7 @@ instance on which it was called.
         have finished.
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBDatabase>transaction(|storeNames|, |mode|, |options|)</dfn> method steps are:
 
@@ -2657,7 +2658,7 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|, |mode|, |options|)</df
 1. If |mode| is not {{"readonly"}} or {{"readwrite"}},
     [=throw=] a [=TypeError=].
 
-1. Let |transaction| be a newly [=transaction/created=] [=/transaction=] with |connection|, |mode|, |options|' {{IDBTransactionOptions/durability}} member, and the set of [=/object stores=] named in |scope|.
+1. Let |transaction| be a newly [=transaction/created=] [=/transaction=] with this [=/connection=], |mode|, |options|' {{IDBTransactionOptions/durability}} member, and the set of [=/object stores=] named in |scope|.
 
 1. Set |transaction|'s [=transaction/cleanup event loop=] to the
     current [=/event loop=].
@@ -2679,7 +2680,7 @@ The <dfn method for=IDBDatabase>transaction(|storeNames|, |mode|, |options|)</df
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBDatabase>close()</dfn> method steps are:
 
@@ -2765,7 +2766,7 @@ dictionary IDBIndexParameters {
     ::
         Returns the [=object-store/key path=] of the store, or null if none.
 
-    : |list| . {{IDBObjectStore/indexNames}}
+    : |store| . {{IDBObjectStore/indexNames}}
     ::
         Returns a list of the names of indexes in the store.
 
@@ -2793,7 +2794,7 @@ The <dfn attribute for=IDBObjectStore>name</dfn> getter steps are to return [=/t
 </details>
 
 
-<div class=algorithm>
+<div algorithm="IDBObjectStore name setter">
 
 The {{IDBObjectStore/name}} setter steps are:
 
@@ -2914,7 +2915,7 @@ The <dfn method for=IDBObjectStore>put(|value|, |key|)</dfn> method steps are to
 
 The <dfn method for=IDBObjectStore>add(|value|, |key|)</dfn> method steps are to return the result of running [=add or put=] with [=/this=], |value|, |key| and the |no-overwrite flag| true.
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|, run these steps:
 
@@ -2985,14 +2986,14 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with |handle| as |source| and
+    with |handle| as <var ignore>source</var> and
     [=store a record into an object store=] as
-    |operation|, using |store|, the |clone| as |value|, |key|, and
+    <var ignore>operation</var>, using |store|, the |clone| as <var ignore>value</var>, |key|, and
     |no-overwrite flag|.
 
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>delete(|query|)</dfn> method steps are:
 
@@ -3011,19 +3012,21 @@ The <dfn method for=IDBObjectStore>delete(|query|)</dfn> method steps are:
 
 1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
-    |null disallowed flag| true. Rethrow any exceptions.
+    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
+    with [=/this=] as <var ignore>source</var> and
     [=delete records from an object store=] as
-    |operation|, using |store| and |range|.
+    <var ignore>operation</var>, using |store| and |range|.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/records=] keys to be
 deleted.
+</aside>
 
 <aside class=note>
   Unlike other methods which take keys or key ranges, this method does
@@ -3032,7 +3035,7 @@ deleted.
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>clear()</dfn> method steps are:
 
@@ -3051,10 +3054,11 @@ The <dfn method for=IDBObjectStore>clear()</dfn> method steps are:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
+    with [=/this=] as <var ignore>source</var> and
     [=clear an object store=] as
-    |operation|, using |store|.
+    <var ignore>operation</var>, using |store|.
 
+</div>
 
 <div class="domintro note">
   The following methods throw a "{{TransactionInactiveError}}" {{DOMException}} if called
@@ -3108,6 +3112,8 @@ The <dfn method for=IDBObjectStore>clear()</dfn> method steps are:
         If successful, |request|'s {{IDBRequest/result}} will be the count.
 </div>
 
+<div algorithm>
+
 The <dfn method for=IDBObjectStore>get(|query|)</dfn> method steps are:
 
 1. Let |transaction| be [=/this=]'s [=object-store-handle/transaction=].
@@ -3122,21 +3128,23 @@ The <dfn method for=IDBObjectStore>get(|query|)</dfn> method steps are:
 
 1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
-    |null disallowed flag| true. Rethrow any exceptions.
+    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and [=retrieve a value from
-    an object store=] as |operation|, using the
-    [=current Realm=] as |targetRealm|,
+    with [=/this=] as <var ignore>source</var> and [=retrieve a value from
+    an object store=] as <var ignore>operation</var>, using the
+    [=current Realm=] as <var ignore>targetRealm</var>,
     |store| and |range|.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/record=] to be retrieved. If a
 range is specified, the method retrieves the first existing value in
 that range.
+</aside>
 
 <aside class=note>
   This method produces the same result if a record with the given key
@@ -3148,7 +3156,7 @@ that range.
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>getKey(|query|)</dfn> method steps are:
 
@@ -3164,23 +3172,25 @@ The <dfn method for=IDBObjectStore>getKey(|query|)</dfn> method steps are:
 
 1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
-    |null disallowed flag| true. Rethrow any exceptions.
+    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and [=retrieve a key from an
-    object store=] as |operation|, using |store|
+    with [=/this=] as <var ignore>source</var> and [=retrieve a key from an
+    object store=] as <var ignore>operation</var>, using |store|
     and |range|.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/record=] key to be
 retrieved. If a range is specified, the method retrieves
 the first existing key in that range.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn> method steps are:
 
@@ -3200,21 +3210,23 @@ The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn> method steps a
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
+    with [=/this=] as <var ignore>source</var> and
     [=retrieve multiple values from an object store=]
-    as |operation|, using the [=current Realm=] as |targetRealm|,
+    as <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>,
     |store|, |range|, and |count| if given.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/records=] to be retrieved. If null or not given,
 an [=unbounded key range=] is used. If |count| is specified and
 there are more than |count| records in range, only the first |count|
 will be retrieved.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>getAllKeys(|query|, |count|)</dfn> method steps are:
 
@@ -3234,20 +3246,22 @@ The <dfn method for=IDBObjectStore>getAllKeys(|query|, |count|)</dfn> method ste
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
+    with [=/this=] as <var ignore>source</var> and
     [=retrieve multiple keys from an object store=] as
-    |operation|, using |store|, |range|, and |count| if given.
+    <var ignore>operation</var>, using |store|, |range|, and |count| if given.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/records=] keys to be retrieved. If null or not
 given, an [=unbounded key range=] is used. If |count| is specified
 and there are more than |count| keys in range, only the first |count|
 will be retrieved.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>count(|query|)</dfn> method steps are:
 
@@ -3267,15 +3281,18 @@ The <dfn method for=IDBObjectStore>count(|query|)</dfn> method steps are:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
-    [=count the records in a range=] as |operation|, using
-    |source| and |range|.
+    with [=/this=] as <var ignore>source</var> and
+    [=count the records in a range=] as <var ignore>operation</var>, using
+    |store| as <var ignore>source</var> and |range|.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/records=] keys to be counted. If null or not
 given, an [=unbounded key range=] is used.
+</aside>
+
 
 <div class="domintro note">
   The following methods throw a "{{TransactionInactiveError}}" {{DOMException}} if called
@@ -3306,7 +3323,7 @@ given, an [=unbounded key range=] is used.
         null if there were no matching [=object-store/records=].
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>openCursor(|query|, |direction|)</dfn> method steps are:
 
@@ -3335,8 +3352,8 @@ The <dfn method for=IDBObjectStore>openCursor(|query|, |direction|)</dfn> method
     [=cursor/key only flag=] set to false.
 
 1. Let |request| be the result of running
-    [=asynchronously execute a request=] with [=/this=] as |source| and [=iterate a cursor=] as
-    |operation|, using the [=current Realm=] as |targetRealm|, and
+    [=asynchronously execute a request=] with [=/this=] as <var ignore>source</var> and [=iterate a cursor=] as
+    <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>, and
     |cursor|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
@@ -3345,12 +3362,14 @@ The <dfn method for=IDBObjectStore>openCursor(|query|, |direction|)</dfn> method
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 to use as the [=cursor=]'s [=cursor/range=].
 If null or not given, an [=unbounded key range=] is used.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>openKeyCursor(|query|, |direction|)</dfn> method steps are:
 
@@ -3379,8 +3398,8 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|, |direction|)</dfn> met
     [=cursor/key only flag=] set to true.
 
 1. Let |request| be the result of running
-    [=asynchronously execute a request=] with [=/this=] as |source| and [=iterate a cursor=] as
-    |operation|, using the [=current Realm=] as |targetRealm|, and
+    [=asynchronously execute a request=] with [=/this=] as <var ignore>source</var> and [=iterate a cursor=] as
+    <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>, and
     |cursor|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
@@ -3389,9 +3408,12 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|, |direction|)</dfn> met
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 to use as the [=cursor=]'s [=cursor/range=]. If null
 or not given, an [=unbounded key range=] is used.
+</aside>
+
 
 <div class="domintro note">
     : |index| = |store| . index(|name|)
@@ -3420,7 +3442,7 @@ or not given, an [=unbounded key range=] is used.
         transaction=].
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>createIndex(|name|, |keyPath|, |options|)</dfn> method steps are:
 
@@ -3495,7 +3517,7 @@ need to ask the user for permission for quota reasons. Such
 implementations must still create and return an {{IDBIndex}} object,
 and once the implementation determines that creating the index has
 failed, it must run the steps to [=abort
-a transaction=] using an appropriate error as |error|. For example
+a transaction=] using an appropriate error as <var ignore>error</var>. For example
 if creating the [=/index=] failed due to quota reasons,
 a "{{QuotaExceededError}}" {{DOMException}} must be used as error and if the index can't be
 created due to [=unique flag=] constraints, a "{{ConstraintError}}" {{DOMException}}
@@ -3522,7 +3544,7 @@ must be used as error.
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>index(|name|)</dfn> method steps are:
 
@@ -3558,7 +3580,7 @@ The <dfn method for=IDBObjectStore>index(|name|)</dfn> method steps are:
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBObjectStore>deleteIndex(|name|)</dfn> method steps are:
 
@@ -3665,7 +3687,7 @@ return [=/this=]'s [=index/name=].
 </details>
 
 
-<div class=algorithm>
+<div algorithm="IDBIndex name setter">
 
 The {{IDBIndex/name}} setter steps are:
 
@@ -3776,7 +3798,7 @@ return [=/this=]'s [=index-handle/index=]'s [=unique flag=].
         count.
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBIndex>get(|query|)</dfn> method steps are:
 
@@ -3792,22 +3814,23 @@ The <dfn method for=IDBIndex>get(|query|)</dfn> method steps are:
 
 1. Let |range| be the result of running
     [=convert a value to a key range=] with |query| and
-    |null disallowed flag| true. Rethrow any exceptions.
+    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
+    with [=/this=] as <var ignore>source</var> and
     [=retrieve a referenced value from an index=]
-    as |operation|, using the [=current Realm=] as |targetRealm|,
+    as <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>,
     |index| and |range|.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/record=] to be retrieved. If a
 range is specified, the method retrieves the first existing record in
 that range.
-
+</aside>
 
 <aside class=note>
   This method produces the same result if a record with the given key
@@ -3819,7 +3842,7 @@ that range.
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBIndex>getKey(|query|)</dfn> method steps are:
 
@@ -3834,24 +3857,26 @@ The <dfn method for=IDBIndex>getKey(|query|)</dfn> method steps are:
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
 1. Let |range| be the result of running [=convert a
-    value to a key range=] with |query| and |null disallowed flag|
+    value to a key range=] with |query| and <var ignore>null disallowed flag</var>
     true. Rethrow any exceptions.
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
-    [=retrieve a value from an index=] as |operation|, using |index|
+    with [=/this=] as <var ignore>source</var> and
+    [=retrieve a value from an index=] as <var ignore>operation</var>, using |index|
     and |range|.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/record=] key to be retrieved.
 If a range is specified, the method retrieves the first existing key
 in that range.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method steps are:
 
@@ -3871,21 +3896,23 @@ The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method steps are:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
+    with [=/this=] as <var ignore>source</var> and
     [=retrieve multiple referenced values from an index=] as
-    |operation|, using the [=current Realm=] as |targetRealm|,
+    <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>,
     |index|, |range|, and |count| if given.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/records=] to be retrieved. If null or not given,
 an [=unbounded key range=] is used. If |count| is specified and
 there are more than |count| records in range, only the first |count|
 will be retrieved.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBIndex>getAllKeys(|query|, |count|)</dfn> method steps are:
 
@@ -3905,20 +3932,22 @@ The <dfn method for=IDBIndex>getAllKeys(|query|, |count|)</dfn> method steps are
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
-    [=retrieve multiple values from an index=] as |operation|, using
+    with [=/this=] as <var ignore>source</var> and
+    [=retrieve multiple values from an index=] as <var ignore>operation</var>, using
     |index|, |range|, and |count| if given.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/records=] keys to be retrieved. If null or not
 given, an [=unbounded key range=] is used. If |count| is specified
 and there are more than |count| keys in range, only the first |count|
 will be retrieved.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBIndex>count(|query|)</dfn> method steps are:
 
@@ -3938,15 +3967,18 @@ The <dfn method for=IDBIndex>count(|query|)</dfn> method steps are:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
-    [=count the records in a range=] as |operation|, using
-    [=/index=] as |source| and |range|.
+    with [=/this=] as <var ignore>source</var> and
+    [=count the records in a range=] as <var ignore>operation</var>, using
+    [=/index=] as <var ignore>source</var> and |range|.
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/records=] keys to be counted. If null or not
 given, an [=unbounded key range=] is used.
+</aside>
+
 
 <div class="domintro note">
   The following methods throw an "{{TransactionInactiveError}}" {{DOMException}} if called
@@ -3976,7 +4008,7 @@ given, an [=unbounded key range=] is used.
         {{IDBCursor}}, or null if there were no matching [=object-store/records=].
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBIndex>openCursor(|query|, |direction|)</dfn> method steps are:
 
@@ -4006,8 +4038,8 @@ The <dfn method for=IDBIndex>openCursor(|query|, |direction|)</dfn> method steps
 
 1. Let |request| be the result of running
     [=asynchronously execute a request=] with [=/this=] as
-    |source| and [=iterate a cursor=] as |operation|,
-    using the [=current Realm=] as |targetRealm|, and |cursor|.
+    <var ignore>source</var> and [=iterate a cursor=] as <var ignore>operation</var>,
+    using the [=current Realm=] as <var ignore>targetRealm</var>, and |cursor|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
 
@@ -4015,12 +4047,14 @@ The <dfn method for=IDBIndex>openCursor(|query|, |direction|)</dfn> method steps
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 to use as the [=cursor=]'s [=cursor/range=]. If null
 or not given, an [=unbounded key range=] is used.
+</aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBIndex>openKeyCursor(|query|, |direction|)</dfn> method steps are:
 
@@ -4050,8 +4084,8 @@ The <dfn method for=IDBIndex>openKeyCursor(|query|, |direction|)</dfn> method st
 
 1. Let |request| be the result of running
     [=asynchronously execute a request=] with [=/this=] as
-    |source| and [=iterate a cursor=] as |operation|,
-    using the [=current Realm=] as |targetRealm|, and |cursor|.
+    <var ignore>source</var> and [=iterate a cursor=] as <var ignore>operation</var>,
+    using the [=current Realm=] as <var ignore>targetRealm</var>, and |cursor|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
 
@@ -4059,9 +4093,11 @@ The <dfn method for=IDBIndex>openKeyCursor(|query|, |direction|)</dfn> method st
 
 </div>
 
-The |query| parameter may be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
+<aside class=note>
+The |query| parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}})
 to use as the [=cursor=]'s [=cursor/range=]. If null
 or not given, an [=unbounded key range=] is used.
+</aside>
 
 
 <!-- ============================================================ -->
@@ -4150,7 +4186,8 @@ return [=/this=]'s [=upper open flag=].
         If |upperOpen| is true, |upper| is not included in the range.
 </div>
 
-<div class=algorithm>
+
+<div algorithm>
 
 The <dfn method for=IDBKeyRange>only(|value|)</dfn> method steps are:
 
@@ -4164,7 +4201,8 @@ The <dfn method for=IDBKeyRange>only(|value|)</dfn> method steps are:
 
 </div>
 
-<div class=algorithm>
+
+<div algorithm>
 
 The <dfn method for=IDBKeyRange>lowerBound(|lower|, |open|)</dfn> method steps are:
 
@@ -4180,7 +4218,8 @@ The <dfn method for=IDBKeyRange>lowerBound(|lower|, |open|)</dfn> method steps a
 
 </div>
 
-<div class=algorithm>
+
+<div algorithm>
 
 The <dfn method for=IDBKeyRange>upperBound(|upper|, |open|)</dfn> method steps are:
 
@@ -4195,7 +4234,8 @@ The <dfn method for=IDBKeyRange>upperBound(|upper|, |open|)</dfn> method steps a
 
 </div>
 
-<div class=algorithm>
+
+<div algorithm>
 
 The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|, |upperOpen|)</dfn> method steps are:
 
@@ -4225,7 +4265,7 @@ The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|, |upperOpen|
     :: Returns true if |key| is included in the range, and false otherwise.
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBKeyRange>includes(|key|)</dfn> method steps are:
 
@@ -4388,7 +4428,7 @@ return [=/this=]'s [=cursor/request=].
 
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBCursor>advance(|count|)</dfn> method steps are:
 
@@ -4415,9 +4455,9 @@ The <dfn method for=IDBCursor>advance(|count|)</dfn> method steps are:
 1. Set |request|'s [=request/done flag=] to false.
 
 1. Run [=asynchronously execute a request=] with
-    [=/this=]'s [=cursor/source=] as |source|,
-    [=iterate a cursor=] as |operation| and |request|, using
-    the [=current Realm=] as |targetRealm|, [=/this=], and |count|.
+    [=/this=]'s [=cursor/source=] as <var ignore>source</var>,
+    [=iterate a cursor=] as <var ignore>operation</var> and |request|, using
+    the [=current Realm=] as <var ignore>targetRealm</var>, [=/this=], and |count|.
 
 </div>
 
@@ -4430,7 +4470,7 @@ The <dfn method for=IDBCursor>advance(|count|)</dfn> method steps are:
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBCursor>continue(|key|)</dfn> method steps are:
 
@@ -4473,9 +4513,9 @@ The <dfn method for=IDBCursor>continue(|key|)</dfn> method steps are:
 1. Set |request|'s [=request/done flag=] to false.
 
 1. Run [=asynchronously execute a request=] with
-    [=/this=]'s [=cursor/source=] as |source|,
-    [=iterate a cursor=] as |operation| and |request|,
-    using the [=current Realm=] as |targetRealm|,
+    [=/this=]'s [=cursor/source=] as <var ignore>source</var>,
+    [=iterate a cursor=] as <var ignore>operation</var> and |request|,
+    using the [=current Realm=] as <var ignore>targetRealm</var>,
     [=/this=], and |key| (if given).
 
 </div>
@@ -4489,7 +4529,7 @@ The <dfn method for=IDBCursor>continue(|key|)</dfn> method steps are:
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBCursor>continuePrimaryKey(|key|, |primaryKey|)</dfn> method steps are:
 
@@ -4553,9 +4593,9 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|, |primaryKey|)</dfn> meth
 1. Set |request|'s [=request/done flag=] to false.
 
 1. Run [=asynchronously execute a request=] with
-    [=/this=]'s [=cursor/source=] as |source|,
-    [=iterate a cursor=] as |operation| and |request|,
-    using the [=current Realm=] as |targetRealm|,
+    [=/this=]'s [=cursor/source=] as <var ignore>source</var>,
+    [=iterate a cursor=] as <var ignore>operation</var> and |request|,
+    using the [=current Realm=] as <var ignore>targetRealm</var>,
     [=/this=], |key| and |primaryKey|.
 
 </div>
@@ -4596,7 +4636,7 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|, |primaryKey|)</dfn> meth
         `undefined`.
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBCursor>update(|value|)</dfn> method steps are:
 
@@ -4646,11 +4686,11 @@ The <dfn method for=IDBCursor>update(|value|)</dfn> method steps are:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and [=store a
-    record into an object store=] as |operation|, using [=/this=]'s
-    [=effective object store=] as |store|, the |clone| as
-    |value|, [=/this=]'s [=effective key=] as |key|, and with the
-    |no-overwrite flag| false.
+    with [=/this=] as <var ignore>source</var> and [=store a
+    record into an object store=] as <var ignore>operation</var>, using [=/this=]'s
+    [=effective object store=] as <var ignore>store</var>, the |clone| as
+    <var ignore>value</var>, [=/this=]'s [=effective key=] as <var ignore>key</var>, and with the
+    <var ignore>no-overwrite flag</var> false.
 
 </div>
 
@@ -4661,7 +4701,7 @@ The <dfn method for=IDBCursor>update(|value|)</dfn> method steps are:
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBCursor>delete()</dfn> method steps are:
 
@@ -4685,10 +4725,10 @@ The <dfn method for=IDBCursor>delete()</dfn> method steps are:
 
 1. Return the result (an {{IDBRequest}}) of running
     [=asynchronously execute a request=]
-    with [=/this=] as |source| and
-    [=delete records from an object store=] as |operation|, using
+    with [=/this=] as <var ignore>source</var> and
+    [=delete records from an object store=] as <var ignore>operation</var>, using
     [=/this=]'s [=effective object store=] and [=effective
-    key=] as |store| and |key| respectively.
+    key=] as <var ignore>store</var> and <var ignore>key</var> respectively.
 
 </div>
 
@@ -4782,7 +4822,7 @@ enum IDBTransactionMode {
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn attribute for=IDBTransaction>objectStoreNames</dfn> getter steps are:
 
@@ -4861,11 +4901,11 @@ none.
         transaction from aborting.
 </div>
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBTransaction>objectStore(|name|)</dfn> method steps are:
 
-1. If |transaction|'s [=transaction/state=] is [=transaction/finished=],
+1. If [=/this=]'s [=transaction/state=] is [=transaction/finished=],
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 1. Let |store| be the [=/object store=]
@@ -4891,7 +4931,7 @@ The <dfn method for=IDBTransaction>objectStore(|name|)</dfn> method steps are:
 </aside>
 
 
-<div class=algorithm>
+<div algorithm>
 
 The <dfn method for=IDBTransaction>abort()</dfn> method steps are:
 
@@ -4900,11 +4940,12 @@ The <dfn method for=IDBTransaction>abort()</dfn> method steps are:
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 1. Set [=/this=]'s [=transaction/state=] to [=transaction/inactive=] and run
-    [=abort a transaction=] with null as |error|.
+    [=abort a transaction=] with null as <var ignore>error</var>.
 
 </div>
 
-<div class=algorithm>
+
+<div algorithm>
 
 The <dfn method for=IDBTransaction>commit()</dfn> method steps are:
 
@@ -4956,7 +4997,7 @@ The <dfn attribute for=IDBTransaction>onerror</dfn> attribute is an [=/event han
 ## Opening a database ## {#opening}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>open a database</dfn> with |origin| which requested the [=database=] to be opened, a database |name|, a database |version|, and a |request|, run these steps:
 
@@ -5034,7 +5075,7 @@ To <dfn>open a database</dfn> with |origin| which requested the [=database=] to 
 ## Closing a database ## {#closing-connection}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>close a database connection</dfn> with a |connection| object, and an
 optional |forced flag|, run these steps:
@@ -5081,7 +5122,7 @@ optional |forced flag|, run these steps:
 ## Deleting a database ## {#deleting-a-database}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>delete a database</dfn> with the |origin| that
 requested the [=database=] to be deleted, a database |name|, and a
@@ -5136,7 +5177,7 @@ requested the [=database=] to be deleted, a database |name|, and a
 ## Committing a transaction ## {#commit-transaction}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>commit a transaction</dfn> with the |transaction| to commit, run these steps:
 
@@ -5185,7 +5226,7 @@ To <dfn>commit a transaction</dfn> with the |transaction| to commit, run these s
 ## Aborting a transaction ## {#abort-transaction}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>abort a transaction</dfn> with the |transaction| to abort, and |error|, run these steps:
 
@@ -5253,7 +5294,7 @@ To <dfn>abort a transaction</dfn> with the |transaction| to abort, and |error|, 
 ## Asynchronously executing a [=/request=] ## {#async-execute-request}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>asynchronously execute a request</dfn> with the |source| object and an |operation| to perform on a database, and an optional |request|, run these steps:
 
@@ -5267,7 +5308,7 @@ created [=/request=] belongs to is [=transaction/aborted=] using the steps to
 1. [=/Assert=]: |transaction|'s [=transaction/state=] is [=transaction/active=].
 
 1. If |request| was not given, let |request| be a new |request| with
-    [=request/source=] as |source|.
+    [=request/source=] as <var ignore>source</var>.
 
 1. Add |request| to the end of |transaction|'s [=request list=].
 
@@ -5279,7 +5320,7 @@ created [=/request=] belongs to is [=transaction/aborted=] using the steps to
     1. Let |result| be the result of performing |operation|.
 
     1. If |result| is an error and |transaction|'s [=transaction/state=] is [=committing=],
-        then run [=abort a transaction=] with |transaction| and |error|,
+        then run [=abort a transaction=] with |transaction| and |result|,
         and terminate these steps.
 
     1. If |result| is an error,
@@ -5319,7 +5360,7 @@ created [=/request=] belongs to is [=transaction/aborted=] using the steps to
 ## Running an upgrade transaction ## {#upgrade-transaction-steps}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>run an upgrade transaction</dfn> with a |connection| object
 which is used to update the [=database=], a new |version| to be set
@@ -5332,7 +5373,7 @@ for the [=database=], and a |request|, run these steps:
     |transaction| includes every [=/object store=] in
     |connection|.
 
-1. Set |database|'s [=database/upgrade transaction=] to |transaction|.
+1. Set |db|'s [=database/upgrade transaction=] to |transaction|.
 
 1. Set |transaction|'s [=transaction/state=] to [=transaction/inactive=].
 
@@ -5382,7 +5423,7 @@ for the [=database=], and a |request|, run these steps:
 ## Aborting an upgrade transaction ## {#abort-upgrade-transaction}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>abort an upgrade transaction</dfn> with |transaction|, run these steps:
 
@@ -5477,7 +5518,7 @@ To <dfn>abort an upgrade transaction</dfn> with |transaction|, run these steps:
 ## Firing a success event ## {#fire-success-event}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>fire a success event</dfn> at a |request|, run these steps:
 
@@ -5516,7 +5557,7 @@ To <dfn>fire a success event</dfn> at a |request|, run these steps:
 ## Firing an error event ## {#fire-error-event}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>fire an error event</dfn> at a |request|, run these steps:
 
@@ -5568,7 +5609,7 @@ To <dfn>fire an error event</dfn> at a |request|, run these steps:
 ## Clone a value ## {#clone-value}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
   To make a <dfn>clone</dfn> of |value| in |targetRealm| during |transaction|,
   run these steps:
@@ -5612,7 +5653,7 @@ a request=].
 ## Object store storage operation ## {#object-store-storage-operation}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>store a record into an object store</dfn> with
 |store|, |value|, an optional |key|, and a |no-overwrite flag|, run these steps:
@@ -5718,7 +5759,7 @@ To <dfn>store a record into an object store</dfn> with
 ## Object store retrieval operations ## {#object-store-retrieval-operation}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve a value from an object store</dfn> with
 |targetRealm|, |store| and |range|, run these steps:
@@ -5736,7 +5777,7 @@ To <dfn>retrieve a value from an object store</dfn> with
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve multiple values from an object
 store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these steps:
@@ -5747,7 +5788,7 @@ store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these
     in |store|'s [=object-store/list of records=] whose [=/key=] is
     [=in=] |range|.
 
-1. Let |list| be an empty list.
+1. Let |list| be an empty [=/list=].
 
 1. [=list/For each=] |record| of |records|:
 
@@ -5760,7 +5801,7 @@ store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve a key from an object store</dfn>
 with |store| and |range|, run these steps:
@@ -5777,7 +5818,7 @@ with |store| and |range|, run these steps:
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve multiple keys from an object store</dfn>
 with |store|, |range| and optional |count|, run these steps:
@@ -5805,7 +5846,7 @@ with |store|, |range| and optional |count|, run these steps:
 ## Index retrieval operations ## {#index-retrieval-operation}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve a referenced value from an index</dfn>
 with |targetRealm|, |index| and |range|, run these steps:
@@ -5822,7 +5863,7 @@ with |targetRealm|, |index| and |range|, run these steps:
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve multiple referenced values from an
 index</dfn> with |targetRealm|, |index|, |range| and optional |count|, run these steps:
@@ -5849,7 +5890,7 @@ index</dfn> with |targetRealm|, |index|, |range| and optional |count|, run these
     [=object-store/records=] in the [=index/referenced=] object store.
 </aside>
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve a value from an index</dfn> with
 |index| and |range|, run these steps:
@@ -5865,7 +5906,7 @@ To <dfn>retrieve a value from an index</dfn> with
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>retrieve multiple values from an index</dfn> with
 |index|, |range| and optional |count|, run these steps:
@@ -5892,7 +5933,7 @@ To <dfn>retrieve multiple values from an index</dfn> with
 ## Object store deletion operation ## {#object-store-deletion-operation}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>delete records from an object store</dfn>
 with |store| and |range|, run these steps:
@@ -5914,7 +5955,7 @@ with |store| and |range|, run these steps:
 ## Record counting operation ## {#record-counting-operation}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>count the records in a range</dfn> with |source| and
 |range|, run these steps:
@@ -5931,7 +5972,7 @@ To <dfn>count the records in a range</dfn> with |source| and
 ## Object store clear operation ## {#object-store-clear-operation}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>clear an object store</dfn> with |store|, run these steps:
 
@@ -5949,7 +5990,7 @@ To <dfn>clear an object store</dfn> with |store|, run these steps:
 ## Cursor iteration operation ## {#cursor-iteration-operation}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
 |key| and |primaryKey| to iterate to, and an optional |count|, run these steps:
@@ -6130,7 +6171,7 @@ algorithm conventions from the ECMAScript Language Specification.
 ## Extract a key from a value ## {#extract-key-from-value}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>extract a key from a value using a key path</dfn>
 with |value|, |keyPath| and an optional |multiEntry flag|, run the
@@ -6155,7 +6196,7 @@ failure, or the steps may throw an exception.
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>evaluate a key path on a value</dfn> with |value|
 and |keyPath|, run the following steps. The result of these steps is an
@@ -6172,7 +6213,7 @@ ECMAScript value or failure, or the steps may throw an exception.
 
         1. Let |key| be the result of recursively running
             [=evaluate a key path on a value=] using
-            |item| as |keyPath| and |value| as |value|.
+            |item| as <var ignore>keyPath</var> and |value| as <var ignore>value</var>.
 
         1. [=/Assert=]: |key| is not an [=abrupt completion=].
 
@@ -6260,12 +6301,10 @@ ECMAScript value or failure, or the steps may throw an exception.
   sequence.
 </aside>
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>check that a key could be injected into a value</dfn> with |value| and a |keyPath|, run the following steps.
 The result of these steps is either true or false.
-
-<div class=algorithm>
 
 1. Let |identifiers| be the result of <a lt="strictly split a string">strictly splitting</a>
     |keyPath| on U+002E FULL STOP characters (.).
@@ -6293,7 +6332,7 @@ The result of these steps is either true or false.
   only applied to values that are the output of <a abstract-op>StructuredDeserialize</a>.
 </aside>
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>inject a key into a value using a key path</dfn> with |value|, a |key| and a |keyPath|, run these steps:
 
@@ -6346,7 +6385,7 @@ To <dfn>inject a key into a value using a key path</dfn> with |value|, a |key| a
 ## Convert a key to a value ## {#convert-key-to-value}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>convert a key to a value</dfn> with |key|, run the following steps.
 The steps return an ECMAScript value.
@@ -6409,7 +6448,7 @@ The steps return an ECMAScript value.
 ## Convert a value to a key ## {#convert-value-to-key}
 <!-- ============================================================ -->
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>convert a value to a key</dfn> with an ECMAScript value |input|, and an optional
 [=/set=] |seen|, run the following steps.
@@ -6501,7 +6540,7 @@ steps may throw an exception.
 </div>
 
 
-<div class=algorithm>
+<div algorithm>
 
 To <dfn>convert a value to a multiEntry key</dfn> with an ECMAScript value |input|, run the following steps.
 The result of these steps is a [=/key=] or invalid, or the

--- a/index.bs
+++ b/index.bs
@@ -2984,12 +2984,10 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
             |clone| and |store|'s [=object-store/key path=] return
             false, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with |handle| as <var ignore>source</var> and
-    [=store a record into an object store=] as
-    <var ignore>operation</var>, using |store|, the |clone| as <var ignore>value</var>, |key|, and
-    |no-overwrite flag|.
+1. Let |operation| be an algorithm to run [=store a record into an object store=] with |store|, |clone|, |key|, and |no-overwrite flag|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with |handle| and |operation|.
+
 
 </div>
 
@@ -3010,15 +3008,11 @@ The <dfn method for=IDBObjectStore>delete(|query|)</dfn> method steps are:
 1. If |transaction| is a [=read-only transaction=],
     [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query| and
-    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
+1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=delete records from an object store=] as
-    <var ignore>operation</var>, using |store| and |range|.
+1. Let |operation| be an algorithm to run [=delete records from an object store=] with |store| and |range|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3052,11 +3046,9 @@ The <dfn method for=IDBObjectStore>clear()</dfn> method steps are:
 1. If |transaction| is a [=read-only transaction=],
     [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=clear an object store=] as
-    <var ignore>operation</var>, using |store|.
+1. Let |operation| be an algorithm to run [=clear an object store=] with |store|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3126,16 +3118,11 @@ The <dfn method for=IDBObjectStore>get(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query| and
-    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
+1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and [=retrieve a value from
-    an object store=] as <var ignore>operation</var>, using the
-    [=current Realm=] as <var ignore>targetRealm</var>,
-    |store| and |range|.
+1. Let |operation| be an algorithm to run [=retrieve a value from an object store=] with [=current Realm=], |store| and |range|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3170,15 +3157,11 @@ The <dfn method for=IDBObjectStore>getKey(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query| and
-    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
+1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and [=retrieve a key from an
-    object store=] as <var ignore>operation</var>, using |store|
-    and |range|.
+1. Let |operation| be an algorithm to run [=retrieve a key from an object store=] with |store| and |range|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3208,12 +3191,10 @@ The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn> method steps a
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=retrieve multiple values from an object store=]
-    as <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>,
-    |store|, |range|, and |count| if given.
+1. Let |operation| be an algorithm to run [=retrieve multiple values from an object store=] with [=current Realm=], |store|, |range|, and |count| if given.
+
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3244,11 +3225,9 @@ The <dfn method for=IDBObjectStore>getAllKeys(|query|, |count|)</dfn> method ste
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=retrieve multiple keys from an object store=] as
-    <var ignore>operation</var>, using |store|, |range|, and |count| if given.
+1. Let |operation| be an algorithm to run [=retrieve multiple keys from an object store=] with |store|, |range|, and |count| if given.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3279,11 +3258,9 @@ The <dfn method for=IDBObjectStore>count(|query|)</dfn> method steps are:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=count the records in a range=] as <var ignore>operation</var>, using
-    |store| as <var ignore>source</var> and |range|.
+1. Let |operation| be an algorithm to run [=count the records in a range=] with |store| and |range|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3351,10 +3328,9 @@ The <dfn method for=IDBObjectStore>openCursor(|query|, |direction|)</dfn> method
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to false.
 
-1. Let |request| be the result of running
-    [=asynchronously execute a request=] with [=/this=] as <var ignore>source</var> and [=iterate a cursor=] as
-    <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>, and
-    |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with [=current Realm=] |cursor|.
+
+1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
 
@@ -3397,10 +3373,9 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|, |direction|)</dfn> met
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to true.
 
-1. Let |request| be the result of running
-    [=asynchronously execute a request=] with [=/this=] as <var ignore>source</var> and [=iterate a cursor=] as
-    <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>, and
-    |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with [=current Realm=] and |cursor|.
+
+1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
 
@@ -3517,7 +3492,7 @@ need to ask the user for permission for quota reasons. Such
 implementations must still create and return an {{IDBIndex}} object,
 and once the implementation determines that creating the index has
 failed, it must run the steps to [=abort
-a transaction=] using an appropriate error as <var ignore>error</var>. For example
+a transaction=] using an appropriate error. For example
 if creating the [=/index=] failed due to quota reasons,
 a "{{QuotaExceededError}}" {{DOMException}} must be used as error and if the index can't be
 created due to [=unique flag=] constraints, a "{{ConstraintError}}" {{DOMException}}
@@ -3812,16 +3787,11 @@ The <dfn method for=IDBIndex>get(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query| and
-    <var ignore>null disallowed flag</var> true. Rethrow any exceptions.
+1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=retrieve a referenced value from an index=]
-    as <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>,
-    |index| and |range|.
+1. Let |operation| be an algorithm to run [=retrieve a referenced value from an index=] with [=current Realm=], |index| and |range|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3856,15 +3826,11 @@ The <dfn method for=IDBIndex>getKey(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running [=convert a
-    value to a key range=] with |query| and <var ignore>null disallowed flag</var>
-    true. Rethrow any exceptions.
+1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=retrieve a value from an index=] as <var ignore>operation</var>, using |index|
-    and |range|.
+1. Let |operation| be an algorithm to run [=retrieve a value from an index=] with |index| and |range|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3894,12 +3860,9 @@ The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method steps are:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=retrieve multiple referenced values from an index=] as
-    <var ignore>operation</var>, using the [=current Realm=] as <var ignore>targetRealm</var>,
-    |index|, |range|, and |count| if given.
+1. Let |operation| be an algorithm to run [=retrieve multiple referenced values from an index=] with [=current Realm=], |index|, |range|, and |count| if given.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3930,11 +3893,9 @@ The <dfn method for=IDBIndex>getAllKeys(|query|, |count|)</dfn> method steps are
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=retrieve multiple values from an index=] as <var ignore>operation</var>, using
-    |index|, |range|, and |count| if given.
+1. Let |operation| be an algorithm to run [=retrieve multiple values from an index=] with |index|, |range|, and |count| if given.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -3965,11 +3926,9 @@ The <dfn method for=IDBIndex>count(|query|)</dfn> method steps are:
     [=convert a value to a key range=] with |query|.
     Rethrow any exceptions.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=count the records in a range=] as <var ignore>operation</var>, using
-    [=/index=] as <var ignore>source</var> and |range|.
+1. Let |operation| be an algorithm to run [=count the records in a range=] with |index| and |range|.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -4036,10 +3995,9 @@ The <dfn method for=IDBIndex>openCursor(|query|, |direction|)</dfn> method steps
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to false.
 
-1. Let |request| be the result of running
-    [=asynchronously execute a request=] with [=/this=] as
-    <var ignore>source</var> and [=iterate a cursor=] as <var ignore>operation</var>,
-    using the [=current Realm=] as <var ignore>targetRealm</var>, and |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with [=current Realm=] and |cursor|.
+
+1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
 
@@ -4082,10 +4040,9 @@ The <dfn method for=IDBIndex>openKeyCursor(|query|, |direction|)</dfn> method st
     [=cursor/range=] set to |range|, and
     [=cursor/key only flag=] set to true.
 
-1. Let |request| be the result of running
-    [=asynchronously execute a request=] with [=/this=] as
-    <var ignore>source</var> and [=iterate a cursor=] as <var ignore>operation</var>,
-    using the [=current Realm=] as <var ignore>targetRealm</var>, and |cursor|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=current Realm=], and |cursor|.
+
+1. Let |request| be the result of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 1. Set |cursor|'s [=cursor/request=] to |request|.
 
@@ -4454,10 +4411,9 @@ The <dfn method for=IDBCursor>advance(|count|)</dfn> method steps are:
 
 1. Set |request|'s [=request/done flag=] to false.
 
-1. Run [=asynchronously execute a request=] with
-    [=/this=]'s [=cursor/source=] as <var ignore>source</var>,
-    [=iterate a cursor=] as <var ignore>operation</var> and |request|, using
-    the [=current Realm=] as <var ignore>targetRealm</var>, [=/this=], and |count|.
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=current Realm=], [=/this=], and |count|.
+
+1. Run [=asynchronously execute a request=] with [=/this=]'s [=cursor/source=], |operation|, and |request|.
 
 </div>
 
@@ -4512,11 +4468,9 @@ The <dfn method for=IDBCursor>continue(|key|)</dfn> method steps are:
 
 1. Set |request|'s [=request/done flag=] to false.
 
-1. Run [=asynchronously execute a request=] with
-    [=/this=]'s [=cursor/source=] as <var ignore>source</var>,
-    [=iterate a cursor=] as <var ignore>operation</var> and |request|,
-    using the [=current Realm=] as <var ignore>targetRealm</var>,
-    [=/this=], and |key| (if given).
+1. Let |operation| be an algorithm to run [=iterate a cursor=] with the [=current Realm=], [=/this=], and |key| (if given).
+
+1. Run [=asynchronously execute a request=] with [=/this=]'s [=cursor/source=], |operation|, and |request|.
 
 </div>
 
@@ -4592,11 +4546,9 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|, |primaryKey|)</dfn> meth
 
 1. Set |request|'s [=request/done flag=] to false.
 
-1. Run [=asynchronously execute a request=] with
-    [=/this=]'s [=cursor/source=] as <var ignore>source</var>,
-    [=iterate a cursor=] as <var ignore>operation</var> and |request|,
-    using the [=current Realm=] as <var ignore>targetRealm</var>,
-    [=/this=], |key| and |primaryKey|.
+1. Let |operation| be the an algorithm to run [=iterate a cursor=] with the [=current Realm=], [=/this=], |key|, and |primaryKey|.
+
+1. Run [=asynchronously execute a request=] with [=/this=]'s [=cursor/source=], |operation|, and |request|.
 
 </div>
 
@@ -4684,13 +4636,9 @@ The <dfn method for=IDBCursor>update(|value|)</dfn> method steps are:
         [=/this=]'s [=effective key=], [=throw=] a
         "{{DataError}}" {{DOMException}}.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and [=store a
-    record into an object store=] as <var ignore>operation</var>, using [=/this=]'s
-    [=effective object store=] as <var ignore>store</var>, the |clone| as
-    <var ignore>value</var>, [=/this=]'s [=effective key=] as <var ignore>key</var>, and with the
-    <var ignore>no-overwrite flag</var> false.
+1. Let |operation| be an algorithm to run [=store a record into an object store=] with [=/this=]'s [=effective object store=], |clone|, [=/this=]'s [=effective key=], and false.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -4723,12 +4671,9 @@ The <dfn method for=IDBCursor>delete()</dfn> method steps are:
 1. If [=/this=]'s [=cursor/key only flag=] is true, [=throw=] an
     "{{InvalidStateError}}" {{DOMException}}.
 
-1. Return the result (an {{IDBRequest}}) of running
-    [=asynchronously execute a request=]
-    with [=/this=] as <var ignore>source</var> and
-    [=delete records from an object store=] as <var ignore>operation</var>, using
-    [=/this=]'s [=effective object store=] and [=effective
-    key=] as <var ignore>store</var> and <var ignore>key</var> respectively.
+1. Let |operation| be an algorithm to run [=delete records from an object store=] with [=/this=]'s [=effective object store=] and [=/this=]'s [=effective key=].
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 </div>
 
@@ -4940,7 +4885,7 @@ The <dfn method for=IDBTransaction>abort()</dfn> method steps are:
     then [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
 1. Set [=/this=]'s [=transaction/state=] to [=transaction/inactive=] and run
-    [=abort a transaction=] with null as <var ignore>error</var>.
+    [=abort a transaction=] with [=/this=] and null.
 
 </div>
 
@@ -5307,8 +5252,7 @@ created [=/request=] belongs to is [=transaction/aborted=] using the steps to
 
 1. [=/Assert=]: |transaction|'s [=transaction/state=] is [=transaction/active=].
 
-1. If |request| was not given, let |request| be a new |request| with
-    [=request/source=] as <var ignore>source</var>.
+1. If |request| was not given, let |request| be a new [=/request=] with [=request/source=] as |source|.
 
 1. Add |request| to the end of |transaction|'s [=request list=].
 
@@ -6212,8 +6156,7 @@ ECMAScript value or failure, or the steps may throw an exception.
     1. [=list/For each=] |item| of |keyPath|:
 
         1. Let |key| be the result of recursively running
-            [=evaluate a key path on a value=] using
-            |item| as <var ignore>keyPath</var> and |value| as <var ignore>value</var>.
+            [=evaluate a key path on a value=] with |item| and |value|.
 
         1. [=/Assert=]: |key| is not an [=abrupt completion=].
 


### PR DESCRIPTION
The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.

Switch from `<div class=algorithm>` to `<div algorithm>` to get better var highlighting/checking. A consequence of this is fixing issues, the biggest one being places where algorithm A calls into B with named parameters, e.g. "with foo as bar". In that case, "bar" needs to be called out with `<var ignore>`. 

A few other glitches were noticed along the way, e.g. in domintro sections, some non-normative text was correctly marked as asides, and a few incorrect variables were fixed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/336.html" title="Last updated on May 20, 2020, 11:14 PM UTC (2f546e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/336/ff8346e...2f546e3.html" title="Last updated on May 20, 2020, 11:14 PM UTC (2f546e3)">Diff</a>