### PR TITLE
Remove unnecessary transaction state change in IDBTransaction::abort()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4936,8 +4936,7 @@ The <dfn method for=IDBTransaction>abort()</dfn> method steps are:
     or [=transaction/finished=],
     then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
 
-1. Set [=/this=]'s [=transaction/state=] to [=transaction/inactive=] and run
-    [=abort a transaction=] with [=/this=] and null.
+1. Run [=abort a transaction=] with [=/this=] and null.
 
 </div>
 
@@ -6891,6 +6890,7 @@ For the revision history of the second edition, see [that document's Revision Hi
 * Add direction option to {{IDBObjectStore/getAll()}} and {{IDBObjectStore/getAllKeys()}} for {{IDBObjectStore}} and {{IDBIndex}} (<#130>)
 * Use of {{QuotaExceededError}} has been updated to reflect that it is now a {{DOMException}}-derived interface instead of an exception name. (<#463>)
 * Specify that null is valid for [=transaction/error=], and allow it to be set in [=abort a transaction=] (<#433>)
+* Remove redundant transaction state change in {{IDBTransaction/abort()}}.
 
 <!-- ============================================================ -->
 # Acknowledgements # {#acknowledgements}


### PR DESCRIPTION
... because the steps in "abort a transaction" also set the transaction state.

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec/BikeShed errors or warnings.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/467.html" title="Last updated on Aug 11, 2025, 7:44 PM UTC (f4c5865)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/467/f0a1064...f4c5865.html" title="Last updated on Aug 11, 2025, 7:44 PM UTC (f4c5865)">Diff</a>