### PR TITLE
Clarify the direction predicates for cursor iteration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5905,63 +5905,53 @@ To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
               Let |found record| be the first record in |records| which
               satisfy all of the following requirements:
 
-              * If |key| is defined, the record's key is [=greater
-                  than=] or [=equal to=] |key|.
+              * If |key| is defined
+                * The record's key is [=greater than=] or [=equal to=] |key|.
 
-              * If |primaryKey| is defined, the record's key is [=equal
-                  to=] |key| and the record's value is [=greater
-                  than=] or [=equal to=] |primaryKey|, or the
-                  record's key is [=greater than=] |key|.
+              * If |primaryKey| is defined
+                * The record's key is [=equal to=] |key| and the record's value is [=greater than=] or [=equal to=] |primaryKey|
+                * The record's key is [=greater than=] |key|.
 
-              * If |position| is defined, and |source| is an
-                  [=/object store=], the record's key is [=greater than=]
-                  |position|.
+              * If |position| is defined and |source| is an [=/object store=]
+                  * The record's key is [=greater than=] |position|.
 
-              * If |position| is defined, and |source| is an
-                  [=/index=], the record's key is [=equal to=]
-                  |position| and the record's value is [=greater
-                  than=] |object store position| or the record's key is
-                  [=greater than=] |position|.
+              * If |position| is defined and |source| is an [=/index=]
+                  * The record's key is [=equal to=] |position| and the record's value is [=greater than=] |object store position|
+                  * The record's key is [=greater than=] |position|.
 
-              * The record's key is [=in=]
-                  |range|.
+              * The record's key is [=in=] |range|.
 
           : "{{IDBCursorDirection/nextunique}}"
           ::
               Let |found record| be the first record in |records| which
               satisfy all of the following requirements:
 
-              * If |key| is defined, the record's key is [=greater
-                  than=] or [=equal to=] |key|.
+              * If |key| is defined
+                * The record's key is [=greater than=] or [=equal to=] |key|.
 
-              * If |position| is defined, the record's key is [=greater
-                  than=] |position|.
+              * If |position| is defined
+                * The record's key is [=greater than=] |position|.
 
-              * The record's key is [=in=]
-                  |range|.
+              * The record's key is [=in=] |range|.
 
           : "{{IDBCursorDirection/prev}}"
           ::
               Let |found record| be the last record in |records| which
               satisfy all of the following requirements:
 
-              * If |key| is defined, the record's key is [=less
-                  than=] or [=equal to=] |key|.
+              * If |key| is defined
+                * The record's key is [=less than=] or [=equal to=] |key|.
 
-              * If |primaryKey| is defined, the record's key is [=equal
-                  to=] |key| and the record's value is [=less than=]
-                  or [=equal to=] |primaryKey|, or the record's key is
-                  [=less than=] |key|.
+              * If |primaryKey| is defined
+                * The record's key is [=equal to=] |key| and the record's value is [=less than=] or [=equal to=] |primaryKey|
+                * The record's key is [=less than=] |key|.
 
-              * If |position| is defined, and |source| is an
-                  [=/object store=], the record's key is [=less
-                  than=] |position|.
+              * If |position| is defined and |source| is an [=/object store=]
+                * The record's key is [=less than=] |position|.
 
-              * If |position| is defined, and |source| is an
-                  [=/index=], the record's key is [=equal to=]
-                  |position| and the record's value is [=less than=]
-                  |object store position| or the record's key is
-                  [=less than=] |position|.
+              * If |position| is defined and |source| is an [=/index=]
+                * The record's key is [=equal to=] |position| and the record's value is [=less than=] |object store position|
+                * The record's key is [=less than=] |position|.
 
               * The record's key is [=in=] |range|.
 
@@ -5970,14 +5960,13 @@ To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
               Let |temp record| be the last record in
               |records| which satisfy all of the following requirements:
 
-              * If |key| is defined, the record's key is [=less
-                  than=] or [=equal to=] |key|.
+              * If |key| is defined
+                * The record's key is [=less than=] or [=equal to=] |key|.
 
-              * If |position| is defined, the record's key is [=less
-                  than=] |position|.
+              * If |position| is defined
+                * The record's key is [=less than=] |position|.
 
-              * The record's key is [=in=]
-                  |range|.
+              * The record's key is [=in=] |range|.
 
               If |temp record| is defined, let |found record| be the
               first record in |records| whose [=/key=] is [=equal to=]
