### PR TITLE
Remove "otherwise" language after throwing in algorithms.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2015,7 +2015,7 @@ enum IDBRequestReadyState {
 The <dfn attribute for=IDBRequest>result</dfn> getter steps are:
 
 1. If [=/this=]'s [=request/done flag=] is false, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
-1. Otherwise, return [=/this=]'s [=request/result=], or undefined if the request resulted in an error.
+1. Return [=/this=]'s [=request/result=], or undefined if the request resulted in an error.
 
 </div>
 
@@ -2023,7 +2023,7 @@ The <dfn attribute for=IDBRequest>result</dfn> getter steps are:
 The <dfn attribute for=IDBRequest>error</dfn> getter steps are:
 
 1. If [=/this=]'s [=request/done flag=] is false, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
-1. Otherwise, return [=/this=]'s [=request/error=], or null if no error occurred.
+1. Return [=/this=]'s [=request/error=], or null if no error occurred.
 
 </div>
 
@@ -2981,8 +2981,7 @@ To <dfn>add or put</dfn> with |handle|, |value|, |key|, and |no-overwrite flag|,
         1. If |store| does not have a [=key generator=], [=exception/throw=]
             a "{{DataError}}" {{DOMException}}.
 
-        1. Otherwise, if
-            [=check that a key could be injected into a value=] with
+        1. If [=check that a key could be injected into a value=] with
             |clone| and |store|'s [=object-store/key path=] return
             false, [=exception/throw=] a "{{DataError}}" {{DOMException}}.
 


### PR DESCRIPTION
Remove "otherwise" language after throwing exceptions in algorithmic steps.

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanstade/IndexedDB/pull/438.html" title="Last updated on Jan 10, 2025, 7:35 PM UTC (c1b4174)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/438/1dd072d...evanstade:c1b4174.html" title="Last updated on Jan 10, 2025, 7:35 PM UTC (c1b4174)">Diff</a>