### PR TITLE
Remove unnecessary state change in `IDBTransaction::abort()`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4932,8 +4932,7 @@ The <dfn method for=IDBTransaction>abort()</dfn> method steps are:
     or [=transaction/finished=],
     then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Set [=/this=]'s [=transaction/state=] to [=transaction/inactive=] and run
-    [=abort a transaction=] with [=/this=] and null.
+1. Run [=abort a transaction=] with [=/this=] and null.
 
 </div>
 


### PR DESCRIPTION
As far as I can tell, this line about changing the transaction's state to `inactive` upon `abort()` is non-observable and superfluous. The reason it's superfluous is because it's immediately followed by the ["abort a transaction"](https://w3c.github.io/IndexedDB/#abort-a-transaction) steps, which change the state to "finished" on step 3, and steps 1-2 do not contain user-observable hooks (e.g. errors, listeners, etc.):

> To abort a transaction with the transaction to abort, and error, run these steps:
>
>    1. All the changes made to the [database](https://w3c.github.io/IndexedDB/#database) by the [transaction](https://w3c.github.io/IndexedDB/#transaction-concept) are reverted. For [upgrade transactions](https://w3c.github.io/IndexedDB/#upgrade-transaction) this includes changes to the set of [object stores](https://w3c.github.io/IndexedDB/#object-store) and [indexes](https://w3c.github.io/IndexedDB/#index-concept), as well as the change to the [version](https://w3c.github.io/IndexedDB/#database-version). Any [object stores](https://w3c.github.io/IndexedDB/#object-store) and [indexes](https://w3c.github.io/IndexedDB/#index-concept) which were created during the transaction are now considered deleted for the purposes of other algorithms.
>
>    2. If transaction is an [upgrade transaction](https://w3c.github.io/IndexedDB/#upgrade-transaction), run the steps to [abort an upgrade transaction](https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction) with transaction.
>
>        NOTE: This reverts changes to all [connection](https://w3c.github.io/IndexedDB/#connection), [object store handle](https://w3c.github.io/IndexedDB/#object-store-handle), and [index handle](https://w3c.github.io/IndexedDB/#index-handle) instances associated with transaction.
>
>    3. Set transaction’s [state](https://w3c.github.io/IndexedDB/#transaction-state) to [finished](https://w3c.github.io/IndexedDB/#transaction-finished).

Looking at the various browser implementations, it seems that they already ignore this step in practice:

1. Gecko [does not set the state to inactive](https://searchfox.org/mozilla-central/rev/fcb776c1d580000af961677f6df3aeef67168a6f/dom/indexedDB/IDBTransaction.cpp#651) and directly calls `AbortInternal` which [immediately sets `mReadyState` to "finished"](https://searchfox.org/mozilla-central/rev/fcb776c1d580000af961677f6df3aeef67168a6f/dom/indexedDB/IDBTransaction.cpp#587).
2. WebKit [does not set the state to inactive](https://github.com/WebKit/WebKit/blob/2d4b420bfd1804cdd34c10a965f0ec01c9b80e50/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp#L212) and directly calls `abortInternal()`. It doesn't seem to set the state to `inactive` during this process.
3. Chromium also [does not set the state to inactive](https://github.com/chromium/chromium/blob/349627a1eba4178d74f70f59ed0bf9175b752ee2/third_party/blink/renderer/modules/indexeddb/idb_transaction.cc#L348-L356) and calls `StartAborting` which also doesn't seem to set the state to `inactive`.

The exception I can find is Ladybird, which [does set the state to `inactive`](https://github.com/LadybirdBrowser/ladybird/blob/34ec33d71c750428ee7ddc0992f16c1c0081e511/Libraries/LibWeb/IndexedDB/IDBTransaction.cpp#L91), but then immediately [sets the state to `finished`](https://github.com/LadybirdBrowser/ladybird/blob/34ec33d71c750428ee7ddc0992f16c1c0081e511/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp#L552) which seems to illustrate that the `inactive` step is unnecessary.

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request) (**N/A - not observable**)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nolanlawson/IndexedDB/pull/466.html" title="Last updated on Aug 8, 2025, 2:36 AM UTC (5da2c31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/466/f2cd646...nolanlawson:5da2c31.html" title="Last updated on Aug 8, 2025, 2:36 AM UTC (5da2c31)">Diff</a>