@@ -6720,6 +6709,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Correct [=/upgrade a database=] steps to handle aborted transactions. (<#436>)
 * Update [=/iterate a cursor=] value serialization to use [=/value=] for [=/object stores=] instead of [=index/referenced values=]. (<#452>)
 * Add [=cursor/source handle=] to [=/cursor=] to avoid exposing internal indexes and object stores to script. (<#445>)
+* Clarify cursor iteration predicates (<#450>)
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}

--- a/index.bs
+++ b/index.bs
@@ -5911,17 +5911,17 @@ To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
               Let |found record| be the first record in |records| which
               satisfy all of the following requirements:
 
-              * If |key| is defined
-                * The record's key is [=greater than=] or [=equal to=] |key|.
+              * If |key| is defined:
+                  * The record's key is [=greater than=] or [=equal to=] |key|.
 
-              * If |primaryKey| is defined
-                * The record's key is [=equal to=] |key| and the record's value is [=greater than=] or [=equal to=] |primaryKey|
-                * The record's key is [=greater than=] |key|.
+              * If |primaryKey| is defined:
+                  * The record's key is [=equal to=] |key| and the record's value is [=greater than=] or [=equal to=] |primaryKey|
+                  * The record's key is [=greater than=] |key|.
 
-              * If |position| is defined and |source| is an [=/object store=]
+              * If |position| is defined and |source| is an [=/object store=]:
                   * The record's key is [=greater than=] |position|.
 
-              * If |position| is defined and |source| is an [=/index=]
+              * If |position| is defined and |source| is an [=/index=]:
                   * The record's key is [=equal to=] |position| and the record's value is [=greater than=] |object store position|
                   * The record's key is [=greater than=] |position|.
 
@@ -5932,11 +5932,11 @@ To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
               Let |found record| be the first record in |records| which
               satisfy all of the following requirements:
 
-              * If |key| is defined
-                * The record's key is [=greater than=] or [=equal to=] |key|.
+              * If |key| is defined:
+                  * The record's key is [=greater than=] or [=equal to=] |key|.
 
-              * If |position| is defined
-                * The record's key is [=greater than=] |position|.
+              * If |position| is defined:
+                  * The record's key is [=greater than=] |position|.
 
               * The record's key is [=in=] |range|.
 
@@ -5945,19 +5945,19 @@ To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
               Let |found record| be the last record in |records| which
               satisfy all of the following requirements:
 
-              * If |key| is defined
-                * The record's key is [=less than=] or [=equal to=] |key|.
+              * If |key| is defined:
+                  * The record's key is [=less than=] or [=equal to=] |key|.
 
-              * If |primaryKey| is defined
-                * The record's key is [=equal to=] |key| and the record's value is [=less than=] or [=equal to=] |primaryKey|
-                * The record's key is [=less than=] |key|.
+              * If |primaryKey| is defined:
+                  * The record's key is [=equal to=] |key| and the record's value is [=less than=] or [=equal to=] |primaryKey|
+                  * The record's key is [=less than=] |key|.
 
-              * If |position| is defined and |source| is an [=/object store=]
-                * The record's key is [=less than=] |position|.
+              * If |position| is defined and |source| is an [=/object store=]:
+                  * The record's key is [=less than=] |position|.
 
-              * If |position| is defined and |source| is an [=/index=]
-                * The record's key is [=equal to=] |position| and the record's value is [=less than=] |object store position|
-                * The record's key is [=less than=] |position|.
+              * If |position| is defined and |source| is an [=/index=]:
+                  * The record's key is [=equal to=] |position| and the record's value is [=less than=] |object store position|
+                  * The record's key is [=less than=] |position|.
 
               * The record's key is [=in=] |range|.
 
@@ -5966,11 +5966,11 @@ To <dfn>iterate a cursor</dfn> with |targetRealm|, |cursor|, an optional
               Let |temp record| be the last record in
               |records| which satisfy all of the following requirements:
 
-              * If |key| is defined
-                * The record's key is [=less than=] or [=equal to=] |key|.
+              * If |key| is defined:
+                  * The record's key is [=less than=] or [=equal to=] |key|.
 
-              * If |position| is defined
-                * The record's key is [=less than=] |position|.
+              * If |position| is defined:
+                  * The record's key is [=less than=] |position|.
 
               * The record's key is [=in=] |range|.
 


### PR DESCRIPTION
Closes #450

Splits the bulletpoints for cursor iteration into an additional level to improve clarity when reading

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stelar7/IndexedDB/pull/457.html" title="Last updated on May 15, 2025, 8:29 PM UTC (c0a6999)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/457/91642aa...stelar7:c0a6999.html" title="Last updated on May 15, 2025, 8:29 PM UTC (c0a6999)">Diff</a>