### PR TITLE
Specify the error code for failures when reading a value from disk

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1869,8 +1869,8 @@ usage.
   <tr>
     <td>{{NotReadableError}}</td>
     <td>
-      The operation failed because the file(s) containing the requested
-      data could not be read.
+      The operation failed because the underlying storage containing
+      the requested data could not be read.
     </td>
   </tr>
   <tr>
@@ -1900,7 +1900,7 @@ usage.
     <td>{{UnknownError}}</td>
     <td>
       The operation failed for transient reasons unrelated to the
-      database itself and not covered by any other error.
+      database itself or not covered by any other error.
     </td>
   </tr>
   <tr>
@@ -5643,6 +5643,9 @@ To <dfn>store a record into an object store</dfn> with
 To <dfn>retrieve a value from an object store</dfn> with
 |targetRealm|, |store| and |range|, run these steps:
 
+NOTE:
+    May return a {{DOMException}} if an error occurs while running these steps.
+
 1. Let |record| be the first [=object-store/record=] in |store|'s
     [=object-store/list of records=] whose [=/key=] is [=in=] |range|, if
     any.
@@ -5661,6 +5664,9 @@ To <dfn>retrieve a value from an object store</dfn> with
 
 To <dfn>retrieve multiple values from an object
 store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these steps:
+
+NOTE:
+    May return a {{DOMException}} if an error occurs while running these steps.
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 

--- a/index.bs
+++ b/index.bs
@@ -1867,6 +1867,13 @@ usage.
     </td>
   </tr>
   <tr>
+    <td>{{NotReadableError}}</td>
+    <td>
+      The operation failed because the file(s) containing the requested
+      data could not be read.
+    </td>
+  </tr>
+  <tr>
     <td>{{QuotaExceededError}}</td>
     <td>
       The operation failed because there was not enough remaining
@@ -1892,8 +1899,8 @@ usage.
   <tr>
     <td>{{UnknownError}}</td>
     <td>
-      The operation failed for reasons unrelated to the database
-      itself and not covered by any other errors.
+      The operation failed for transient reasons unrelated to the
+      database itself and not covered by any other error.
     </td>
   </tr>
   <tr>
@@ -5642,7 +5649,8 @@ To <dfn>retrieve a value from an object store</dfn> with
 
 1. If |record| was not found, return undefined.
 
-1. Let |serialized| be of |record|'s [=/value=].
+1. Let |serialized| be |record|'s [=/value=]. If an error occurs while reading the value from the
+    underlying storage, return a newly [=exception/created=] "{{NotReadableError}}" {{DOMException}}.
 
 1. Return [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
 
@@ -5664,7 +5672,8 @@ store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these
 
 1. [=list/For each=] |record| of |records|:
 
-    1. Let |serialized| be |record|'s [=/value=].
+    1. Let |serialized| be |record|'s [=/value=]. If an error occurs while reading the value from the
+        underlying storage, return a newly [=exception/created=] "{{NotReadableError}}" {{DOMException}}.
     1. Let |entry| be [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
     1. Append |entry| to |list|.
 

--- a/index.bs
+++ b/index.bs
@@ -6717,6 +6717,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Added <a href="#accessibility">Accessibility considerations</a> section. ([Issue #327](https://github.com/w3c/IndexedDB/issues/327))
 * Used [[infra]]'s list sorting definition. ([Issue #346](https://github.com/w3c/IndexedDB/issues/346))
 * Added a definition for [=transaction/live=] transactions, and renamed "run an upgrade transaction" to [=/upgrade a database=], to disambiguate "running". ([Issue #408](https://github.com/w3c/IndexedDB/issues/408))
+* Specified the {{DOMException}} type for failures when reading a value from the underlying storage in [[#object-store-retrieval-operation]]. ([Issue #423](https://github.com/w3c/IndexedDB/issues/423))
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}
@@ -6736,6 +6737,7 @@ specification authoring tool used to create this document, and
 for his general authoring advice.
 
 Special thanks to
+Abhishek Shanthkumar,
 Adam Klein,
 Addison Phillips,
 Adrienne Walker,

--- a/index.bs
+++ b/index.bs
@@ -5641,10 +5641,8 @@ To <dfn>store a record into an object store</dfn> with
 <div algorithm>
 
 To <dfn>retrieve a value from an object store</dfn> with
-|targetRealm|, |store| and |range|, run these steps:
-
-NOTE:
-    May return a {{DOMException}} if an error occurs while running these steps.
+|targetRealm|, |store| and |range|, run these steps.
+They return undefined, an ECMAScript value, or an error (a {{DOMException}}):
 
 1. Let |record| be the first [=object-store/record=] in |store|'s
     [=object-store/list of records=] whose [=/key=] is [=in=] |range|, if
@@ -5663,10 +5661,8 @@ NOTE:
 <div algorithm>
 
 To <dfn>retrieve multiple values from an object
-store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these steps:
-
-NOTE:
-    May return a {{DOMException}} if an error occurs while running these steps.
+store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these steps.
+They return a <code>[=/sequence=]&lt;{{any}}&gt;</code> or an error (a {{DOMException}}):
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 


### PR DESCRIPTION
This PR:
- Updates the description of `UnknownError` to convey that it should be used for transient reasons, per the [Web IDL Standard](https://webidl.spec.whatwg.org/#unknownerror).
- Adds `NotReadableError` from the [Web IDL Standard](https://webidl.spec.whatwg.org/#notreadableerror) to the list of possible exceptions.
- Specifies `NotReadableError` to be returned when reading the value from the underlying storage fails in the `object-store-retrieval-operation` algorithms.

Closes #423

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] ~Modified Web platform tests (link to pull request)~ A WPT for this scenario does not seem feasible because the location of IndexedDB data on disk differs across browsers and platforms.
 

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=362123231)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/430.html" title="Last updated on Oct 14, 2024, 9:34 AM UTC (1489231)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/430/010ecb2...1489231.html" title="Last updated on Oct 14, 2024, 9:34 AM UTC (1489231)">Diff</a>