### PR TITLE
Adjust how the direction is defaulted in "Creating a request to retrieve multiple items"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5629,13 +5629,11 @@ To <dfn>create a [=request=] to retrieve multiple items</dfn> from an [=object s
 
 1. Let |range| be a [=key range=].
 
-1. Let |direction| be a [=cursor/direction|cursor direction=].
+1. Let |direction| be "{{IDBCursorDirection/next}}".
 
 1. If running [=is a potentially valid key range=] with |queryOrOptions| is true, then:
 
     1. Set |range| to the result of [=/converting a value to a key range=] with |queryOrOptions|.  Rethrow any exceptions.
-
-    1. Set |direction| to "{{IDBCursorDirection/next}}".
 
 1. Else:
 


### PR DESCRIPTION
Since [getAllKeys](https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getallkeys) takes an `any` parameter, we cant be sure that the object we get is of the type `IDBGetAllOptions`. As such, there is no default values applied to the object passed in.

If the object passed then doesnt contain direction, we will try to call `retrieve_multiple_items_from_an_XXX` with an undefined value for `direction`. This in turn will result in 0 records being returned. I assume this is not the intention, and as such this PR aims to set the default value of `"next"` in those cases.

The same would apply to `query` and `count`, but those are explicitly handled to return an unbounded key, and infinite results in other places.

Ideally there would be some wording like `"Set direction to queryOrOptions['direction'] if it exists."`, but I'm not sure of the correct spec syntax in these cases

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stelar7/IndexedDB/pull/478.html" title="Last updated on Oct 17, 2025, 8:35 PM UTC (0a4563a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/478/f704918...stelar7:0a4563a.html" title="Last updated on Oct 17, 2025, 8:35 PM UTC (0a4563a)">Diff</a>