### PR TITLE
Editorial: Add event definition for 'close'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -500,10 +500,12 @@ running.
 A [=/connection=]'s [=get the parent=] algorithm returns
 null.
 
-A <dfn event>`versionchange`</dfn> will be fired at an open
+An event with type <dfn event>`versionchange`</dfn> will be fired at an open
 [=/connection=] if an attempt is made to upgrade or delete the
 [=database=]. This gives the [=/connection=] the opportunity to close
 to allow the upgrade or delete to proceed.
+
+An event with type <dfn event>`close`</dfn> will be fired at a [=/connection=] if the connection is [=/close a database connection|closed=] abormally.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -505,7 +505,7 @@ An event with type <dfn event>`versionchange`</dfn> will be fired at an open
 [=database=]. This gives the [=/connection=] the opportunity to close
 to allow the upgrade or delete to proceed.
 
-An event with type <dfn event>`close`</dfn> will be fired at a [=/connection=] if the connection is [=/close a database connection|closed=] abormally.
+An event with type <dfn event>`close`</dfn> will be fired at a [=/connection=] if the connection is [=/close a database connection|closed=] abnormally.
 
 </div>
 


### PR DESCRIPTION
A reference to a 'close' event turned into a link back in d2bc4db1 but
there wasn't a local definition - it ended up linking into HTML! This
is now triggering a Bikeshed warning - yay!

Add a minimal local definition for the event type, like the others.

(No normative behavior changes, no tests required.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/384.html" title="Last updated on Jun 3, 2022, 1:02 AM UTC (6ec48c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/384/e067b06...6ec48c2.html" title="Last updated on Jun 3, 2022, 1:02 AM UTC (6ec48c2)">Diff</a>