### PR TITLE
Do not include databases with version 0 in databases() results

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2338,6 +2338,7 @@ The <dfn method for=IDBFactory>databases()</dfn> method steps are:
 
     1. [=set/For each=] |db| of |databases|:
 
+        1. If |db|'s [=database/version=] is 0, then [=iteration/continue=].
         1. Let |info| be a new {{IDBDatabaseInfo}} dictionary.
         1. Set |info|'s {{IDBDatabaseInfo/name}} dictionary member to |db|'s [=database/name=].
         1. Set |info|'s {{IDBDatabaseInfo/version}} dictionary member to |db|'s [=database/version=].
@@ -6716,6 +6717,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Specified the {{DOMException}} type for failures when reading a value from the underlying storage in [[#object-store-retrieval-operation]]. (<#423>)
 * Updated [=convert a value to a key=] to return invalid for detached array buffers. (<#417>)
 * Updated {{IDBFactory/open()}} to set its request's [=request/processed flag=] to true.
+* Don't include databases that aren't done being created in {{IDBFactory/databases()}}. (<#442>)
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}
@@ -6786,6 +6788,7 @@ Pablo Castro,
 Philip Jägenstedt,
 Shawn Wilsher,
 Simon Pieters,
+Steffen Larssen,
 Steve Becker,
 Tobie Langel,
 Victor Costan,


### PR DESCRIPTION
When a database is first created it is treated as an upgrade from version 0 to the new version (the default is 1). Per WPT, all implementations exclude these in-progress databases from the enumeration returned by databases(), so reflect this in the algorithm steps.

Closes #442


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/448.html" title="Last updated on Apr 11, 2025, 7:42 PM UTC (fb85794)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/448/1b311f3...fb85794.html" title="Last updated on Apr 11, 2025, 7:42 PM UTC (fb85794)">Diff</a>