### PR TITLE
Editorial: Use newfangled bikeshed issue links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6703,20 +6703,20 @@ For the revision history of the first edition, see [that document's Revision His
 For the revision history of the second edition, see [that document's Revision History](https://www.w3.org/TR/IndexedDB-2/#revision-history).
 
 * The [=transaction/cleanup Indexed Database transactions=] algorithm now returns a value for integration with other specs. ([PR #232](https://github.com/w3c/IndexedDB/pull/232))
-* Updated [partial interface definition](#global-scope) since {{WindowOrWorkerGlobalScope}} is now a `mixin` ([PR #238](https://github.com/w3c/IndexedDB/pull/238)).
-* Added {{IDBFactory/databases()}} method. ([Issue #31](https://github.com/w3c/IndexedDB/issues/31))
-* Added {{IDBTransaction/commit()}} method. ([Issue #234](https://github.com/w3c/IndexedDB/issues/234))
-* Added {{IDBCursor/request}} attribute. ([Issue #255](https://github.com/w3c/IndexedDB/issues/255))
-* Removed handling for nonstandard `lastModifiedDate` property of {{File}} objects. ([Issue #215](https://github.com/w3c/IndexedDB/issues/215))
-* Remove escaping {{IDBKeyRange/includes()}} method. ([Issue #294](https://github.com/w3c/IndexedDB/issues/294))
-* Restrict array keys to [=ECMAScript/Array exotic objects=] (i.e. disallow proxies). ([Issue #309](https://github.com/w3c/IndexedDB/issues/309))
-* Transactions are now temporarily made inactive during clone operations.
-* Added {{IDBTransactionOptions/durability}} option and {{IDBTransaction/durability}} attribute. ([Issue #50](https://github.com/w3c/IndexedDB/issues/50))
-* Specified [[#transaction-scheduling]] more precisely and disallow starting read/write transactions while read-only transactions with overlapping scope are running. ([Issue #253](https://github.com/w3c/IndexedDB/issues/253))
-* Added <a href="#accessibility">Accessibility considerations</a> section. ([Issue #327](https://github.com/w3c/IndexedDB/issues/327))
-* Used [[infra]]'s list sorting definition. ([Issue #346](https://github.com/w3c/IndexedDB/issues/346))
-* Added a definition for [=transaction/live=] transactions, and renamed "run an upgrade transaction" to [=/upgrade a database=], to disambiguate "running". ([Issue #408](https://github.com/w3c/IndexedDB/issues/408))
-* Specified the {{DOMException}} type for failures when reading a value from the underlying storage in [[#object-store-retrieval-operation]]. ([Issue #423](https://github.com/w3c/IndexedDB/issues/423))
+* Updated [partial interface definition](#global-scope) since {{WindowOrWorkerGlobalScope}} is now a `mixin`. ([PR #238](https://github.com/w3c/IndexedDB/pull/238))
+* Added {{IDBFactory/databases()}} method. (<#31>)
+* Added {{IDBTransaction/commit()}} method. (<#234>)
+* Added {{IDBCursor/request}} attribute. (<#255>)
+* Removed handling for nonstandard `lastModifiedDate` property of {{File}} objects. (<#215>)
+* Remove escaping {{IDBKeyRange/includes()}} method. (<#294>)
+* Restrict array keys to [=ECMAScript/Array exotic objects=] (i.e. disallow proxies). (<#309>)
+* Transactions are now temporarily made inactive during clone operations. ([PR #310](https://github.com/w3c/IndexedDB/pull/310))
+* Added {{IDBTransactionOptions/durability}} option and {{IDBTransaction/durability}} attribute. (<#50>)
+* Specified [[#transaction-scheduling]] more precisely and disallow starting read/write transactions while read-only transactions with overlapping scope are running. (<#253>)
+* Added <a href="#accessibility">Accessibility considerations</a> section. (<#327>)
+* Used [[infra]]'s list sorting definition. (<#346>)
+* Added a definition for [=transaction/live=] transactions, and renamed "run an upgrade transaction" to [=/upgrade a database=], to disambiguate "running". (<#408>)
+* Specified the {{DOMException}} type for failures when reading a value from the underlying storage in [[#object-store-retrieval-operation]]. (<#423>)
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}


### PR DESCRIPTION
This simplifies maintenance of the Revision History.

Also, add a missing PR link.

See https://github.com/speced/bikeshed/issues/1532

Editorial only.