### PR TITLE
Editorial: Replace many instances of 'running' in favor of verbing nouns

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -700,7 +700,7 @@ To <dfn>compare two keys</dfn> |a| and |b|, run these steps:
           1. Let |i| be 0.
           1. While |i| is less than |length|, then:
 
-              1. Let |c| be the result of recursively running [=compare two keys=] with |va|[|i|] and |vb|[|i|].
+              1. Let |c| be the result of recursively [=/comparing two keys=] with |va|[|i|] and |vb|[|i|].
               1. If |c| is not 0, return |c|.
               1. Increase |i| by 1.
 
@@ -713,15 +713,15 @@ To <dfn>compare two keys</dfn> |a| and |b|, run these steps:
 </div>
 
 The [=/key=] |a| is <dfn lt="greater than|ascending">greater than</dfn> the [=/key=] |b| if the
-result of running [=compare two keys=] with |a| and |b|
+result of [=/comparing two keys=] with |a| and |b|
 is 1.
 
 The [=/key=] |a| is <dfn>less than</dfn> the [=/key=] |b| if the
-result of running [=compare two keys=] with |a| and |b|
+result of [=/comparing two keys=] with |a| and |b|
 is -1.
 
 The [=/key=] |a| is <dfn>equal to</dfn> the [=/key=] |b| if the result
-of running [=compare two keys=] with |a| and |b| is 0.
+of [=/comparing two keys=] with |a| and |b| is 0.
 
 <aside class=note>
   As a result of the above rules, negative infinity is the lowest
@@ -1376,7 +1376,7 @@ To <dfn>convert a value to a key range</dfn> with
     "{{DataError}}" {{DOMException}} if |null disallowed flag| is true, or return an
     [=unbounded key range=] otherwise.
 
