### PR TITLE
Specify that the requests error should go back to the unset state

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5332,7 +5332,7 @@ created [=/request=] belongs to is [=transaction/aborted=] using the steps to
         1. Otherwise:
 
             1. Set |request|'s [=request/result=] to |result|.
-            1. Set |request|'s [=request/error=] to undefined.
+            1. Unset |request|'s [=request/error=].
             1. [=Fire a success event=] at |request|.
 
 1. Return |request|.


### PR DESCRIPTION
While running `asynchronously execute a request`, `request`'s `error` is set to `undefined`.  
In most cases this would mean the JS value `undefined`, but in this case, its supposed to go back to the unset state.

Im not sure if there is a better spec wording for this 😅 

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/471.html" title="Last updated on Aug 13, 2025, 1:47 PM UTC (b6eee7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/471/c59639b...b6eee7d.html" title="Last updated on Aug 13, 2025, 1:47 PM UTC (b6eee7d)">Diff</a>