### PR TITLE
Clarify IDBRecord getters shall return the same object over multiple calls. Fixes #494.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4301,10 +4301,30 @@ interface IDBRecord {
 
 The <dfn attribute for=IDBRecord>key</dfn> getter steps are to return the result of [=/converting a key to a value=] with [=/this=]'s [=record snapshot/key=].
 
+NOTE:
+If {{IDBRecord/key}} returns an object (e.g. a {{Date}} or {{Array}}), it
+returns the same object instance every time it is inspected. This means that if
+the object is modified, those modifications will be seen by anyone inspecting
+the value of the record. However modifying such an object does not modify the
+contents of the database.
+
 The <dfn attribute for=IDBRecord>primaryKey</dfn> getter steps are to return the result of [=/converting a key to a value=] with [=/this=]'s [=record snapshot/primary key=].
+
+NOTE:
+If {{IDBRecord/primaryKey}} returns an object (e.g. a {{Date}} or {{Array}}),
+it returns the same object instance every time it is inspected. This means that
+if the object is modified, those modifications will be seen by anyone
+inspecting the value of the record. However modifying such an object does not
+modify the contents of the database.
 
 The <dfn attribute for=IDBRecord>value</dfn> getter steps are to return [=/this=]'s [=record snapshot/value=].
 
+NOTE:
+If {{IDBRecord/value}} returns an object (e.g. a {{Date}} or {{Array}}), it
+returns the same object instance every time it is inspected. This means that if
+the object is modified, those modifications will be seen by anyone inspecting
+the value of the record. However modifying such an object does not modify the
+contents of the database.
 
 <!-- ============================================================ -->
 ## The {{IDBCursor}} interface ## {#cursor-interface}


### PR DESCRIPTION
See issue #494.

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests: TODO

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium: already implements this behavior
 * [x] Gecko: plans to implement this behavior: https://phabricator.services.mozilla.com/D295592#10262750


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ArnaudBienner/IndexedDB/pull/495.html" title="Last updated on May 21, 2026, 2:56 PM UTC (003909b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/495/f704918...ArnaudBienner:003909b.html" title="Last updated on May 21, 2026, 2:56 PM UTC (003909b)">Diff</a>