### PR TITLE
Add getAllRecords() method and update getAll()/getAllKeys to support direction option

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1371,6 +1371,38 @@ To <dfn>convert a value to a key range</dfn> with
 
 </div>
 
+A <dfn>potentially valid key range</dfn> is a value that could probably be [=convert a value to a key range|converted to a key range=] successfully without throwing an exception.
+This algorithm considers certain [=key/type|types=] of values that could produce valid [=key|keys=].
+However, the actual [=convert a value to a key range|conversion=] of a [=potentially valid key range=] to a [=key range=] might still throw an exception.
+
+NOTE:
+  For example, a value that is a detached ArrayBuffer is a potentially valid key range that will throw when [=convert a value to a key range|converted to a key range=].
+
+<div algorithm>
+
+  To determine when a value <dfn>is a potentially valid key range</dfn> with |value|, run these steps:
+
+  1. If |value| is a [=/key range=], return true.
+
+  1. Else if [=ECMAScript/Type=](|value|) is Number, return true.
+
+  1. Else if [=ECMAScript/Type=](|value|) is String, return true.
+
+  1. Else if |value| is a {{Date}} (has a \[[DateValue]] internal slot), return true.
+
+  1. Else if |value| is a [=buffer source type=], return true.
+
+  1. Else if |value| is an [=ECMAScript/Array exotic object=], return true.
+  
+  1. Else return false.
+
+NOTE:
+  The {{IDBObjectStore/getAll()}} and {{IDBObjectStore/getAllKeys()}} methods use [=is a potentially valid key range=] to handle their first argument.
+  If the argument is a [=potentially valid key range=], {{IDBObjectStore/getAll()}} and {{IDBObjectStore/getAllKeys()}} use [=key range=] for their first argument.
+  Otherwise, {{IDBGetAllOptions}} is used for their first argument.
+
+</div>
+
 <!-- ============================================================ -->
 ## Cursor ## {#cursor-construct}
 <!-- ============================================================ -->
