### PR TITLE
Update IDBFactory open() to set its request's processed flag

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2227,6 +2227,8 @@ The <dfn method for=IDBFactory>open(|name|, |version|)</dfn> method steps are:
           [=database/version=] equal to 1.
         </details>
 
+    1. Set |request|'s [=request/processed flag=] to true.
+
     1. [=Queue a task=] to run these steps:
 
         1. If |result| is an error, then:
@@ -6720,6 +6722,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Added a definition for [=transaction/live=] transactions, and renamed "run an upgrade transaction" to [=/upgrade a database=], to disambiguate "running". (<#408>)
 * Specified the {{DOMException}} type for failures when reading a value from the underlying storage in [[#object-store-retrieval-operation]]. (<#423>)
 * Updated [=convert a value to a key=] to return invalid for detached array buffers. (<#417>)
+* Updated {{IDBFactory/open()}} to set its request's [=request/processed flag=] to true.
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}


### PR DESCRIPTION
Closes #434

The following tasks have been completed:
 * [X ] Confirmed there are no ReSpec/BikeShed errors or warnings.

I looked for other cases where the spec maybe forgot about the processed flag, but I did not find any obvious issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/441.html" title="Last updated on Feb 28, 2025, 10:11 PM UTC (ecfee18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/441/c659eb3...ecfee18.html" title="Last updated on Feb 28, 2025, 10:11 PM UTC (ecfee18)">Diff</a>