### PR TITLE
Editorial: Remove redundant ticks from <dfn event> text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -498,12 +498,12 @@ running.
 A [=/connection=]'s [=get the parent=] algorithm returns
 null.
 
-An event with type <dfn event for=IDBDatabase>`versionchange`</dfn> will be fired at an open
+An event with type <dfn event for=IDBDatabase>versionchange</dfn> will be fired at an open
 [=/connection=] if an attempt is made to upgrade or delete the
 [=/database=]. This gives the [=/connection=] the opportunity to close
 to allow the upgrade or delete to proceed.
 
-An event with type <dfn event for=IDBDatabase>`close`</dfn> will be fired at a [=/connection=] if the connection is [=/close a database connection|closed=] abnormally.
+An event with type <dfn event for=IDBDatabase>close</dfn> will be fired at a [=/connection=] if the connection is [=/close a database connection|closed=] abnormally.
 
 </div>
 
@@ -1133,10 +1133,10 @@ They will return true if any transactions were cleaned up, or false otherwise.
   each [=/transaction=].
 </aside>
 
-An event with type <dfn event for=IDBTransaction>`complete`</dfn> is fired at
+An event with type <dfn event for=IDBTransaction>complete</dfn> is fired at
 a [=/transaction=] that has successfully [=transaction/committed=].
 
-An event with type <dfn event for=IDBTransaction>`abort`</dfn> is fired at
+An event with type <dfn event for=IDBTransaction>abort</dfn> is fired at
 a [=/transaction=] that has [=transaction/aborted=].
 
 <!-- ============================================================ -->
@@ -1241,12 +1241,12 @@ request=].
 When a request is made, a new [=/request=] is returned with its [=request/done
 flag=] set to false. If a request completes successfully, its [=request/done flag=]
 is set to true, its [=request/result=] is set to the result of the request,
-and an event with type <dfn event for=IDBRequest>`success`</dfn> is fired at the
+and an event with type <dfn event for=IDBRequest>success</dfn> is fired at the
 [=/request=].
 
 If an error occurs while performing the operation, the request's [=request/done flag=]
 is set to true, the request's [=request/error=] is set to the error, and an event with
-type <dfn event for=IDBRequest>`error`</dfn> is fired at the request.
+type <dfn event for=IDBRequest>error</dfn> is fired at the request.
 
 A [=/request=]'s [=get the parent=] algorithm returns the request's
 [=request/transaction=].
@@ -1269,7 +1269,7 @@ A [=/request=]'s [=get the parent=] algorithm returns the request's
 An <dfn>open request</dfn> is a special type of [=/request=] used
 when opening a [=/connection=] or deleting a [=/database=].
 In addition to {{IDBRequest/success!!event}} and {{IDBRequest/error!!event}} events,
-<dfn event for=IDBOpenDBRequest>`blocked`</dfn> and <dfn event for=IDBOpenDBRequest>`upgradeneeded`</dfn> events may be fired at an [=request/open
+<dfn event for=IDBOpenDBRequest>blocked</dfn> and <dfn event for=IDBOpenDBRequest>upgradeneeded</dfn> events may be fired at an [=request/open
 request=] to indicate progress.
 
 The [=request/source=] of an [=request/open request=]


### PR DESCRIPTION
Bikeshed formats these as code automagically, so the ticks are not needed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/398.html" title="Last updated on Mar 3, 2023, 6:32 PM UTC (4e1dd96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/398/af5536b...4e1dd96.html" title="Last updated on Mar 3, 2023, 6:32 PM UTC (4e1dd96)">Diff</a>