@@ -1801,6 +1833,29 @@ store.put(4); // will throw DataError
 ```
 </div>
 
+<!-- ============================================================ -->
+## Record Snapshot ## {#record-snapshot-construct}
+<!-- ============================================================ -->
+
+A <dfn>record snapshot</dfn> contains keys and values copied from an [=object-store/list of records|object store record=] or an [=index/list of records|index record=].
+
+<div dfn-for="record snapshot">
+
+A [=/record snapshot=] has a <dfn>key</dfn> which is a [=key=].
+
+A [=/record snapshot=] has a <dfn>value</dfn> which is a [=value=].
+
+NOTE:
+  For an [=index/list of records|index record=], the snapshot's [=record snapshot/value=] is a copy of the record's [=index/referenced value=].
+  For an [=object-store/list of records|object store record=], the snapshot's [=record snapshot/value=] is the [=object-store/record|record's value=].
+
+A [=/record snapshot=] also has a <dfn>primary key</dfn> which is a [=key=].
+
+NOTE:
+  For an [=index/list of records|index record=], the snapshot's [=record snapshot/primary key=] is the record's [=index/values|value=], which is the key of the record in the index's [=index/referenced|referenced object store=].
+  For an [=object-store/list of records|object store record=], the snapshot's [=record snapshot/primary key=] and [=record snapshot/key=] are the same [=key=], which is the [=object-store/record|record's key=].
+
+</div>
 
 <!-- ============================================================ -->
 # Exceptions # {#exceptions}
@@ -2726,10 +2781,11 @@ interface IDBObjectStore {
   [NewObject] IDBRequest clear();
   [NewObject] IDBRequest get(any query);
   [NewObject] IDBRequest getKey(any query);
-  [NewObject] IDBRequest getAll(optional any query,
+  [NewObject] IDBRequest getAll(optional any query_or_options,
                                 optional [EnforceRange] unsigned long count);
-  [NewObject] IDBRequest getAllKeys(optional any query,
+  [NewObject] IDBRequest getAllKeys(optional any query_or_options,
                                     optional [EnforceRange] unsigned long count);
+  [NewObject] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
   [NewObject] IDBRequest count(optional any query);
 
   [NewObject] IDBRequest openCursor(optional any query,
@@ -2748,6 +2804,12 @@ interface IDBObjectStore {
 dictionary IDBIndexParameters {
   boolean unique = false;
   boolean multiEntry = false;
+};
+
+dictionary IDBGetAllOptions {
+  any query = null;
+  [EnforceRange] unsigned long count;
+  IDBCursorDirection direction = "next";
 };
 </xmp>
 
@@ -3078,24 +3140,31 @@ The <dfn method for=IDBObjectStore>clear()</dfn> method steps are:
         [=/key=], or `undefined` if there was no matching
         [=object-store/record=].
 
-    : |request| = |store| .
-          {{IDBObjectStore/getAll()|getAll}}(|query| [, |count|])
+    : |request| = |store| . {{IDBObjectStore/getAll()|getAll}}(|query| [, |count|])
+    : |request| = |store| . {{IDBObjectStore/getAll()|getAll}}({|query|, |count|, |direction|})
     ::
-        Retrieves the [=/values=] of the [=object-store/records=] matching the
-        given [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Retrieves the [=/values=] of the [=object-store/records=] matching the given [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Set the |direction| option to "{{IDBCursorDirection/next}}" to retrieve the first |count| values, or "{{IDBCursorDirection/prev}}" to return the last |count| values.
 
-        If successful, |request|'s {{IDBRequest/result}} will
-        be an {{Array}} of the [=/values=].
+        If successful, |request|'s {{IDBRequest/result}} will be an {{Array}} of the [=/values=].
 
-    : |request| = |store| .
-          {{IDBObjectStore/getAllKeys()|getAllKeys}}(|query| [,
-          |count|])
+    : |request| = |store| . {{IDBObjectStore/getAllKeys()|getAllKeys}}(|query| [, |count|])
+    : |request| = |store| . {{IDBObjectStore/getAllKeys()|getAllKeys}}({|query|, |count|, |direction|})
     ::
-        Retrieves the [=/keys=] of [=object-store/records=] matching the
-        given [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Retrieves the [=/keys=] of [=object-store/records=] matching the given [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Set the |direction| option to "{{IDBCursorDirection/next}}" to retrieve the first |count| keys, or "{{IDBCursorDirection/prev}}" to return the last |count| keys.
 
-        If successful, |request|'s {{IDBRequest/result}} will
-        be an {{Array}} of the [=/keys=].
+        If successful, |request|'s {{IDBRequest/result}} will be an {{Array}} of the [=/keys=].
+
+    : |request| = |store| . {{IDBObjectStore/getAllRecords()|getAllRecords}}({|query|, |count|, |direction|})
+    ::
+        Retrieves the [=/keys=] and [=/values=] of [=object-store/records=].
+
+        The |query| option specifies a [=/key=] or [=key range=] to match.
+        The |count| option limits the number or records matched.
+        Set the |direction| option to "{{IDBCursorDirection/next}}" to retrieve the first |count| records, or "{{IDBCursorDirection/prev}}" to return the last |count| records.
+
+        If successful, |request|'s {{IDBRequest/result}} will be an {{Array}}, with each member being a {{IDBRecord}}.
 
     : |request| = |store| .
           {{IDBObjectStore/count()|count}}(|query|)
@@ -3174,7 +3243,7 @@ the first existing key in that range.
 
 <div algorithm>
 
-The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn> method steps are:
+The <dfn method for=IDBObjectStore>getAll(|query_or_options|, |count|)</dfn> method steps are:
 
 1. Let |transaction| be [=/this=]'s [=object-store-handle/transaction=].
 
@@ -3186,17 +3255,30 @@ The <dfn method for=IDBObjectStore>getAll(|query|, |count|)</dfn> method steps a
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=exception/throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of
-    [=/converting a value to a key range=] with |query|.
-    Rethrow any exceptions.
+1. Let |range| be a [=key range=].
 
-1. Let |operation| be an algorithm to run [=retrieve multiple values from an object store=] with [=ECMAScript/the current Realm record=], |store|, |range|, and |count| if given.
+1. Let |direction| be a [=cursor/direction|cursor direction=].
 
+1. If running [=is a potentially valid key range=] with |query_or_options| is true, then:
+  
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|.  Rethrow any exceptions.
+
+    1. Set |direction| to "{{IDBCursorDirection/next}}".
+
+1. Else:
+
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|["{{IDBGetAllOptions/query}}"].  Rethrow any exceptions.
+
+    1. Set |count| to |query_or_options|["{{IDBGetAllOptions/count}}"].
+
+    1. Set |direction| to |query_or_options|["{{IDBGetAllOptions/direction}}"].
+
+1. Let |operation| be an algorithm to run [=retrieve multiple items from an object store=] with [=ECMAScript/the current Realm record=], |store|, |range|, "value", |direction|, and |count| if given.
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 NOTE:
-The |query| parameter can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
+The |range| can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/record=] values to be retrieved. If null or not given,
 an [=unbounded key range=] is used. If |count| is specified and
 there are more than |count| records in range, only the first |count|
@@ -3207,7 +3289,7 @@ will be retrieved.
 
 <div algorithm>
 
-The <dfn method for=IDBObjectStore>getAllKeys(|query|, |count|)</dfn> method steps are:
+The <dfn method for=IDBObjectStore>getAllKeys(|query_or_options|, |count|)</dfn> method steps are:
 
 1. Let |transaction| be [=/this=]'s [=object-store-handle/transaction=].
 
@@ -3219,22 +3301,69 @@ The <dfn method for=IDBObjectStore>getAllKeys(|query|, |count|)</dfn> method ste
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=exception/throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of
-    [=/converting a value to a key range=] with |query|.
-    Rethrow any exceptions.
+1. Let |range| be a [=key range=].
 
-1. Let |operation| be an algorithm to run [=retrieve multiple keys from an object store=] with |store|, |range|, and |count| if given.
+1. Let |direction| be a [=cursor/direction|cursor direction=].
+
+1. If running [=is a potentially valid key range=] with |query_or_options| is true, then:
+  
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|.  Rethrow any exceptions.
+
+    1. Set |direction| to "{{IDBCursorDirection/next}}".
+
+1. Else:
+  
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|["{{IDBGetAllOptions/query}}"].  Rethrow any exceptions.
+
+    1. Set |count| to |query_or_options|["{{IDBGetAllOptions/count}}"].
+
+    1. Set |direction| to |query_or_options|["{{IDBGetAllOptions/direction}}"].
+
+1. Let |operation| be an algorithm to run [=retrieve multiple items from an object store=] with [=ECMAScript/the current Realm record=], |store|, |range|, "key", |direction|, and |count| if given.
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 NOTE:
-The |query| parameter can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
+The |range| can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/record=] keys to be retrieved. If null or not
 given, an [=unbounded key range=] is used. If |count| is specified
 and there are more than |count| keys in range, only the first |count|
 will be retrieved.
 
 </div>
+
+
+<div algorithm>
+
+The <dfn method for=IDBObjectStore>getAllRecords(|options|)</dfn> method steps are:
+
+1. Let |transaction| be [=/this=]'s [=object-store-handle/transaction=].
+
+1. Let |store| be [=/this=]'s [=object-store-handle/object store=].
+
+1. If |store| has been deleted, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
+
+1. If |transaction|'s [=transaction/state=] is not [=transaction/active=], then [=exception/throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
+
+1. Let |range| be the result of [=/converting a value to a key range=] with |options|["{{IDBGetAllOptions/query}}"]. Rethrow any exceptions.
+
+1. Let |operation| be an algorithm to run [=retrieve multiple items from an object store=] with [=ECMAScript/the current Realm record=], |store|, |range|, "record", |options|["{{IDBGetAllOptions/direction}}"], and |options|["{{IDBGetAllOptions/count}}"] if given.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
+
+</div>
+
+<aside class=note>
+  The |options|["{{IDBGetAllOptions/query}}"] parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}}) identifying the [=object-store/records=] to be retrieved.
+  If null or not given, an [=unbounded key range=] is used.
+  If |options|["{{IDBGetAllOptions/count}}"] is specified and there are more than |options|["{{IDBGetAllOptions/count}}"] keys in range, only the first |options|["{{IDBGetAllOptions/count}}"] will be retrieved.
+</aside>
+
+<aside class=advisement>
+  &#x1F6A7;
+  The {{IDBObjectStore/getAllRecords()}} method is new in this edition.
+  &#x1F6A7;
+</aside>
 
 
 <div algorithm>
@@ -3600,10 +3729,11 @@ interface IDBIndex {
 
   [NewObject] IDBRequest get(any query);
   [NewObject] IDBRequest getKey(any query);
-  [NewObject] IDBRequest getAll(optional any query,
+  [NewObject] IDBRequest getAll(optional any query_or_options,
                                 optional [EnforceRange] unsigned long count);
-  [NewObject] IDBRequest getAllKeys(optional any query,
+  [NewObject] IDBRequest getAllKeys(optional any query_or_options,
                                     optional [EnforceRange] unsigned long count);
+  [NewObject] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
   [NewObject] IDBRequest count(optional any query);
 
   [NewObject] IDBRequest openCursor(optional any query,
@@ -3732,24 +3862,34 @@ return [=/this=]'s [=index-handle/index=]'s [=index/unique flag=].
         [=/key=], or `undefined` if there was no matching
         [=object-store/record=].
 
-    : |request| = |index| .
-          {{IDBIndex/getAll()|getAll}}(|query| [, |count|])
+    : |request| = |index| . {{IDBIndex/getAll()|getAll}}(|query| [, |count|])
+    : |request| = |index| . {{IDBIndex/getAll()|getAll}}({|query|, |count|, |direction|})
     ::
-        Retrieves the [=/values=] of the [=object-store/records=] matching the given
-        [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Retrieves the [=/values=] of the [=object-store/records=] matching the given [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Set the |direction| option to "{{IDBCursorDirection/next}}" to retrieve the first |count| values, "{{IDBCursorDirection/prev}}" to return the last |count| values.
+        Set the |direction| option to "{{IDBCursorDirection/nextunique}}" or "{{IDBCursorDirection/prevunique}}" to exclude records with duplicate index keys after retrieving the first record with the duplicate index key.
 
-        If successful, |request|'s {{IDBRequest/result}} will be an
-        {{Array}} of the [=/values=].
+        If successful, |request|'s {{IDBRequest/result}} will be an {{Array}} of the [=/values=].
 
-    : |request| = |index| .
-          {{IDBIndex/getAllKeys()|getAllKeys}}(|query| [,
-          |count|])
+    : |request| = |index| . {{IDBIndex/getAllKeys()|getAllKeys}}(|query| [, |count|])
+    : |request| = |index| . {{IDBIndex/getAllKeys()|getAllKeys}}({|query|, |count|, |direction|})
     ::
-        Retrieves the [=/keys=] of [=object-store/records=] matching the given
-        [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Retrieves the [=/keys=] of [=object-store/records=] matching the given [=/key=] or [=/key range=] in |query| (up to |count| if given).
+        Set the |direction| option to "{{IDBCursorDirection/next}}" to retrieve the first |count| keys, "{{IDBCursorDirection/prev}}" to return the last |count| keys.
+        Set the |direction| option to "{{IDBCursorDirection/nextunique}}" or "{{IDBCursorDirection/prevunique}}" to exclude records with duplicate index keys after retrieving the first record with the duplicate index key.
 
-        If successful, |request|'s {{IDBRequest/result}} will be an
-        {{Array}} of the [=/keys=].
+        If successful, |request|'s {{IDBRequest/result}} will be an {{Array}} of the [=/keys=].
+
+    : |request| = |index| . {{IDBIndex/getAllRecords()|getAllRecords}}({|query|, |count|, |direction|})
+    ::
+        Retrieves the [=/keys=], [=/values=], and index [=/keys=] of [=object-store/records=].
+
+        The |query| option specifies a [=/key=] or [=key range=] to match.
+        The |count| option limits the number or records matched.
+        Set the |direction| option to "{{IDBCursorDirection/next}}" to retrieve the first |count| records, "{{IDBCursorDirection/prev}}" to return the last |count| records.
+        Set the |direction| option to "{{IDBCursorDirection/nextunique}}" or "{{IDBCursorDirection/prevunique}}" to exclude records with duplicate index keys after retrieving the first record with the duplicate index key.
+
+        If successful, |request|'s {{IDBRequest/result}} will be an {{Array}}, with each member being an {{IDBRecord}}. Use the {{IDBRecord/key|IDBRecord's key}} to get the record's index [=key=].  Use the {{IDBRecord/primaryKey|IDBRecord's primaryKey}} to get the record's [=key=].
 
     : |request| = |index| .
           {{IDBIndex/count()|count}}(|query|)
@@ -3829,7 +3969,7 @@ in that range.
 
 <div algorithm>
 
-The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method steps are:
+The <dfn method for=IDBIndex>getAll(|query_or_options|, |count|)</dfn> method steps are:
 
 1. Let |transaction| be [=/this=]'s [=index-handle/transaction=].
 
@@ -3841,16 +3981,30 @@ The <dfn method for=IDBIndex>getAll(|query|, |count|)</dfn> method steps are:
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=exception/throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of
-    [=/converting a value to a key range=] with |query|.
-    Rethrow any exceptions.
+1. Let |range| be a [=key range=].
 
-1. Let |operation| be an algorithm to run [=retrieve multiple referenced values from an index=] with [=ECMAScript/the current Realm record=], |index|, |range|, and |count| if given.
+1. Let |direction| be a [=cursor/direction|cursor direction=].
+
+1. If running [=is a potentially valid key range=] with |query_or_options| is true, then:
+  
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|.  Rethrow any exceptions.
+
+    1. Set |direction| to "{{IDBCursorDirection/next}}".
+
+1. Else:
+  
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|["{{IDBGetAllOptions/query}}"].  Rethrow any exceptions.
+
+    1. Set |count| to |query_or_options|["{{IDBGetAllOptions/count}}"].
+
+    1. Set |direction| to |query_or_options|["{{IDBGetAllOptions/direction}}"].
+
+1. Let |operation| be an algorithm to run [=retrieve multiple items from an index=] with [=ECMAScript/the current Realm record=], |index|, |range|, "value", |direction| and |count| if given.
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 NOTE:
-The |query| parameter can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
+The |range| can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
 identifying the [=index/referenced values=] to be retrieved. If null or not given,
 an [=unbounded key range=] is used. If |count| is specified and
 there are more than |count| records in range, only the first |count|
@@ -3861,7 +4015,7 @@ will be retrieved.
 
 <div algorithm>
 
-The <dfn method for=IDBIndex>getAllKeys(|query|, |count|)</dfn> method steps are:
+The <dfn method for=IDBIndex>getAllKeys(|query_or_options|, |count|)</dfn> method steps are:
 
 1. Let |transaction| be [=/this=]'s [=index-handle/transaction=].
 
@@ -3873,22 +4027,69 @@ The <dfn method for=IDBIndex>getAllKeys(|query|, |count|)</dfn> method steps are
 1. If |transaction|'s [=transaction/state=] is not [=transaction/active=],
     then [=exception/throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
 
-1. Let |range| be the result of
-    [=/converting a value to a key range=] with |query|.
-    Rethrow any exceptions.
+1. Let |range| be a [=key range=].
 
-1. Let |operation| be an algorithm to run [=retrieve multiple values from an index=] with |index|, |range|, and |count| if given.
+1. Let |direction| be a [=cursor/direction|cursor direction=].
+
+1. If running [=is a potentially valid key range=] with |query_or_options| is true, then:
+  
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|.  Rethrow any exceptions.
+
+    1. Set |direction| to "{{IDBCursorDirection/next}}".
+
+1. Else:
+  
+    1. Set |range| to the result of [=/converting a value to a key range=] with |query_or_options|["{{IDBGetAllOptions/query}}"].  Rethrow any exceptions.
+
+    1. Set |count| to |query_or_options|["{{IDBGetAllOptions/count}}"].
+
+    1. Set |direction| to |query_or_options|["{{IDBGetAllOptions/direction}}"].
+
+1. Let |operation| be an algorithm to run [=retrieve multiple items from an index=] with [=ECMAScript/the current Realm record=], |index|, |range|, "key", |direction| and |count| if given.
 
 1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
 
 NOTE:
-The |query| parameter can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
+The |range| can be a [=/key=] or [=/key range=] (an {{IDBKeyRange}})
 identifying the [=object-store/record=] keys to be retrieved. If null or not
 given, an [=unbounded key range=] is used. If |count| is specified
 and there are more than |count| keys in range, only the first |count|
 will be retrieved.
 
 </div>
+
+
+<div algorithm>
+
+The <dfn method for=IDBIndex>getAllRecords(|options|)</dfn> method steps are:
+
+1. Let |transaction| be [=/this=]'s [=index-handle/transaction=].
+
+1. Let |index| be [=/this=]'s [=index-handle/index=].
+
+1. If |index| or |index|'s [=/object store=] has been deleted, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
+
+1. If |transaction|'s [=transaction/state=] is not [=transaction/active=], then [=exception/throw=] a "{{TransactionInactiveError}}" {{DOMException}}.
+
+1. Let |range| be the result of [=/converting a value to a key range=] with |options|["{{IDBGetAllOptions/query}}"]. Rethrow any exceptions.
+
+1. Let |operation| be an algorithm to run [=retrieve multiple items from an index=] with [=ECMAScript/the current Realm record=], |index|, |range|, "record", |options|["{{IDBGetAllOptions/direction}}"], and |options|["{{IDBGetAllOptions/count}}"] if given.
+
+1. Return the result (an {{IDBRequest}}) of running [=asynchronously execute a request=] with [=/this=] and |operation|.
+
+</div>
+
+<aside class=note>
+The |options|["{{IDBGetAllOptions/query}}"] parameter can be a [=/key=] or [=key range=] (an {{IDBKeyRange}}) identifying the [=object-store/records=] to be retrieved.
+If null or not given, an [=unbounded key range=] is used.
+If |options|["{{IDBGetAllOptions/count}}"] is specified and there are more than |options|["{{IDBGetAllOptions/count}}"] keys in range, only the first |options|["{{IDBGetAllOptions/count}}"] will be retrieved.
+</aside>
+
+<aside class=advisement>
+  &#x1F6A7;
+  The {{IDBIndex/getAllRecords()}} method is new in this edition.
+  &#x1F6A7;
+</aside>
 
 
 <div algorithm>
@@ -4213,6 +4414,44 @@ The <dfn method for=IDBKeyRange>includes(|key|)</dfn> method steps are:
     this range, and false otherwise.
 
 </div>
+
+
+<!-- ============================================================ -->
+## The {{IDBRecord}} interface ## {#record-interface}
+<!-- ============================================================ -->
+
+The {{IDBRecord}} interface represents a [=record snapshot=].
+
+<xmp class=idl>
+[Exposed=(Window,Worker)]
+interface IDBRecord {
+  readonly attribute any key;
+  readonly attribute any primaryKey;
+  readonly attribute any value;
+};
+</xmp>
+
+<div class="domintro note">
+    : |record| . {{IDBRecord/key}}
+    ::
+        Returns the record's [=key=].
+
+    : |record| . {{IDBRecord/primaryKey}}
+    ::
+        If the record is retrieved from an [=index=], returns the key of the record in the index's [=index/referenced|referenced object store=].
+
+        If the record is retrieved from an [=object store=], returns the record's [=key=], which is the same key as |record|.{{IDBRecord/key}}.
+
+    : |record| . {{IDBRecord/value}}
+    ::
+        Returns the record's [=value=].
+</div>
+
+The <dfn attribute for=IDBRecord>key</dfn> getter steps are to return the result of [=/converting a key to a value=] with [=/this=]'s [=record snapshot/key=].
+
+The <dfn attribute for=IDBRecord>primaryKey</dfn> getter steps are to return the result of [=/converting a key to a value=] with [=/this=]'s [=record snapshot/primary key=].
+
+The <dfn attribute for=IDBRecord>value</dfn> getter steps are to return [=/this=]'s [=record snapshot/value=].
 
 
 <!-- ============================================================ -->
@@ -5488,6 +5727,7 @@ To <dfn>fire an error event</dfn> at a |request|, run these steps:
 
 </div>
 
+
 <!-- ============================================================ -->
 ## Clone a value ## {#clone-value}
 <!-- ============================================================ -->
@@ -5659,32 +5899,6 @@ They return undefined, an ECMAScript value, or an error (a {{DOMException}}):
 
 <div algorithm>
 
-To <dfn>retrieve multiple values from an object
-store</dfn> with |targetRealm|, |store|, |range| and optional |count|, run these steps.
-They return a <code>[=/sequence=]&lt;{{any}}&gt;</code> or an error (a {{DOMException}}):
-
-1. If |count| is not given or is 0 (zero), let |count| be infinity.
-
-1. Let |records| be a [=/list=] containing the first |count| [=object-store/records=]
-    in |store|'s [=object-store/list of records=] whose [=/key=] is
-    [=in=] |range|.
-
-1. Let |list| be an empty [=/list=].
-
-1. [=list/For each=] |record| of |records|:
-
-    1. Let |serialized| be |record|'s [=/value=]. If an error occurs while reading the value from the
-        underlying storage, return a newly [=exception/created=] "{{NotReadableError}}" {{DOMException}}.
-    1. Let |entry| be [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
-    1. Append |entry| to |list|.
-
-1. Return |list| converted to a <code>[=/sequence=]&lt;{{any}}&gt;</code>.
-
-</div>
-
-
-<div algorithm>
-
 To <dfn>retrieve a key from an object store</dfn>
 with |store| and |range|, run these steps:
 
@@ -5702,24 +5916,43 @@ with |store| and |range|, run these steps:
 
 <div algorithm>
 
-To <dfn>retrieve multiple keys from an object store</dfn>
-with |store|, |range| and optional |count|, run these steps:
+To <dfn>retrieve multiple items from an object store</dfn> with |targetRealm|, |store|, |range|, |kind|, |direction|, and optional |count|, run these steps:
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 
-1. Let |records| be a list containing the first |count| [=object-store/records=]
-    in |store|'s [=object-store/list of records=] whose [=/key=] is
-    [=in=] |range|.
+1. Let |records| be a an empty [=/list=] of [=object-store/records=].
+
+1. If |direction| is "{{IDBCursorDirection/next}}" or "{{IDBCursorDirection/nextunique}}", set |records| to the first |count| of |store|'s [=object-store/list of records=] whose [=/key=] is [=in=] |range|.
+
+1. If |direction| is "{{IDBCursorDirection/prev}}" or "{{IDBCursorDirection/prevunique}}", set |records| to the last |count| of |store|'s [=object-store/list of records=] whose [=/key=] is [=in=] |range|.
 
 1. Let |list| be an empty [=/list=].
 
-1. [=list/For each=] |record| of |records|:
+1. [=list/For each=] |record| of |records|, switching on |kind|:
 
-    1. Let |entry| be the result of [=/converting a
-        key to a value=] with |record|'s key.
-    1. Append |entry| to |list|.
+    <dl class=switch>
+      : "key"
+      ::
+          1. Let |key| be the result of [=/converting a key to a value=] with |record|'s key.
+          1. [=list/Append=] |key| to |list|.
 
-1. Return |list| converted to a <code>[=/sequence=]&lt;{{any}}&gt;</code>.
+      : "value"
+      ::
+          1. Let |serialized| be |record|'s [=/value=].
+          1. Let |value| be [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
+          1. [=list/Append=] |value| to |list|.
+
+      : "record"
+      ::
+          1. Let |key| be the |record|'s key.
+          1. Let |serialized| be |record|'s [=/value=].
+          1. Let |value| be [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
+          1. Let |record snapshot| be a new [=record snapshot=] with its [=record snapshot/key=] set to |key|, [=record snapshot/value=] set to |value|, and [=record snapshot/primary key=] set to |key|.
+          1. [=list/Append=] |record snapshot| to |list|.
+
+    </dl>
+
+1. Return |list|.
 
 </div>
 
@@ -5747,32 +5980,6 @@ with |targetRealm|, |index| and |range|, run these steps:
 
 <div algorithm>
 
-To <dfn>retrieve multiple referenced values from an
-index</dfn> with |targetRealm|, |index|, |range| and optional |count|, run these steps:
-
-1. If |count| is not given or is 0 (zero), let |count| be infinity.
-
-1. Let |records| be a list containing the first |count| [=object-store/records=]
-    in |index|'s [=index/list of records=] whose [=index/key=] is [=in=] |range|.
-
-1. Let |list| be an empty [=/list=].
-
-1. [=list/For each=] |record| of |records|:
-
-    1. Let |serialized| be |record|'s [=index/referenced value=].
-    1. Let |entry| be [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
-    1. Append |entry| to |list|.
-
-1. Return |list| converted to a <code>[=/sequence=]&lt;{{any}}&gt;</code>.
-
-</div>
-
-NOTE:
-    The [=index/values=] of an [=index/record=] in an index are the keys of
-    [=object-store/records=] in the [=index/referenced=] object store.
-
-<div algorithm>
-
 To <dfn>retrieve a value from an index</dfn> with
 |index| and |range|, run these steps:
 
@@ -5789,25 +5996,81 @@ To <dfn>retrieve a value from an index</dfn> with
 
 <div algorithm>
 
-To <dfn>retrieve multiple values from an index</dfn> with
-|index|, |range| and optional |count|, run these steps:
+To <dfn>retrieve multiple items from an index</dfn> with |targetRealm|, |index|, |range|, |kind|, |direction| and optional |count|, run these steps:
 
 1. If |count| is not given or is 0 (zero), let |count| be infinity.
 
-1. Let |records| be a list containing the first |count| [=index/records=] in
-    |index|'s [=index/list of records=] whose [=index/key=] is [=in=] |range|.
+1. Let |records| be a an empty [=/list=] of [=object-store/records=].
+
+1. Switching on |direction|:
+
+    <dl class=switch>
+      : "next"
+      ::
+          1. Set |records| to the first |count| of |index|'s [=index/list of records=] whose [=index/key=] is [=in=] |range|.
+
+      : "nextunique"
+      ::
+          1. Let |range records| be a list containing the |index|'s [=index/list of records=] whose [=index/key=] is [=in=] |range|.
+          1. Let |range records length| be |range records|'s [=list/size=].
+          1. Let |i| be 0.
+          1. While |i| is less than |range records length|, then:
+              1. Increase |i| by 1.
+              1. if |record|'s [=list/size=] is equal to |count|, then [=iteration/break=].
+              1. If |i| is greater than 0 and the result of [=comparing two keys=] using the keys from |range records[i]| and |range records[i-1]| is equal, then [=iteration/continue=].
+              1. Else [=list/append=] |range records[i]| to |records|.
+
+      : "prev"
+      ::
+          1. Set |records| to the last |count| of |index|'s [=index/list of records=] whose [=index/key=] is [=in=] |range|.
+
+      : "prevunique"
+      ::
+          1. Let |range records| be a list containing the |index|'s [=index/list of records=] whose [=index/key=] is [=in=] |range|.
+          1. Let |range records length| be |range records|'s [=list/size=].
+          1. Let |i| be 0.
+          1. While |i| is less than |range records length|, then:
+              1. Increase |i| by 1.
+              1. if |record|'s [=list/size=] is equal to |count|, then [=iteration/break=].
+              1. If |i| is greater than 0 and the result of [=comparing two keys=] using the keys from |range records[i]| and |range records[i-1]| is equal, then [=iteration/continue=].
+              1. Else [=list/prepend=] |range records[i]| to |records|.
+
+    </dl>
 
 1. Let |list| be an empty [=/list=].
 
-1. [=list/For each=] |record| of |records|:
+1. [=list/For each=] |record| of |records|, switching on |kind|:
 
-    1. Let |entry| be the result of [=/converting a
-        key to a value=] with |record|'s value.
-    1. Append |entry| to |list|.
+    <dl class=switch>
+      : "key"
+      ::
+          1. Let |key| be the result of [=/converting a key to a value=] with |record|'s value.
+          1. [=list/Append=] |key| to |list|.
 
-1. Return |list| converted to a <code>[=/sequence=]&lt;{{any}}&gt;</code>.
+      : "value"
+      ::
+          1. Let |serialized| be |record|'s [=index/referenced value=].
+          1. Let |value| be [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
+          1. [=list/Append=] |value| to |list|.
+
+      : "record"
+      ::
+          1. Let |index key| be the |record|'s key.
+          1. Let |key| be the |record|'s value.
+          1. Let |serialized| be |record|'s [=index/referenced value=].
+          1. Let |value| be [=ECMAScript/!=] [$StructuredDeserialize$](|serialized|, |targetRealm|).
+          1. Let |record snapshot| be a new [=record snapshot=] with its [=record snapshot/key=] set to |index key|, [=record snapshot/value=] set to |value|, and [=record snapshot/primary key=] set to |key|.
+          1. [=list/Append=] |record snapshot| to |list|.
+
+    </dl>
+
+1. Return |list|.
 
 </div>
+
+<aside class=note>
+  The [=index/values=] of a [=index/record=] in an index are the keys of [=object-store/records=] in the [=index/referenced=] object store.
+</aside>
 
 
 <!-- ============================================================ -->
@@ -6718,6 +6981,8 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Define [=Queue a database task=] and replace [=Queue a task=] with it (<#421>)
 * Add missing parallel step to {{IDBFactory/databases()|databases}}() (<#421>)
 * Clarify cursor iteration predicates (<#450>)
+* Add {{IDBObjectStore/getAllRecords(options)}} method to {{IDBObjectStore}} and {{IDBIndex}}. (<#206>)
+* Add direction option to {{IDBObjectStore/getAll()}} and {{IDBObjectStore/getAllKeys()}} for {{IDBObjectStore}} and {{IDBIndex}} (<#130>)
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}


### PR DESCRIPTION
Closes #206 #130 

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [X] Modified Web platform tests (link to pull request)

### WPT coverage:
getAllRecords():
//IndexedDB/idbobjectstore_getAllRecords.tentative.any.js
//IndexedDB/idbindex_getAllRecords.tentative.any.js

getAll()/getAllKey() direction option: 
//IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js
//IndexedDB/idbindex_getAllKeys-options.tentative.any.js
//IndexedDB/idbobjectstore_getAll-options.tentative.any.js
//IndexedDB/idbindex_getAll-options.tentative.any.js

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [X] Chromium (https://issues.chromium.org/issues/40746016)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)

### Outline of change:

#### Potentially valid key range

Added to support overloading getAll()/getAllKeys() with IDBGetAllOptions as the first argument.   Preserves existing behavior for key ranges and keys.  Avoids parsing the first argument for getAll()/getAllKeys() as a IDBGetAllOptions when the argument is a key range or has a type that could be a valid key (Number, String, Date, ArrayBuffer, or Array).

#### Record snapshot

Added for the output of getAllRecords(), which includes the record's key, value and primaryKey.  For IDBIndex, key is the index key and primaryKey is the record's key.  Required because object stores and indexes define different types of records.

#### getAll()/getAllKeys()

Methods updated to support overload of the first argument, which is either a key range or an IDBGetAllOptions.  IDBGetAllOptions adds direction support.

#### getAllRecords()

New method added to both IDBObjectStore and IDBIndex.  Supports IDBGetAllOptions only.

#### Retrieve multiple items from an object store/index

Algorithm updated to include more inputs: kind and direction.  Kind determines the type of output, which is either keys, values or record snaptshots.  Direction determines the sorting of the output, which is either ascending or descending.