### PR TITLE
Use Bikeshed's special syntax for linking to abstract operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -583,7 +583,7 @@ stored and retrieved by value rather than by reference; later changes
 to a value have no effect on the record stored in the database.
 
 Record [=/values=] are [=/Records=] output by the
-<a abstract-op>StructuredSerializeForStorage</a> operation.
+[$StructuredSerializeForStorage$] operation.
 
 
 <!-- ============================================================ -->
@@ -754,7 +754,7 @@ from a [=/value=]. A <dfn>valid key path</dfn> is one of:
 </aside>
 
 [=/Key path=] values can only be accessed from properties explicitly
-copied by <a abstract-op>StructuredSerializeForStorage</a>, as well as the
+copied by [$StructuredSerializeForStorage$], as well as the
 following type-specific properties:
 
 <table class=props>
@@ -5566,9 +5566,9 @@ To <dfn>fire an error event</dfn> at a |request|, run these steps:
           The [=/transaction=] is made [=transaction/inactive=] so that getters or other side effects triggered by the cloning operation are unable to make additional requests against the transaction.
         </aside>
 
-  1. Let |serialized| be [=?=] <a abstract-op>StructuredSerializeForStorage</a>(|value|).
+  1. Let |serialized| be [=?=] [$StructuredSerializeForStorage$](|value|).
 
-  1. Let |clone| be [=?=] <a abstract-op>StructuredDeserialize</a>(|serialized|, |targetRealm|).
+  1. Let |clone| be [=?=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
 
   1. Set |transaction|'s [=transaction/state=] to [=transaction/active=].
 
@@ -5587,10 +5587,10 @@ These operations are run by the steps to [=asynchronously execute
 a request=].
 
 <aside class=note>
-  Invocations of <a abstract-op>StructuredDeserialize</a>() in the operation
+  Invocations of [$StructuredDeserialize$]() in the operation
   steps below can be asserted not to throw (as indicated by the [=!=] prefix)
   because they operate only on previous output of
-  <a abstract-op>StructuredSerializeForStorage</a>().
+  [$StructuredSerializeForStorage$]().
 </aside>
 
 <!-- ============================================================ -->
@@ -5631,7 +5631,7 @@ To <dfn>store a record into an object store</dfn> with
     [=delete records from an object store=].
 
 1. Store a record in |store| containing |key| as its key and
-    [=!=] <a abstract-op>StructuredSerializeForStorage</a>(|value|)
+    [=!=] [$StructuredSerializeForStorage$](|value|)
     as its value. The record is stored in the object store's
     [=object-store/list of records=] such that the list is sorted
     according to the key of the records in [=ascending=] order.
@@ -5716,7 +5716,7 @@ To <dfn>retrieve a value from an object store</dfn> with
 
 1. Let |serialized| be of |record|'s [=/value=].
 
-1. Return [=!=] <a abstract-op>StructuredDeserialize</a>(|serialized|, |targetRealm|).
+1. Return [=!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
 
 </div>
 
@@ -5737,7 +5737,7 @@ store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these
 1. [=list/For each=] |record| of |records|:
 
     1. Let |serialized| be |record|'s [=/value=].
-    1. Let |entry| be [=!=] <a abstract-op>StructuredDeserialize</a>(|serialized|, |targetRealm|).
+    1. Let |entry| be [=!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
     1. Append |entry| to |list|.
 
 1. Return |list| converted to a <code>[=/sequence=]&lt;{{any}}&gt;</code>.
@@ -5802,7 +5802,7 @@ with |targetRealm|, |index| and |range|, run these steps:
 
 1. Let |serialized| be |record|'s [=referenced value=].
 
-1. Return [=!=] <a abstract-op>StructuredDeserialize</a>(|serialized|, |targetRealm|).
+1. Return [=!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
 
 </div>
 
@@ -5822,7 +5822,7 @@ index</dfn> with |targetRealm|, |index|, |range| and optional |count|, run these
 1. [=list/For each=] |record| of |records|:
 
     1. Let |serialized| be |record|'s [=referenced value=].
-    1. Let |entry| be [=!=] <a abstract-op>StructuredDeserialize</a>(|serialized|, |targetRealm|).
+    1. Let |entry| be [=!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
     1. Append |entry| to |list|.
 
 1. Return |list| converted to a <code>[=/sequence=]&lt;{{any}}&gt;</code>.
@@ -6090,7 +6090,7 @@ To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
 
     1. Let |serialized| be |found record|'s [=referenced value=].
     1. Set |cursor|'s [=cursor/value=] to
-        [=!=] <a abstract-op>StructuredDeserialize</a>(|serialized|, |targetRealm|)
+        [=!=] [$StructuredDeserialize$](|serialized|, |targetRealm|)
 
 1. Set |cursor|'s [=cursor/got value flag=] to true.
 
@@ -6228,7 +6228,7 @@ ECMAScript value or failure, or the steps may throw an exception.
 
 <aside class=note>
   Assertions can be made in the above steps because this algorithm is
-  only applied to values that are the output of <a abstract-op>StructuredDeserialize</a>
+  only applied to values that are the output of [$StructuredDeserialize$]
   and only access "own" properties.
 </aside>
 
@@ -6272,7 +6272,7 @@ The result of these steps is either true or false.
 
 <aside class=note>
   Assertions can be made in the above steps because this algorithm is
-  only applied to values that are the output of <a abstract-op>StructuredDeserialize</a>.
+  only applied to values that are the output of [$StructuredDeserialize$].
 </aside>
 
 <div algorithm>
@@ -6318,7 +6318,7 @@ To <dfn>inject a key into a value using a key path</dfn> with |value|, a |key| a
 
 <aside class=note>
   Assertions can be made in the above steps because this algorithm is
-  only applied to values that are the output of <a abstract-op>StructuredDeserialize</a>,
+  only applied to values that are the output of [$StructuredDeserialize$],
   and the steps to [=check that a key could be injected into a value=] have
   been run.
 </aside>
@@ -6719,8 +6719,8 @@ handling of older data can result in security issues. In addition to
 basic serialization concerns, serialized data could encode assumptions
 which are not valid in newer versions of the user agent.
 
-A practical example of this is the [=RegExp=] type. The <a
-abstract-op>StructuredSerializeForStorage</a> operation allows serializing [=RegExp=]
+A practical example of this is the [=RegExp=] type. The
+[$StructuredSerializeForStorage$] operation allows serializing [=RegExp=]
 objects. A typical user agent will compile a regular expression into
 native machine instructions, with assumptions about how the input data
 is passed and results returned. If this internal state was serialized


### PR DESCRIPTION
Replace `<a abstract-op>....</a>` with `[$....$]`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/341.html" title="Last updated on Jun 30, 2020, 6:12 PM UTC (ab6a78a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/341/59eeeb6...ab6a78a.html" title="Last updated on Jun 30, 2020, 6:12 PM UTC (ab6a78a)">Diff</a>