### PR TITLE
Specify that the state refers to the passed transaction when aborting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5218,7 +5218,7 @@ To <dfn>commit a transaction</dfn> with the |transaction| to commit, run these s
 
 To <dfn>abort a transaction</dfn> with the |transaction| to abort, and |error|, run these steps:
 
-1. If [=transaction/state=] is [=transaction/finished=], abort these steps.
+1. If |transaction|'s [=transaction/state=] is [=transaction/finished=], abort these steps.
 
 1. All the changes made to the [=/database=] by the [=/transaction=]
     are reverted. For [=/upgrade transactions=] this includes changes


### PR DESCRIPTION
The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/468.html" title="Last updated on Aug 11, 2025, 2:27 PM UTC (6b89b97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/468/8a573ea...6b89b97.html" title="Last updated on Aug 11, 2025, 2:27 PM UTC (6b89b97)">Diff</a>