### PR TITLE
erratum in Example 6 regarding behavior of key generator with in-line key

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1789,10 +1789,7 @@ Attempting to store a property on a primitive value will fail and
 throw an error. In the first example below the [=object-store/key
 path=] for the object store is "`foo`". The actual object
 is a primitive with the value, `4`. Trying to define a
-property on that primitive value fails. The same is true for arrays.
-Properties are not allowed on an array. In the second example below,
-the actual object is an array, `[10]`. Trying to define a
-property on the array fails.
+property on that primitive value fails.
 
 ```js
 const store = db.createObjectStore("store", { keyPath: "foo", autoIncrement: true });
@@ -1800,10 +1797,6 @@ const store = db.createObjectStore("store", { keyPath: "foo", autoIncrement: tru
 // The key generation will attempt to create and store the key path
 // property on this primitive.
 store.put(4); // will throw DataError
-
-// The key generation will attempt to create and store the key path
-// property on this array.
-store.put([10]); // will throw DataError
 ```
 </div>
 


### PR DESCRIPTION
Closes https://github.com/w3c/IndexedDB/issues/443

This is a non-substantive correction to an example. There is no change to the normative text of the specification or the test suite.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chairmank/IndexedDB/pull/444.html" title="Last updated on Mar 26, 2025, 4:14 PM UTC (5fc1884)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/444/4270575...chairmank:5fc1884.html" title="Last updated on Mar 26, 2025, 4:14 PM UTC (5fc1884)">Diff</a>