-1. Let |key| be the result of running [=convert
+1. Let |key| be the result of [=/converting
     a value to a key=] with |value|. Rethrow any exceptions.
 
 1. If |key| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -2222,8 +2222,8 @@ The <dfn method for=IDBFactory>open(|name|, |version|)</dfn> method steps are:
 
 1. Run these steps [=in parallel=]:
 
-    1. Let |result| be the result of running
-        [=open a database=], with |origin|,
+    1. Let |result| be the result of
+        [=/opening a database=], with |origin|,
         |name|, |version| if given and undefined
         otherwise, and |request|.
 
@@ -2293,8 +2293,8 @@ The <dfn method for=IDBFactory>deleteDatabase(|name|)</dfn> method steps are:
 
 1. Run these steps [=in parallel=]:
 
-    1. Let |result| be the result of running
-        [=delete a database=], with |origin|,
+    1. Let |result| be the result of
+        [=/deleting a database=], with |origin|,
         |name|, and |request|.
 
     1. Set |request|'s [=request/processed flag=] to true.
@@ -2392,17 +2392,17 @@ The <dfn method for=IDBFactory>databases()</dfn> method steps are:
 
 The <dfn method for=IDBFactory>cmp(|first|, |second|)</dfn> method steps are:
 
-1. Let |a| be the result of running [=convert a
+1. Let |a| be the result of [=/converting a
     value to a key=] with |first|. Rethrow any exceptions.
 
 1. If |a| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Let |b| be the result of running [=convert a
+1. Let |b| be the result of [=/converting a
     value to a key=] with |second|. Rethrow any exceptions.
 
 1. If |b| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Return the results of running [=compare two keys=]
+1. Return the results of [=/comparing two keys=]
     with |a| and |b|.
 
 </div>
@@ -2964,7 +2964,7 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
 
 1. If |key| was given, then:
 
-    1. Let |r| be the result of running [=convert a
+    1. Let |r| be the result of [=/converting a
         value to a key=] with |key|. Rethrow any exceptions.
 
     1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -2986,7 +2986,7 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
 
 1. If |store| uses [=in-line keys=], then:
 
-    1. Let |kpk| be the result of running [=extract a
+    1. Let |kpk| be the result of [=/extracting a
         key from a value using a key path=] with |clone| and
         |store|'s [=object-store/key path=]. Rethrow any
         exceptions.
@@ -3029,7 +3029,7 @@ The <dfn method for=IDBObjectStore>delete(|query|)</dfn> method steps are:
 1. If |transaction| is a [=read-only transaction=],
     [=throw=] a "{{ReadOnlyError}}" {{DOMException}}.
 
-1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
+1. Let |range| be the result of [=/converting a value to a key range=] with |query| and true. Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=delete records from an object store=] with |store| and |range|.
 
@@ -3139,7 +3139,7 @@ The <dfn method for=IDBObjectStore>get(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
+1. Let |range| be the result of [=/converting a value to a key range=] with |query| and true. Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve a value from an object store=] with the [=/current Realm=], |store|, and |range|.
 
@@ -3178,7 +3178,7 @@ The <dfn method for=IDBObjectStore>getKey(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
+1. Let |range| be the result of [=/converting a value to a key range=] with |query| and true. Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve a key from an object store=] with |store| and |range|.
 
@@ -3208,8 +3208,8 @@ The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn> method steps a
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve multiple values from an object store=] with the [=/current Realm=], |store|, |range|, and |count| if given.
@@ -3242,8 +3242,8 @@ The <dfn method for=IDBObjectStore>getAllKeys(|query|, |count|)</dfn> method ste
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve multiple keys from an object store=] with |store|, |range|, and |count| if given.
@@ -3275,8 +3275,8 @@ The <dfn method for=IDBObjectStore>count(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=count the records in a range=] with |store| and |range|.
@@ -3335,8 +3335,8 @@ The <dfn method for=IDBObjectStore>openCursor(|query|, |direction|)</dfn> method
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |cursor| be a new [=cursor=] with its
@@ -3380,8 +3380,8 @@ The <dfn method for=IDBObjectStore>openKeyCursor(|query|, |direction|)</dfn> met
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |cursor| be a new [=cursor=] with its
@@ -3808,7 +3808,7 @@ The <dfn method for=IDBIndex>get(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
+1. Let |range| be the result of [=/converting a value to a key range=] with |query| and true. Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve a referenced value from an index=] with the [=/current Realm=], |index|, and |range|.
 
@@ -3847,7 +3847,7 @@ The <dfn method for=IDBIndex>getKey(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running [=convert a value to a key range=] with |query| and true. Rethrow any exceptions.
+1. Let |range| be the result of [=/converting a value to a key range=] with |query| and true. Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve a value from an index=] with |index| and |range|.
 
@@ -3877,8 +3877,8 @@ The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve multiple referenced values from an index=] with the [=/current Realm=], |index|, |range|, and |count| if given.
@@ -3910,8 +3910,8 @@ The <dfn method for=IDBIndex>getAllKeys(|query|, |count|)</dfn> method steps are
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=retrieve multiple values from an index=] with |index|, |range|, and |count| if given.
@@ -3943,8 +3943,8 @@ The <dfn method for=IDBIndex>count(|query|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |operation| be an algorithm to run [=count the records in a range=] with |index| and |range|.
@@ -4002,8 +4002,8 @@ The <dfn method for=IDBIndex>openCursor(|query|, |direction|)</dfn> method steps
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |cursor| be a new [=cursor=] with its
@@ -4047,8 +4047,8 @@ The <dfn method for=IDBIndex>openKeyCursor(|query|, |direction|)</dfn> method st
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of running
-    [=convert a value to a key range=] with |query|.
+1. Let |range| be the result of
+    [=/converting a value to a key range=] with |query|.
     Rethrow any exceptions.
 
 1. Let |cursor| be a new [=cursor=] with its
@@ -4121,11 +4121,11 @@ interface IDBKeyRange {
 </div>
 
 The <dfn attribute for=IDBKeyRange>lower</dfn> getter steps are to
-return the result of running [=convert a key to a value=]
+return the result of [=/converting a key to a value=]
 with [=/this=]'s [=lower bound=] if it is not null, or undefined otherwise.
 
 The <dfn attribute for=IDBKeyRange>upper</dfn> getter steps are to
-return the result of running [=convert a key to a
+return the result of [=/converting a key to a
 value=] with [=/this=]'s [=upper bound=] if it is not null, or undefined
 otherwise.
 
@@ -4169,7 +4169,7 @@ return [=/this=]'s [=upper open flag=].
 
 The <dfn method for=IDBKeyRange>only(|value|)</dfn> method steps are:
 
-1. Let |key| be the result of running [=convert
+1. Let |key| be the result of [=/converting
     a value to a key=] with |value|. Rethrow any exceptions.
 
 1. If |key| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4184,7 +4184,7 @@ The <dfn method for=IDBKeyRange>only(|value|)</dfn> method steps are:
 
 The <dfn method for=IDBKeyRange>lowerBound(|lower|, |open|)</dfn> method steps are:
 
-1. Let |lowerKey| be the result of running [=convert a
+1. Let |lowerKey| be the result of [=/converting a
     value to a key=] with |lower|. Rethrow any exceptions.
 
 1. If |lowerKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4201,7 +4201,7 @@ The <dfn method for=IDBKeyRange>lowerBound(|lower|, |open|)</dfn> method steps a
 
 The <dfn method for=IDBKeyRange>upperBound(|upper|, |open|)</dfn> method steps are:
 
-1. Let |upperKey| be the result of running [=convert a
+1. Let |upperKey| be the result of [=/converting a
     value to a key=] with |upper|. Rethrow any exceptions.
 
 1. If |upperKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4217,12 +4217,12 @@ The <dfn method for=IDBKeyRange>upperBound(|upper|, |open|)</dfn> method steps a
 
 The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|, |upperOpen|)</dfn> method steps are:
 
-1. Let |lowerKey| be the result of running [=convert a
+1. Let |lowerKey| be the result of [=/converting a
     value to a key=] with |lower|. Rethrow any exceptions.
 
 1. If |lowerKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
-1. Let |upperKey| be the result of running [=convert a
+1. Let |upperKey| be the result of [=/converting a
     value to a key=] with |upper|. Rethrow any exceptions.
 
 1. If |upperKey| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4247,7 +4247,7 @@ The <dfn method for=IDBKeyRange>bound(|lower|, |upper|, |lowerOpen|, |upperOpen|
 
 The <dfn method for=IDBKeyRange>includes(|key|)</dfn> method steps are:
 
-1. Let |k| be the result of running [=convert a
+1. Let |k| be the result of [=/converting a
     value to a key=] with |key|. Rethrow any exceptions.
 
 1. If |k| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4333,7 +4333,7 @@ The <dfn attribute for=IDBCursor>direction</dfn> getter steps are to
 return [=/this=]'s [=cursor/direction=].
 
 The <dfn attribute for=IDBCursor>key</dfn> getter steps are to
-return the result of running [=convert a key to a
+return the result of [=/converting a key to a
 value=] with the cursor's current [=cursor/key=].
 
 <aside class=note>
@@ -4346,7 +4346,7 @@ an object does not modify the contents of the database.
 </aside>
 
 The <dfn attribute for=IDBCursor>primaryKey</dfn> getter steps are to
-return the result of running [=convert a key to a
+return the result of [=/converting a key to a
 value=] with the cursor's current [=effective key=].
 
 <aside class=note>
@@ -4466,7 +4466,7 @@ The <dfn method for=IDBCursor>continue(|key|)</dfn> method steps are:
 
 1. If |key| is given, then:
 
-    1. Let |r| be the result of running [=convert a
+    1. Let |r| be the result of [=/converting a
         value to a key=] with |key|. Rethrow any exceptions.
 
     1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4526,14 +4526,14 @@ The <dfn method for=IDBCursor>continuePrimaryKey(|key|, |primaryKey|)</dfn> meth
     the cursor is being iterated or has iterated past its end,
     [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Let |r| be the result of running [=convert a value to
+1. Let |r| be the result of [=/converting a value to
     a key=] with |key|. Rethrow any exceptions.
 
 1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
 
 1. Let |key| be |r|.
 
-1. Let |r| be the result of running [=convert a value
+1. Let |r| be the result of [=/converting a value
      to a key=] with |primaryKey|. Rethrow any exceptions.
 
 1. If |r| is invalid, [=throw=] a "{{DataError}}" {{DOMException}}.
@@ -4647,8 +4647,8 @@ The <dfn method for=IDBCursor>update(|value|)</dfn> method steps are:
 1. If [=/this=]'s [=effective object store=] uses [=in-line
     keys=], then:
 
-    1. Let |kpk| be the result of running
-        [=extract a key from a value using a key path=] with
+    1. Let |kpk| be the result of
+        [=/extracting a key from a value using a key path=] with
         |clone| and the [=object-store/key
         path=] of [=/this=]'s [=effective object store=].
         Rethrow any exceptions.
@@ -4664,7 +4664,7 @@ The <dfn method for=IDBCursor>update(|value|)</dfn> method steps are:
 </div>
 
 <aside class=note>
-  A result of running the steps to [=store a record into an object
+  A result of [=/storing a record into an object
   store=] is that if the record has been deleted since the cursor
   moved to it, a new record will be created.
 </aside>
@@ -5359,8 +5359,8 @@ for the [=database=], and a |request|, run these steps:
     1. Set |request|'s [=request/transaction=] to |transaction|.
     1. Set |request|'s [=request/done flag=] to true.
     1. Set |transaction|'s [=transaction/state=] to [=transaction/active=].
-    1. Let |didThrow| be the result of running
-        [=fire a version change event=] named
+    1. Let |didThrow| be the result of
+        [=firing a version change event=] named
         <a event>`upgradeneeded`</a> at |request| with |old
         version| and |version|.
     1. Set |transaction|'s [=transaction/state=] to [=transaction/inactive=].
@@ -5622,8 +5622,8 @@ To <dfn>store a record into an object store</dfn> with
 
     1. If |key| is undefined, then:
 
-        1. Let |key| be the result of running
-            [=generate a key=] for |store|.
+        1. Let |key| be the result of
+            [=generating a key=] for |store|.
 
         1. If |key| is failure, then this operation failed with a
             "{{ConstraintError}}" {{DOMException}}. Abort this
@@ -5654,8 +5654,8 @@ To <dfn>store a record into an object store</dfn> with
 
 1. For each |index| which [=references=] |store|:
 
-    1. Let |index key| be the result of running
-        [=extract a key from a value using a key path=] with
+    1. Let |index key| be the result of
+        [=/extracting a key from a value using a key path=] with
         |value|, |index|'s [=index/key path=], and |index|'s
         [=multiEntry flag=].
 
@@ -5772,7 +5772,7 @@ with |store| and |range|, run these steps:
 
 1. If |record| was not found, return undefined.
 
-1. Return the result of running [=convert a
+1. Return the result of [=/converting a
     key to a value=] with |record|'s key.
 
 </div>
@@ -5793,7 +5793,7 @@ with |store|, |range| and optional |count|, run these steps:
 
 1. [=list/For each=] |record| of |records|:
 
-    1. Let |entry| be the result of running [=convert a
+    1. Let |entry| be the result of [=/converting a
         key to a value=] with |record|'s key.
     1. Append |entry| to |list|.
 
@@ -5860,7 +5860,7 @@ To <dfn>retrieve a value from an index</dfn> with
 
 1. If |record| was not found, return undefined.
 
-1. Return the result of running [=convert a
+1. Return the result of [=/converting a
         key to a value=] with |record|'s [=/value=].
 
 </div>
@@ -5880,7 +5880,7 @@ To <dfn>retrieve multiple values from an index</dfn> with
 
 1. [=list/For each=] |record| of |records|:
 
-    1. Let |entry| be the result of running [=convert a
+    1. Let |entry| be the result of [=/converting a
         key to a value=] with |record|'s value.
     1. Append |entry| to |list|.
 
@@ -6138,15 +6138,15 @@ with |value|, |keyPath| and an optional |multiEntry flag|, run the
 following steps. The result of these steps is a [=/key=], invalid, or
 failure, or the steps may throw an exception.
 
-1. Let |r| be the result of running [=evaluate a key
+1. Let |r| be the result of [=/evaluating a key
     path on a value=] with |value| and |keyPath|. Rethrow any
     exceptions.
 
 1. If |r| is failure, return failure.
 
-1. Let |key| be the result of running [=convert a value
+1. Let |key| be the result of [=/converting a value
     to a key=] with |r| if the |multiEntry flag| is false, and the
-    result of running [=convert a value to a multiEntry
+    result of [=/converting a value to a multiEntry
     key=] with |r| otherwise. Rethrow any exceptions.
 
 1. If |key| is invalid, return invalid.
@@ -6171,8 +6171,8 @@ ECMAScript value or failure, or the steps may throw an exception.
 
     1. [=list/For each=] |item| of |keyPath|:
 
-        1. Let |key| be the result of recursively running
-            [=evaluate a key path on a value=] with |item| and |value|.
+        1. Let |key| be the result of recursively
+            [=/evaluating a key path on a value=] with |item| and |value|.
 
         1. [=/Assert=]: |key| is not an [=abrupt completion=].
 
@@ -6323,7 +6323,7 @@ To <dfn>inject a key into a value using a key path</dfn> with |value|, a |key| a
 
 1. [=/Assert=]: |value| is an [=Object=] or an [=Array=].
 
-1. Let |keyValue| be the result of running [=convert a
+1. Let |keyValue| be the result of [=/converting a
     key to a value=] with |key|.
 
 1. Let |status| be [=CreateDataProperty=](|value|, |last|, |keyValue|).
@@ -6389,8 +6389,8 @@ The steps return an ECMAScript value.
           1. Let |index| be 0.
           1. While |index| is less than |len|:
 
-              1. Let |entry| be the result of running
-                  [=convert a key to a value=] with |value|[|index|].
+              1. Let |entry| be the result of
+                  [=/converting a key to a value=] with |value|[|index|].
               1. Let |status| be [=CreateDataProperty=](|array|, |index|,
                   |entry|).
               1. [=/Assert=]: |status| is true.
@@ -6451,8 +6451,8 @@ steps may throw an exception.
       <!-- Binary -->
       : If |input| is a [=buffer source type=]
       ::
-          1. Let |bytes| be the result of running
-              <a lt="get a copy of the buffer source">get a copy of the bytes held by the buffer source</a>
+          1. Let |bytes| be the result of
+              <a lt="get a copy of the buffer source">getting a copy of the bytes held by the buffer source</a>
               |input|. Rethrow any exceptions.
 
           1. Return a new [=/key=] with [=key/type=]
@@ -6474,8 +6474,8 @@ steps may throw an exception.
 
               1. Let |entry| be [=?=] [=Get=](|input|, |index|).
 
-              1. Let |key| be the result of running
-                  [=convert a value to a key=] with arguments |entry|
+              1. Let |key| be the result of
+                  [=/converting a value to a key=] with arguments |entry|
                   and |seen|.
 
               1. [=ReturnIfAbrupt=](|key|).
@@ -6521,8 +6521,8 @@ steps may throw an exception.
 
         1. If |entry| is not an [=abrupt completion=], then:
 
-             1. Let |key| be the result of running
-                 [=convert a value to a key=] with arguments
+             1. Let |key| be the result of
+                 [=/converting a value to a key=] with arguments
                  |entry| and |seen|.
 
              1. If |key| is not invalid or an [=abrupt completion=],
@@ -6533,7 +6533,7 @@ steps may throw an exception.
 
     1. Return a new [=array key=] with [=key/value=] set to |keys|.
 
-1. Otherwise, return the result of running [=convert a
+1. Otherwise, return the result of [=/converting a
     value to a key=] with argument |input|.
     Rethrow any exceptions.
 


### PR DESCRIPTION
Editorial

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/359.html" title="Last updated on Jun 4, 2021, 4:38 PM UTC (6cc7608)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/359/dbf01a4...6cc7608.html" title="Last updated on Jun 4, 2021, 4:38 PM UTC (6cc7608)">Diff</a>